### PR TITLE
Add keepalive and lease logic

### DIFF
--- a/dev/dev-deployment.yaml
+++ b/dev/dev-deployment.yaml
@@ -72,6 +72,9 @@ rules:
   - apiGroups: ["batch"]
     resources: ["jobs", "cronjobs"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/internal/provider/defaults.go
+++ b/internal/provider/defaults.go
@@ -26,6 +26,7 @@ func GetInitialNodeSpec(config *config.Config) v1.Node {
 			},
 		},
 		Status: v1.NodeStatus{
+			Phase:      v1.NodeRunning,
 			Conditions: InitNodeConditions(),
 			NodeInfo:   InitNodeSystemInfo(config),
 			Capacity:   initNodeCapacity(),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cisco/virtual-kubelet-cisco/internal/drivers"
 	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/virtual-kubelet/virtual-kubelet/errdefs"
-	"github.com/virtual-kubelet/virtual-kubelet/node"
 	"github.com/virtual-kubelet/virtual-kubelet/node/api"
 	"github.com/virtual-kubelet/virtual-kubelet/node/api/statsv1alpha1"
 	"github.com/virtual-kubelet/virtual-kubelet/node/nodeutil"
@@ -133,25 +132,30 @@ func (p *AppHostingProvider) RunInContainer(ctx context.Context, namespace strin
 	panic("unimplemented")
 }
 
-// Just return node.NewNaiveNodeProvider for now
+// AppHostingNode implements node.NodeProvider for proper heartbeat management.
+// This follows the NaiveNodeProvider pattern from virtual-kubelet.
+// The library's NodeController handles periodic heartbeat updates automatically.
+type AppHostingNode struct{}
+
+// NewAppHostingNode creates a new AppHostingNode
 func NewAppHostingNode(
 	ctx context.Context,
 	appCfg *config.Config,
 	vkCfg nodeutil.ProviderConfig,
-) (*node.NaiveNodeProviderV2, error) {
-	// TODO: Use the NaiveNodeProviderV2 for now
-	return node.NewNaiveNodeProvider(), nil
-}
-
-// PLACEHOLDER
-type AppHostingNode struct{}
-
-// NotifyNodeStatus implements node.NodeProvider.
-func (a *AppHostingNode) NotifyNodeStatus(ctx context.Context, cb func(*v1.Node)) {
-	panic("unimplemented")
+) (*AppHostingNode, error) {
+	return &AppHostingNode{}, nil
 }
 
 // Ping implements node.NodeProvider.
-func (a *AppHostingNode) Ping(context.Context) error {
-	panic("unimplemented")
+// Called periodically by the library's nodePingController.
+// Returning nil indicates the node is healthy.
+func (a *AppHostingNode) Ping(ctx context.Context) error {
+	return nil
+}
+
+// NotifyNodeStatus implements node.NodeProvider.
+// This is for async/event-driven status updates (e.g., device health changes).
+// The library's controlLoop handles periodic heartbeat updates automatically.
+func (a *AppHostingNode) NotifyNodeStatus(ctx context.Context, cb func(*v1.Node)) {
+	// No-op - library handles periodic updates via controlLoop and updateNodeStatusHeartbeat()
 }


### PR DESCRIPTION
## Description

Keepalive and lease logic was blocked in the dev release train due to permissions, this PR contains the following updates. 

dev-deployment.yaml:75-77
- Update RBAC permissions for node lease 

defaults.go:29
- Added Phase: NodeRunning to initial node spec:

provider.go:135-161
- Implemented minimal NodeProvider following virtual-kubelet standards

dev/README.md 
- fixed minor path issues in the documentation

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented


