### PR TITLE
Add UUID naming conflict resolution

### DIFF
--- a/cmd/virtual-kubelet/main.go
+++ b/cmd/virtual-kubelet/main.go
@@ -125,7 +125,7 @@ func main() {
 
 	newProviderFunc := func(vkCfg nodeutil.ProviderConfig) (nodeutil.Provider, node.NodeProvider, error) {
 
-		PodHandler, err := provider.NewAppHostingProvider(ctx, appCfg, vkCfg)
+		PodHandler, err := provider.NewAppHostingProvider(ctx, appCfg, vkCfg, clientset)
 		if err != nil {
 			log.G(ctx).WithError(err).Fatal("Failed to initialise PodHandler")
 		}

--- a/internal/drivers/common/helpers.go
+++ b/internal/drivers/common/helpers.go
@@ -5,9 +5,8 @@ import (
 )
 
 func PodToContainer(pod *v1.Pod) (*Container, error) {
-	// Convert K8s pod name to valid Cisco AppHosting name
 	return &Container{
-		Name: K8sToAppHostingName(pod.Namespace, pod.Name),
+		Name: GetAppHostingName(pod),
 	}, nil
 }
 

--- a/internal/drivers/common/naming.go
+++ b/internal/drivers/common/naming.go
@@ -1,67 +1,22 @@
 package common
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"strings"
+
+	v1 "k8s.io/api/core/v1"
 )
 
 const (
-	// MaxAppHostingNameLength is the maximum length allowed by Cisco AppHosting YANG model
-	MaxAppHostingNameLength = 40
+	// AppHostingNameLabel is the label key used to store the AppHosting name on a pod
+	AppHostingNameLabel = "cisco.com/apphosting-name"
 )
 
-// K8sToAppHostingName converts a Kubernetes pod identifier to a valid Cisco AppHosting name.
-// Kubernetes naming (RFC 1123): lowercase alphanumeric + hyphen, max 63 chars
-// Cisco AppHosting YANG: alphanumeric + underscore only, max 40 chars
-//
-// Format: {sanitized_name}_{short_namespace_hash} if namespace != "default"
-// Format: {sanitized_name} if namespace == "default" or empty
-func K8sToAppHostingName(namespace, name string) string {
-	// Replace hyphens with underscores (K8s uses -, Cisco allows _)
-	sanitized := strings.ReplaceAll(name, "-", "_")
-
-	// For non-default namespaces, add a short hash suffix for uniqueness
-	if namespace != "" && namespace != "default" {
-		hash := sha256.Sum256([]byte(namespace))
-		suffix := "_" + hex.EncodeToString(hash[:])[:6] // 6 char hash
-
-		// Ensure total length <= 40
-		maxBase := MaxAppHostingNameLength - len(suffix)
-		if len(sanitized) > maxBase {
-			sanitized = sanitized[:maxBase]
-		}
-		return sanitized + suffix
+// GetAppHostingName returns the AppHosting name for a pod using its UID.
+// The UID is guaranteed unique and fits within the 40-char YANG constraint (32 chars without hyphens).
+// If the pod already has the label set, returns that value for idempotency.
+func GetAppHostingName(pod *v1.Pod) string {
+	if name, ok := pod.Labels[AppHostingNameLabel]; ok {
+		return name
 	}
-
-	// Truncate if needed for default namespace
-	if len(sanitized) > MaxAppHostingNameLength {
-		sanitized = sanitized[:MaxAppHostingNameLength]
-	}
-
-	return sanitized
-}
-
-// AppHostingToK8sName converts a Cisco AppHosting name back to a Kubernetes-style name.
-// This handles simple cases (default namespace). For namespaced lookups with hash suffixes,
-// the original pod name should be retrieved from the pod annotation or a mapping.
-func AppHostingToK8sName(appName string) string {
-	// Remove namespace hash suffix if present (last 7 chars: _XXXXXX where X is hex)
-	if len(appName) > 7 && appName[len(appName)-7] == '_' {
-		suffix := appName[len(appName)-6:]
-		if isHexString(suffix) {
-			appName = appName[:len(appName)-7]
-		}
-	}
-	return strings.ReplaceAll(appName, "_", "-")
-}
-
-// isHexString returns true if s contains only hexadecimal characters
-func isHexString(s string) bool {
-	for _, c := range s {
-		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
-			return false
-		}
-	}
-	return true
+	return strings.ReplaceAll(string(pod.UID), "-", "")
 }

--- a/internal/drivers/common/naming_test.go
+++ b/internal/drivers/common/naming_test.go
@@ -2,135 +2,77 @@ package common
 
 import (
 	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
-func TestK8sToAppHostingName(t *testing.T) {
+func TestGetAppHostingName(t *testing.T) {
 	tests := []struct {
-		name      string
-		namespace string
-		podName   string
-		want      string
+		name string
+		pod  *v1.Pod
+		want string
 	}{
 		{
-			name:      "simple name with hyphen in default namespace",
-			namespace: "default",
-			podName:   "nginx-on-switch",
-			want:      "nginx_on_switch",
+			name: "generates name from UID",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: types.UID("a24a730b-8b13-4fd0-96ee-900f99d87670"),
+				},
+			},
+			want: "a24a730b8b134fd096ee900f99d87670",
 		},
 		{
-			name:      "simple name with hyphen in empty namespace",
-			namespace: "",
-			podName:   "nginx-on-switch",
-			want:      "nginx_on_switch",
-		},
-		{
-			name:      "name without hyphen",
-			namespace: "default",
-			podName:   "nginx",
-			want:      "nginx",
-		},
-		{
-			name:      "name with multiple hyphens",
-			namespace: "default",
-			podName:   "my-cool-app-v2",
-			want:      "my_cool_app_v2",
-		},
-		{
-			name:      "non-default namespace adds hash suffix",
-			namespace: "production",
-			podName:   "nginx",
-			want:      "nginx_ab8e18", // hash of "production"
-		},
-		{
-			name:      "non-default namespace with hyphen in pod name",
-			namespace: "prod",
-			podName:   "nginx-app",
-			want:      "nginx_app_6754af", // hash of "prod"
-		},
-		{
-			name:      "long name gets truncated in default namespace",
-			namespace: "default",
-			podName:   "this-is-a-very-long-pod-name-that-exceeds-forty-characters",
-			want:      "this_is_a_very_long_pod_name_that_exceed", // truncated to 40
-		},
-		{
-			name:      "long name with non-default namespace",
-			namespace: "production",
-			podName:   "this-is-a-very-long-pod-name-that-exceeds-forty",
-			want:      "this_is_a_very_long_pod_name_that_ab8e18", // truncated + hash
+			name: "returns existing label if set",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: types.UID("a24a730b-8b13-4fd0-96ee-900f99d87670"),
+					Labels: map[string]string{
+						AppHostingNameLabel: "existinglabel123",
+					},
+				},
+			},
+			want: "existinglabel123",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := K8sToAppHostingName(tt.namespace, tt.podName)
+			got := GetAppHostingName(tt.pod)
 			if got != tt.want {
-				t.Errorf("K8sToAppHostingName(%q, %q) = %q, want %q", tt.namespace, tt.podName, got, tt.want)
-			}
-			// Verify length constraint
-			if len(got) > MaxAppHostingNameLength {
-				t.Errorf("K8sToAppHostingName(%q, %q) length = %d, exceeds max %d", tt.namespace, tt.podName, len(got), MaxAppHostingNameLength)
+				t.Errorf("GetAppHostingName() = %q, want %q", got, tt.want)
 			}
 		})
 	}
 }
 
-func TestAppHostingToK8sName(t *testing.T) {
-	tests := []struct {
-		name    string
-		appName string
-		want    string
-	}{
-		{
-			name:    "simple name with underscore",
-			appName: "nginx_on_switch",
-			want:    "nginx-on-switch",
-		},
-		{
-			name:    "name without underscore",
-			appName: "nginx",
-			want:    "nginx",
-		},
-		{
-			name:    "name with hash suffix removed",
-			appName: "nginx_app_6754af",
-			want:    "nginx-app",
-		},
-		{
-			name:    "name with multiple underscores",
-			appName: "my_cool_app_v2",
-			want:    "my-cool-app-v2",
+func TestGetAppHostingNameLength(t *testing.T) {
+	// UUID without hyphens is 32 chars, which fits in 40-char YANG constraint
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: types.UID("a24a730b-8b13-4fd0-96ee-900f99d87670"),
 		},
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := AppHostingToK8sName(tt.appName)
-			if got != tt.want {
-				t.Errorf("AppHostingToK8sName(%q) = %q, want %q", tt.appName, got, tt.want)
-			}
-		})
+	got := GetAppHostingName(pod)
+	if len(got) > 40 {
+		t.Errorf("GetAppHostingName() length = %d, exceeds max 40", len(got))
+	}
+	if len(got) != 32 {
+		t.Errorf("GetAppHostingName() length = %d, expected 32 (UUID without hyphens)", len(got))
 	}
 }
 
-func TestK8sToAppHostingNameValidCharacters(t *testing.T) {
-	// Test that output only contains valid AppHosting characters: [0-9a-zA-Z_]
-	testCases := []struct {
-		namespace string
-		podName   string
-	}{
-		{"default", "nginx-on-switch"},
-		{"prod", "my-app-v2"},
-		{"kube-system", "coredns-abc123"},
-		{"", "simple"},
+func TestGetAppHostingNameValidCharacters(t *testing.T) {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: types.UID("a24a730b-8b13-4fd0-96ee-900f99d87670"),
+		},
 	}
-
-	for _, tc := range testCases {
-		result := K8sToAppHostingName(tc.namespace, tc.podName)
-		for _, c := range result {
-			if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_') {
-				t.Errorf("K8sToAppHostingName(%q, %q) = %q contains invalid character %q", tc.namespace, tc.podName, result, string(c))
-			}
+	result := GetAppHostingName(pod)
+	for _, c := range result {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			t.Errorf("GetAppHostingName() = %q contains invalid character %q (expected hex only)", result, string(c))
 		}
 	}
 }

--- a/internal/drivers/fake/driver.go
+++ b/internal/drivers/fake/driver.go
@@ -41,8 +41,7 @@ func (d *FAKEDriver) GetDeviceResources(ctx context.Context) (*v1.ResourceList, 
 }
 
 func (d *FAKEDriver) DeployContainer(ctx context.Context, pod *v1.Pod) error {
-	// Convert K8s pod name to valid Cisco AppHosting name
-	appName := common.K8sToAppHostingName(pod.Namespace, pod.Name)
+	appName := common.GetAppHostingName(pod)
 	log.G(ctx).WithFields(log.Fields{
 		"namespace":   pod.Namespace,
 		"pod":         pod.Name,

--- a/internal/drivers/iosxe/pod_lifecycle.go
+++ b/internal/drivers/iosxe/pod_lifecycle.go
@@ -11,8 +11,7 @@ import (
 )
 
 func (d *XEDriver) ConfigureAppContainer(ctx context.Context, pod *v1.Pod) error {
-	// Convert K8s pod name to valid Cisco AppHosting name
-	appName := common.K8sToAppHostingName(pod.Namespace, pod.Name)
+	appName := common.GetAppHostingName(pod)
 	log.G(ctx).Infof("Configuring AppHosting app: %s (k8s: %s/%s)", appName, pod.Namespace, pod.Name)
 
 	// POST to app-hosting-cfg-data using correct YANG schema from Cisco-IOS-XE-app-hosting-cfg.yang

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,42 +2,49 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"sync"
 
 	"github.com/cisco/virtual-kubelet-cisco/internal/config"
 	"github.com/cisco/virtual-kubelet-cisco/internal/drivers"
+	"github.com/cisco/virtual-kubelet-cisco/internal/drivers/common"
 	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/virtual-kubelet/virtual-kubelet/errdefs"
 	"github.com/virtual-kubelet/virtual-kubelet/node/api"
 	"github.com/virtual-kubelet/virtual-kubelet/node/api/statsv1alpha1"
 	"github.com/virtual-kubelet/virtual-kubelet/node/nodeutil"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 )
 
 type AppHostingProvider struct {
-	ctx    context.Context
-	appCfg *config.Config
-	driver drivers.CiscoDeviceDriver // Injected via factory
-	mutex  sync.RWMutex
+	ctx       context.Context
+	appCfg    *config.Config
+	driver    drivers.CiscoDeviceDriver
+	clientset kubernetes.Interface
+	mutex     sync.RWMutex
 }
 
 func NewAppHostingProvider(
 	ctx context.Context,
 	appCfg *config.Config,
 	vkCfg nodeutil.ProviderConfig,
+	clientset kubernetes.Interface,
 ) (*AppHostingProvider, error) {
 
-	// TODO: We should do auto-discovery (or config) in NewDriver
 	d, err := drivers.NewDriver(ctx, &appCfg.Device)
 	if err != nil {
 		return nil, fmt.Errorf("driver assignment failed: %v", err)
 	}
 	return &AppHostingProvider{
-		ctx:    ctx,
-		appCfg: appCfg,
-		driver: d,
+		ctx:       ctx,
+		appCfg:    appCfg,
+		driver:    d,
+		clientset: clientset,
 	}, nil
 }
 
@@ -47,8 +54,29 @@ func (p *AppHostingProvider) GetCapacity(ctx context.Context) (v1.ResourceList, 
 }
 
 func (p *AppHostingProvider) CreatePod(ctx context.Context, pod *v1.Pod) error {
+	// Add AppHosting name label to pod for reverse lookup
+	appName := common.GetAppHostingName(pod)
+	if pod.Labels == nil {
+		pod.Labels = make(map[string]string)
+	}
+	if _, exists := pod.Labels[common.AppHostingNameLabel]; !exists {
+		pod.Labels[common.AppHostingNameLabel] = appName
+		// Use PATCH to only update metadata labels (Update fails due to spec immutability)
+		patch := map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"labels": map[string]string{
+					common.AppHostingNameLabel: appName,
+				},
+			},
+		}
+		patchBytes, _ := json.Marshal(patch)
+		_, err := p.clientset.CoreV1().Pods(pod.Namespace).Patch(ctx, pod.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+		if err != nil {
+			return errdefs.AsInvalidInput(fmt.Errorf("failed to add apphosting label: %w", err))
+		}
+	}
+
 	if err := p.driver.DeployContainer(p.ctx, pod); err != nil {
-		// Return wrapped errors from github.com/virtual-kubelet/virtual-kubelet/errdefs
 		return errdefs.AsInvalidInput(err)
 	}
 	return nil


### PR DESCRIPTION
## Description

### Problem

Kubernetes pod names (RFC 1123) allow hyphens, but Cisco AppHosting YANG model only allows alphanumeric characters and underscores (max 40 chars). Additionally, reverse lookup from device app names back to K8s pods was needed.

Given the challenges observed in the context of multiple name spaces and some corner case conditions with the earlier commit of - to be substituted for _, the alternative approach of UUID based naming was decided. 

Further details on this change can be found in Issue https://github.com/cisco-open/cisco-virtual-kubelet/issues/16

### Solution

Use the **Pod UID** (stripped of hyphens) as the AppHosting container name. Store this mapping as a label on the pod for efficient reverse lookup.

**Example:**
```
Pod UID:         e5ba94c1-312c-47f0-a257-e0f669d78aaf
AppHosting Name: e5ba94c1312c47f0a257e0f669d78aaf (32 chars)
Pod Label:       cisco.com/apphosting-name=e5ba94c1312c47f0a257e0f669d78aaf
```

### Changes

| File | Description |
|------|-------------|
| [internal/drivers/common/naming.go](cci:7://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/drivers/common/naming.go:0:0-0:0) | New [GetAppHostingName(pod)](cci:1://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/drivers/common/naming.go:13:0-21:1) function using Pod UID |
| [internal/drivers/common/naming_test.go](cci:7://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/drivers/common/naming_test.go:0:0-0:0) | Unit tests for UUID-based naming |
| [internal/drivers/common/helpers.go](cci:7://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/drivers/common/helpers.go:0:0-0:0) | Updated [PodToContainer](cci:1://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/drivers/common/helpers.go:6:0-10:1) to use new naming |
| [internal/drivers/iosxe/pod_lifecycle.go](cci:7://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/drivers/iosxe/pod_lifecycle.go:0:0-0:0) | Updated to use [GetAppHostingName](cci:1://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/drivers/common/naming.go:13:0-21:1) |
| [internal/drivers/fake/driver.go](cci:7://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/drivers/fake/driver.go:0:0-0:0) | Updated to use [GetAppHostingName](cci:1://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/drivers/common/naming.go:13:0-21:1) |
| [internal/provider/provider.go](cci:7://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/provider/provider.go:0:0-0:0) | Added K8s clientset; [CreatePod](cci:1://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/provider/provider.go:48:0-54:1) adds label via PATCH |
| [cmd/virtual-kubelet/main.go](cci:7://file:///Users/johalley/Git/cisco-virtual-kubelet/cmd/virtual-kubelet/main.go:0:0-0:0) | Pass clientset to provider |

### Reason for this approach

- **Ensured uniqueness** - Pod UIDs are unique across the cluster
- **Fits YANG constraint** - 32 hex chars < 40 char limit
- **Reverse lookup** - `kubectl get pods -l cisco.com/apphosting-name=<uuid>`
- **No namespace collision** - UIDs are globally unique, no hash suffix needed

### Testing

```bash
# Unit tests
go test -v ./internal/drivers/common/...

# Manual verification
kubectl apply -f ./dev/test-pod.yaml
kubectl get pods -l cisco.com/apphosting-name=<uuid>
```
## Type of Change

- [x] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
