### PR TITLE
Add path logic

### DIFF
--- a/cmd/virtual-kubelet/cmd/root.go
+++ b/cmd/virtual-kubelet/cmd/root.go
@@ -1,0 +1,168 @@
+// Copyright © 2025 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"path"
+	"runtime"
+	"syscall"
+
+	"github.com/cisco/virtual-kubelet-cisco/internal/config"
+	"github.com/cisco/virtual-kubelet-cisco/internal/provider"
+	logruslib "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/virtual-kubelet/virtual-kubelet/log"
+	"github.com/virtual-kubelet/virtual-kubelet/log/logrus"
+	"github.com/virtual-kubelet/virtual-kubelet/node"
+	"github.com/virtual-kubelet/virtual-kubelet/node/nodeutil"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+var (
+	cfgFile    string
+	kubeconfig string
+	logLevel   string
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "virtual-kubelet",
+	Short: "Cisco Virtual Kubelet for AppHosting",
+	Long: `Cisco Virtual Kubelet implements the Kubelet interface to deploy
+containers on Cisco devices using AppHosting.`,
+	RunE: runVirtualKubelet,
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "",
+		"config file (default: /etc/virtual-kubelet/config.yaml)")
+	rootCmd.PersistentFlags().StringVar(&kubeconfig, "kubeconfig", "",
+		"path to kubeconfig file (default: $KUBECONFIG or in-cluster)")
+	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "",
+		"log level: debug, info, warn, error (default: $LOG_LEVEL or info)")
+}
+
+// Execute runs the root command
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+func runVirtualKubelet(cmd *cobra.Command, args []string) error {
+	// Load config
+	appCfg, err := config.Load(cfgFile)
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Setup logging
+	logrusLogger := logruslib.New()
+	logrusLogger.SetReportCaller(true)
+	logrusLogger.SetFormatter(&logruslib.TextFormatter{
+		FullTimestamp: true,
+		CallerPrettyfier: func(f *runtime.Frame) (string, string) {
+			return "", fmt.Sprintf("%s:%d", path.Base(f.File), f.Line)
+		},
+	})
+
+	// Log level: flag > env > default
+	lvl := logLevel
+	if lvl == "" {
+		lvl = os.Getenv("LOG_LEVEL")
+	}
+	switch lvl {
+	case "debug":
+		logrusLogger.SetLevel(logruslib.DebugLevel)
+	case "warn", "warning":
+		logrusLogger.SetLevel(logruslib.WarnLevel)
+	case "error":
+		logrusLogger.SetLevel(logruslib.ErrorLevel)
+	default:
+		logrusLogger.SetLevel(logruslib.InfoLevel)
+	}
+
+	logger := logrus.FromLogrus(logruslib.NewEntry(logrusLogger))
+	ctx = log.WithLogger(ctx, logger)
+
+	// Signal handling
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sig
+		log.G(ctx).Info("Received shutdown signal")
+		cancel()
+	}()
+
+	// Kubeconfig: flag > env > in-cluster
+	kubeconfigPath := kubeconfig
+	if kubeconfigPath == "" {
+		kubeconfigPath = os.Getenv("KUBECONFIG")
+	}
+	var restconfig *rest.Config
+	if kubeconfigPath != "" {
+		restconfig, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	} else {
+		restconfig, err = rest.InClusterConfig()
+	}
+	if err != nil {
+		return fmt.Errorf("failed to load kubeconfig: %w", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(restconfig)
+	if err != nil {
+		return fmt.Errorf("failed to create Kubernetes client: %w", err)
+	}
+
+	opts := []nodeutil.NodeOpt{
+		nodeutil.WithNodeConfig(nodeutil.NodeConfig{
+			Client:         clientset,
+			NodeSpec:       provider.GetInitialNodeSpec(appCfg),
+			HTTPListenAddr: ":10250",
+			NumWorkers:     5,
+		}),
+	}
+
+	newProviderFunc := func(vkCfg nodeutil.ProviderConfig) (nodeutil.Provider, node.NodeProvider, error) {
+		podHandler, err := provider.NewAppHostingProvider(ctx, appCfg, vkCfg)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to initialise PodHandler: %w", err)
+		}
+		nodeHandler, err := provider.NewAppHostingNode(ctx, appCfg, vkCfg)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to initialise nodeHandler: %w", err)
+		}
+		return podHandler, nodeHandler, nil
+	}
+
+	nodeName := provider.GetNodeName(appCfg)
+	n, err := nodeutil.NewNode(nodeName, newProviderFunc, opts...)
+	if err != nil {
+		return fmt.Errorf("failed to create node: %w", err)
+	}
+
+	if err := n.Run(ctx); err != nil {
+		return fmt.Errorf("node run failed: %w", err)
+	}
+
+	log.G(ctx).Info("Cisco Virtual Kubelet stopped")
+	return nil
+}

--- a/cmd/virtual-kubelet/main.go
+++ b/cmd/virtual-kubelet/main.go
@@ -15,24 +15,13 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
-	"os/signal"
-	"path"
-	"runtime"
-	"syscall"
 
-	"github.com/cisco/virtual-kubelet-cisco/internal/config"
+	"github.com/cisco/virtual-kubelet-cisco/cmd/virtual-kubelet/cmd"
 	"github.com/cisco/virtual-kubelet-cisco/internal/provider"
-	logruslib "github.com/sirupsen/logrus"
-	"github.com/virtual-kubelet/virtual-kubelet/log"
-	"github.com/virtual-kubelet/virtual-kubelet/log/logrus"
 	"github.com/virtual-kubelet/virtual-kubelet/node"
 	"github.com/virtual-kubelet/virtual-kubelet/node/nodeutil"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 // Interface Guard
@@ -40,114 +29,8 @@ var _ nodeutil.Provider = (*provider.AppHostingProvider)(nil)
 var _ node.NodeProvider = (*provider.AppHostingNode)(nil)
 
 func main() {
-
-	appCfg, err := config.Load("/etc/virtual-kubelet/config.yaml")
-	if err != nil {
+	if err := cmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// Setup logging
-	logrusLogger := logruslib.New()
-
-	// Set log formatting
-	logrusLogger.SetReportCaller(true)
-	logrusLogger.SetFormatter(&logruslib.TextFormatter{
-		FullTimestamp: true,
-		CallerPrettyfier: func(f *runtime.Frame) (string, string) {
-			// Return empty for the function name to remove it entirely
-			// Use path.Base to show only the filename:line
-			return "", fmt.Sprintf("%s:%d", path.Base(f.File), f.Line)
-		},
-	})
-
-	// Set log level from environment
-	logLevel := os.Getenv("LOG_LEVEL")
-	switch logLevel {
-	case "debug":
-		logrusLogger.SetLevel(logruslib.DebugLevel)
-	case "warn", "warning":
-		logrusLogger.SetLevel(logruslib.WarnLevel)
-	case "error":
-		logrusLogger.SetLevel(logruslib.ErrorLevel)
-	default:
-		logrusLogger.SetLevel(logruslib.InfoLevel)
-	}
-
-	logger := logrus.FromLogrus(logruslib.NewEntry(logrusLogger))
-	ctx = log.WithLogger(ctx, logger)
-
-	// Handle shutdown gracefully
-	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
-	go func() {
-		<-sig
-		log.G(ctx).Info("Received shutdown signal")
-		cancel()
-	}()
-
-	// TODO: Allow setting of kubeconfig path in config
-	kubeconfig := os.Getenv("KUBECONFIG")
-	// if kubeconfig == "" {
-	// 	kubeconfig = os.Getenv("HOME") + "/.kube/config"
-	// }
-
-	// Create Kubernetes client configuration
-	var restconfig *rest.Config
-
-	if kubeconfig != "" {
-		restconfig, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
-	} else {
-		restconfig, err = rest.InClusterConfig()
-	}
-	if err != nil {
-		log.G(ctx).WithError(err).Fatal("Failed to load kubeconfig")
-	}
-
-	// Create Kubernetes clientset
-	clientset, err := kubernetes.NewForConfig(restconfig)
-	if err != nil {
-		log.G(ctx).WithError(err).Fatal("Failed to create Kubernetes client")
-	}
-
-	// Values here should either be static or derive from appCfg
-	opts := []nodeutil.NodeOpt{
-		nodeutil.WithNodeConfig(nodeutil.NodeConfig{
-			Client:         clientset,
-			NodeSpec:       provider.GetInitialNodeSpec(appCfg), // Reduce scope of appCfg to appCfg.Kubelet?
-			HTTPListenAddr: ":10250",
-			NumWorkers:     5,
-		}),
-	}
-
-	newProviderFunc := func(vkCfg nodeutil.ProviderConfig) (nodeutil.Provider, node.NodeProvider, error) {
-
-		PodHandler, err := provider.NewAppHostingProvider(ctx, appCfg, vkCfg)
-		if err != nil {
-			log.G(ctx).WithError(err).Fatal("Failed to initialise PodHandler")
-		}
-
-		nodeHandler, err := provider.NewAppHostingNode(ctx, appCfg, vkCfg)
-		if err != nil {
-			log.G(ctx).WithError(err).Fatal("Failed to initialise nodeHandler")
-		}
-
-		return PodHandler, nodeHandler, nil
-	}
-
-	nodeName := provider.GetNodeName(appCfg) // Reduce scope of appCfg to appCfg.Kubelet?
-	n, err := nodeutil.NewNode(nodeName, newProviderFunc, opts...)
-	if err != nil {
-		log.G(ctx).WithError(err).Fatal("Failed to create node")
-	}
-
-	// Run node controller
-	if err := n.Run(ctx); err != nil {
-		log.G(ctx).WithError(err).Fatal("Node run failed")
-	}
-
-	log.G(ctx).Info("Cisco Virtual Kubelet stopped")
 }

--- a/dev/README.md
+++ b/dev/README.md
@@ -25,7 +25,7 @@ The `./dev/okteto.yaml` config should be pointing at the `okteto-dev` deployment
 This should launch an Okteto Golang development environment inside the k8s deployment and sync these local files.  From this shell you should be able to start the cisco-virtual-kubelet:
 
 ```
-go run ./cmd/cisco-virtual-kubelet
+go run ./cmd/virtual-kubelet
 ```
 
 In another terminal you should now have a new node registered with your K8s development environment.  Label the node so that you can target it for scheduling directly with a test pod:
@@ -37,7 +37,7 @@ kubectl label node cunningr-dev-node kubernetes.io/hostname=cunningr-dev-node
 You should now be able to create/delete the test pod in your dev k8s cluster:
 
 ```
-kubectl apply -f test-pod.yaml
+kubectl apply -f ./dev/test-pod.yaml
 ```
 
 As you update the code locally Okteto will sync everything to your k8s development containter environment. From the Okteto dev environment you can start/stop the application and watch the cisco-virtual-kubelet logs.  

--- a/dev/test-pod.yaml
+++ b/dev/test-pod.yaml
@@ -5,7 +5,7 @@ metadata:
   name: nginx-on-switch
 spec:
   nodeSelector:
-    kubernetes.io/hostname: cunningr-dev-node
+    kubernetes.io/hostname: cheekycheek
   containers:
   - name: nginx
     image: flash:/nginx.tar

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,16 +3,11 @@ package config
 import (
 	"fmt"
 	"strings"
-	"sync"
 
-	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
-var registerFlagsOnce sync.Once
-
 func Load(filePath ...string) (*Config, error) {
-
 	if len(filePath) > 0 && filePath[0] != "" {
 		viper.SetConfigFile(filePath[0])
 	} else {
@@ -26,22 +21,7 @@ func Load(filePath ...string) (*Config, error) {
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_")) // allow SERVER_PORT for server.port
 	viper.AutomaticEnv()
 
-	registerFlagsOnce.Do(func() {
-		// This doesn't actually work for the current schema
-		pflag.String("device.name", "", "Device name")
-		// Add any other pflag definitions here
-	})
-
-	// Parse flags only if not already parsed (to avoid errors in tests)
-	if !pflag.Parsed() {
-		pflag.Parse()
-	}
-
-	if err := viper.BindPFlags(pflag.CommandLine); err != nil {
-		return nil, err
-	}
-
-	// 4. Read the file
+	// Read the config file
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
 			return nil, fmt.Errorf("error reading config file: %w", err)
@@ -49,7 +29,7 @@ func Load(filePath ...string) (*Config, error) {
 		// It's okay if file is missing; we can rely on ENV or Flags
 	}
 
-	// 5. Unmarshal into struct
+	// Unmarshal into struct
 	var cfg Config
 	if err := viper.UnmarshalExact(&cfg); err != nil {
 		return nil, fmt.Errorf("unable to decode into struct: %w", err)


### PR DESCRIPTION
## Description

Refactored the CLI to use Cobra command structure, adding configurable path selection for configuration files, kubeconfig, and log level via CLI flags with environment variable fallback.

---

### New CLI Flags

```
$ virtual-kubelet --help
Cisco Virtual Kubelet implements the Kubelet interface to deploy
containers on Cisco devices using AppHosting.

Usage:
  virtual-kubelet [flags]

Flags:
  -c, --config string       config file (default: /etc/virtual-kubelet/config.yaml)
  -h, --help                help for virtual-kubelet
      --kubeconfig string   path to kubeconfig file (default: $KUBECONFIG or in-cluster)
      --log-level string    log level: debug, info, warn, error (default: $LOG_LEVEL or info)
```

### Precedence

| Flag | Precedence |
|------|------------|
| `--config` / `-c` | Flag → `/etc/virtual-kubelet/config.yaml` |
| `--kubeconfig` | Flag → `$KUBECONFIG` → in-cluster |
| `--log-level` | Flag → `$LOG_LEVEL` → `info` |

---

### Files Changed

| File | Change |
|------|--------|
| [cmd/virtual-kubelet/cmd/root.go](cci:7://file:///Users/johalley/Git/cisco-virtual-kubelet/cmd/virtual-kubelet/cmd/root.go:0:0-0:0) | **New** - Cobra root command with flags and main run logic |
| [cmd/virtual-kubelet/main.go](cci:7://file:///Users/johalley/Git/cisco-virtual-kubelet/cmd/virtual-kubelet/main.go:0:0-0:0) | Entry point calling [cmd.Execute()](cci:1://file:///Users/johalley/Git/cisco-virtual-kubelet/cmd/virtual-kubelet/cmd/root.go:61:0-64:1) |
| [internal/config/config.go](cci:7://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/config/config.go:0:0-0:0) | Removed  unused pflag code |

---

### Non-Viper CLI Based Variables

1. **Cobra without Viper for CLI flags** — Flags use direct variable binding with manual env fallback, avoiding conflicts with Viper's global state used for config file loading.

3. **Compatible** — Existing environment variables (`KUBECONFIG`, `LOG_LEVEL`) continue to work when flags are not provided.

---

### Testing

Verified with Okteto dev environment:
```bash
default:okteto-dev app> go run ./cmd/virtual-kubelet --help                           
Cisco Virtual Kubelet implements the Kubelet interface to deploy
containers on Cisco devices using AppHosting.

Usage:
  virtual-kubelet [flags]

Flags:
  -c, --config string       config file (default: /etc/virtual-kubelet/config.yaml)
  -h, --help                help for virtual-kubelet
      --kubeconfig string   path to kubeconfig file (default: $KUBECONFIG or in-cluster)
      --log-level string    log level: debug, info, warn, error (default: $LOG_LEVEL or info)
default:okteto-dev app> go run ./cmd/virtual-kubelet -c ./dev/config.yaml --log-level debug
INFO[2026-01-21T15:48:01Z]driver.go:22 Initialise new FAKE driver                   
DEBU[2026-01-21T15:48:01Z]controller.go:107 Started event broadcaster                    
WARN[2026-01-21T15:48:01Z]controller.go:66 TLS config not provided, not starting up http service 
DEBU[2026-01-21T15:48:01Z]podcontroller.go:291 Wrapped non-async provider with async        
DEBU[2026-01-21T15:48:01Z]sync.go:109 Pod status update loop start                 
INFO[2026-01-21T15:48:02Z]podcontroller.go:304 Pod cache in-sync                            
INFO[2026-01-21T15:48:02Z]driver.go:129 Pod ListContainers request received          
INFO[2026-01-21T15:48:02Z]podcontroller.go:415 starting workers                             
INFO[2026-01-21T15:48:02Z]podcontroller.go:427 started workers                              
DEBU[2026-01-21T15:48:02Z]controller.go:133 pod controller ready                         
DEBU[2026-01-21T15:48:02Z]node.go:282 Starting leasecontroller                      leaseController="&{0x40002d2a80 40 10000000000 0x3257300 0x40007581e0 <nil>}"
DEBU[2026-01-21T15:48:02Z]node.go:352 lease controller in use, updating at statusInterval  statusInterval=1m0s
DEBU[2026-01-21T15:48:02Z]controller.go:151 node controller ready                        
DEBU[2026-01-21T15:48:06Z]sync.go:109 Pod status update loop start                 
```

Pod scheduling and lifecycle confirmed working with fake driver.

PR is related to Issue #21

## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass

