### PR TITLE
Add Path Logic and Handling

### DIFF
--- a/cmd/virtual-kubelet/main.go
+++ b/cmd/virtual-kubelet/main.go
@@ -15,24 +15,12 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
-	"os/signal"
-	"path"
-	"runtime"
-	"syscall"
 
-	"github.com/cisco/virtual-kubelet-cisco/internal/config"
 	"github.com/cisco/virtual-kubelet-cisco/internal/provider"
-	logruslib "github.com/sirupsen/logrus"
-	"github.com/virtual-kubelet/virtual-kubelet/log"
-	"github.com/virtual-kubelet/virtual-kubelet/log/logrus"
 	"github.com/virtual-kubelet/virtual-kubelet/node"
 	"github.com/virtual-kubelet/virtual-kubelet/node/nodeutil"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 // Interface Guard
@@ -40,114 +28,8 @@ var _ nodeutil.Provider = (*provider.AppHostingProvider)(nil)
 var _ node.NodeProvider = (*provider.AppHostingNode)(nil)
 
 func main() {
-
-	appCfg, err := config.Load("/etc/virtual-kubelet/config.yaml")
-	if err != nil {
+	if err := Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// Setup logging
-	logrusLogger := logruslib.New()
-
-	// Set log formatting
-	logrusLogger.SetReportCaller(true)
-	logrusLogger.SetFormatter(&logruslib.TextFormatter{
-		FullTimestamp: true,
-		CallerPrettyfier: func(f *runtime.Frame) (string, string) {
-			// Return empty for the function name to remove it entirely
-			// Use path.Base to show only the filename:line
-			return "", fmt.Sprintf("%s:%d", path.Base(f.File), f.Line)
-		},
-	})
-
-	// Set log level from environment
-	logLevel := os.Getenv("LOG_LEVEL")
-	switch logLevel {
-	case "debug":
-		logrusLogger.SetLevel(logruslib.DebugLevel)
-	case "warn", "warning":
-		logrusLogger.SetLevel(logruslib.WarnLevel)
-	case "error":
-		logrusLogger.SetLevel(logruslib.ErrorLevel)
-	default:
-		logrusLogger.SetLevel(logruslib.InfoLevel)
-	}
-
-	logger := logrus.FromLogrus(logruslib.NewEntry(logrusLogger))
-	ctx = log.WithLogger(ctx, logger)
-
-	// Handle shutdown gracefully
-	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
-	go func() {
-		<-sig
-		log.G(ctx).Info("Received shutdown signal")
-		cancel()
-	}()
-
-	// TODO: Allow setting of kubeconfig path in config
-	kubeconfig := os.Getenv("KUBECONFIG")
-	// if kubeconfig == "" {
-	// 	kubeconfig = os.Getenv("HOME") + "/.kube/config"
-	// }
-
-	// Create Kubernetes client configuration
-	var restconfig *rest.Config
-
-	if kubeconfig != "" {
-		restconfig, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
-	} else {
-		restconfig, err = rest.InClusterConfig()
-	}
-	if err != nil {
-		log.G(ctx).WithError(err).Fatal("Failed to load kubeconfig")
-	}
-
-	// Create Kubernetes clientset
-	clientset, err := kubernetes.NewForConfig(restconfig)
-	if err != nil {
-		log.G(ctx).WithError(err).Fatal("Failed to create Kubernetes client")
-	}
-
-	// Values here should either be static or derive from appCfg
-	opts := []nodeutil.NodeOpt{
-		nodeutil.WithNodeConfig(nodeutil.NodeConfig{
-			Client:         clientset,
-			NodeSpec:       provider.GetInitialNodeSpec(appCfg), // Reduce scope of appCfg to appCfg.Kubelet?
-			HTTPListenAddr: ":10250",
-			NumWorkers:     5,
-		}),
-	}
-
-	newProviderFunc := func(vkCfg nodeutil.ProviderConfig) (nodeutil.Provider, node.NodeProvider, error) {
-
-		PodHandler, err := provider.NewAppHostingProvider(ctx, appCfg, vkCfg)
-		if err != nil {
-			log.G(ctx).WithError(err).Fatal("Failed to initialise PodHandler")
-		}
-
-		nodeHandler, err := provider.NewAppHostingNode(ctx, appCfg, vkCfg)
-		if err != nil {
-			log.G(ctx).WithError(err).Fatal("Failed to initialise nodeHandler")
-		}
-
-		return PodHandler, nodeHandler, nil
-	}
-
-	nodeName := provider.GetNodeName(appCfg) // Reduce scope of appCfg to appCfg.Kubelet?
-	n, err := nodeutil.NewNode(nodeName, newProviderFunc, opts...)
-	if err != nil {
-		log.G(ctx).WithError(err).Fatal("Failed to create node")
-	}
-
-	// Run node controller
-	if err := n.Run(ctx); err != nil {
-		log.G(ctx).WithError(err).Fatal("Node run failed")
-	}
-
-	log.G(ctx).Info("Cisco Virtual Kubelet stopped")
 }

--- a/cmd/virtual-kubelet/root.go
+++ b/cmd/virtual-kubelet/root.go
@@ -1,0 +1,220 @@
+// Copyright © 2025 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"path"
+	"runtime"
+	"syscall"
+
+	"github.com/cisco/virtual-kubelet-cisco/internal/config"
+	"github.com/cisco/virtual-kubelet-cisco/internal/provider"
+	logruslib "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/virtual-kubelet/virtual-kubelet/log"
+	"github.com/virtual-kubelet/virtual-kubelet/log/logrus"
+	"github.com/virtual-kubelet/virtual-kubelet/node"
+	"github.com/virtual-kubelet/virtual-kubelet/node/nodeutil"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+var (
+	cfgFile    string
+	kubeconfig string
+	logLevel   string
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "virtual-kubelet",
+	Short: "Cisco Virtual Kubelet for AppHosting",
+	Long: `Cisco Virtual Kubelet implements the Kubelet interface to deploy
+containers on Cisco devices using AppHosting.`,
+	RunE: runVirtualKubelet,
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "",
+		"config file (default: /etc/virtual-kubelet/config.yaml)")
+	rootCmd.PersistentFlags().StringVar(&kubeconfig, "kubeconfig", "",
+		"path to kubeconfig file (default: $KUBECONFIG or in-cluster)")
+	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "",
+		"log level: debug, info, warn, error (default: $LOG_LEVEL or info)")
+}
+
+// Execute runs the root command
+func Execute() error {
+	return rootCmd.Execute()
+}
+
+// validateConfig checks if the config file exists at the given path
+func validateConfig(configPath string) error {
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		return fmt.Errorf("config file not found: %s\n\nSpecify a config file with --config or -c flag, or create the default config at /etc/virtual-kubelet/config.yaml", configPath)
+	}
+	return nil
+}
+
+// validateLogLevel checks if the provided log level is valid
+func validateLogLevel(level string) error {
+	switch level {
+	case "", "info", "debug", "warn", "warning", "error":
+		return nil
+	default:
+		return fmt.Errorf("invalid log level: %q\n\nValid options are: debug, info, warn, error", level)
+	}
+}
+
+// validateKubeconfig checks if the kubeconfig file exists (when path is provided)
+func validateKubeconfig(kubeconfigPath string) error {
+	if kubeconfigPath == "" {
+		return nil // empty is valid - will fall back to env or in-cluster
+	}
+	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
+		return fmt.Errorf("kubeconfig file not found: %s\n\nSpecify a valid kubeconfig with --kubeconfig flag or KUBECONFIG environment variable", kubeconfigPath)
+	}
+	return nil
+}
+
+func runVirtualKubelet(cmd *cobra.Command, args []string) error {
+	// Determine config path: flag > default
+	configPath := cfgFile
+	if configPath == "" {
+		configPath = "/etc/virtual-kubelet/config.yaml"
+	}
+
+	// Validate config file exists
+	if err := validateConfig(configPath); err != nil {
+		return err
+	}
+
+	// Load config
+	appCfg, err := config.Load(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to load config from %s: %w", configPath, err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Setup logging
+	logrusLogger := logruslib.New()
+	logrusLogger.SetReportCaller(true)
+	logrusLogger.SetFormatter(&logruslib.TextFormatter{
+		FullTimestamp: true,
+		CallerPrettyfier: func(f *runtime.Frame) (string, string) {
+			return "", fmt.Sprintf("%s:%d", path.Base(f.File), f.Line)
+		},
+	})
+
+	// Log level: flag > env > default
+	lvl := logLevel
+	if lvl == "" {
+		lvl = os.Getenv("LOG_LEVEL")
+	}
+	if err := validateLogLevel(lvl); err != nil {
+		return err
+	}
+	switch lvl {
+	case "", "info":
+		logrusLogger.SetLevel(logruslib.InfoLevel)
+	case "debug":
+		logrusLogger.SetLevel(logruslib.DebugLevel)
+	case "warn", "warning":
+		logrusLogger.SetLevel(logruslib.WarnLevel)
+	case "error":
+		logrusLogger.SetLevel(logruslib.ErrorLevel)
+	}
+
+	logger := logrus.FromLogrus(logruslib.NewEntry(logrusLogger))
+	ctx = log.WithLogger(ctx, logger)
+
+	// Signal handling
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sig
+		log.G(ctx).Info("Received shutdown signal")
+		cancel()
+	}()
+
+	// Kubeconfig: flag > env > in-cluster
+	kubeconfigPath := kubeconfig
+	if kubeconfigPath == "" {
+		kubeconfigPath = os.Getenv("KUBECONFIG")
+	}
+
+	// Validate kubeconfig if path provided
+	if err := validateKubeconfig(kubeconfigPath); err != nil {
+		return err
+	}
+
+	var restconfig *rest.Config
+	if kubeconfigPath != "" {
+		restconfig, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+		if err != nil {
+			return fmt.Errorf("failed to load kubeconfig from %s: %w", kubeconfigPath, err)
+		}
+	} else {
+		restconfig, err = rest.InClusterConfig()
+		if err != nil {
+			return fmt.Errorf("failed to load in-cluster kubeconfig (not running in a cluster?): %w\n\nSpecify a kubeconfig with --kubeconfig flag or KUBECONFIG environment variable", err)
+		}
+	}
+
+	clientset, err := kubernetes.NewForConfig(restconfig)
+	if err != nil {
+		return fmt.Errorf("failed to create Kubernetes client: %w", err)
+	}
+
+	opts := []nodeutil.NodeOpt{
+		nodeutil.WithNodeConfig(nodeutil.NodeConfig{
+			Client:         clientset,
+			NodeSpec:       provider.GetInitialNodeSpec(appCfg),
+			HTTPListenAddr: ":10250",
+			NumWorkers:     5,
+		}),
+	}
+
+	newProviderFunc := func(vkCfg nodeutil.ProviderConfig) (nodeutil.Provider, node.NodeProvider, error) {
+		podHandler, err := provider.NewAppHostingProvider(ctx, appCfg, vkCfg)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to initialise PodHandler: %w", err)
+		}
+		nodeHandler, err := provider.NewAppHostingNode(ctx, appCfg, vkCfg)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to initialise nodeHandler: %w", err)
+		}
+		return podHandler, nodeHandler, nil
+	}
+
+	nodeName := provider.GetNodeName(appCfg)
+	n, err := nodeutil.NewNode(nodeName, newProviderFunc, opts...)
+	if err != nil {
+		return fmt.Errorf("failed to create node: %w", err)
+	}
+
+	if err := n.Run(ctx); err != nil {
+		return fmt.Errorf("node run failed: %w", err)
+	}
+
+	log.G(ctx).Info("Cisco Virtual Kubelet stopped")
+	return nil
+}

--- a/cmd/virtual-kubelet/root_test.go
+++ b/cmd/virtual-kubelet/root_test.go
@@ -1,0 +1,235 @@
+// Copyright © 2025 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestConfigFileValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		configPath  string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "valid config file",
+			configPath:  "../../dev/config.yaml",
+			wantErr:     false,
+			errContains: "",
+		},
+		{
+			name:        "missing config file",
+			configPath:  "/nonexistent/config.yaml",
+			wantErr:     true,
+			errContains: "config file not found",
+		},
+		{
+			name:        "empty path uses default",
+			configPath:  "",
+			wantErr:     true, // default path won't exist in test environment
+			errContains: "config file not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configPath := tt.configPath
+			if configPath == "" {
+				configPath = "/etc/virtual-kubelet/config.yaml"
+			}
+
+			_, err := os.Stat(configPath)
+			gotErr := os.IsNotExist(err)
+
+			if tt.wantErr && !gotErr {
+				t.Errorf("expected error for path %q, but file exists", configPath)
+			}
+			if !tt.wantErr && gotErr {
+				t.Errorf("expected file to exist at %q, but got error", configPath)
+			}
+		})
+	}
+}
+
+func TestLogLevelValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		logLevel    string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:     "valid level - debug",
+			logLevel: "debug",
+			wantErr:  false,
+		},
+		{
+			name:     "valid level - info",
+			logLevel: "info",
+			wantErr:  false,
+		},
+		{
+			name:     "valid level - warn",
+			logLevel: "warn",
+			wantErr:  false,
+		},
+		{
+			name:     "valid level - warning",
+			logLevel: "warning",
+			wantErr:  false,
+		},
+		{
+			name:     "valid level - error",
+			logLevel: "error",
+			wantErr:  false,
+		},
+		{
+			name:     "valid level - empty (defaults to info)",
+			logLevel: "",
+			wantErr:  false,
+		},
+		{
+			name:        "invalid level - verbose",
+			logLevel:    "verbose",
+			wantErr:     true,
+			errContains: "invalid log level",
+		},
+		{
+			name:        "invalid level - trace",
+			logLevel:    "trace",
+			wantErr:     true,
+			errContains: "invalid log level",
+		},
+		{
+			name:        "invalid level - DEBUG (case sensitive)",
+			logLevel:    "DEBUG",
+			wantErr:     true,
+			errContains: "invalid log level",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateLogLevel(tt.logLevel)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error for log level %q, got nil", tt.logLevel)
+				} else if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("expected error containing %q, got %q", tt.errContains, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error for log level %q: %v", tt.logLevel, err)
+				}
+			}
+		})
+	}
+}
+
+func TestKubeconfigValidation(t *testing.T) {
+	// Create a temporary kubeconfig file for testing
+	tmpDir := t.TempDir()
+	validKubeconfig := filepath.Join(tmpDir, "kubeconfig")
+	if err := os.WriteFile(validKubeconfig, []byte("apiVersion: v1\nkind: Config"), 0644); err != nil {
+		t.Fatalf("failed to create test kubeconfig: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		kubeconfig  string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:       "valid kubeconfig file",
+			kubeconfig: validKubeconfig,
+			wantErr:    false,
+		},
+		{
+			name:        "missing kubeconfig file",
+			kubeconfig:  "/nonexistent/kubeconfig",
+			wantErr:     true,
+			errContains: "kubeconfig file not found",
+		},
+		{
+			name:       "empty path (will try in-cluster or env)",
+			kubeconfig: "",
+			wantErr:    false, // empty is valid - will fall back to env or in-cluster
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateKubeconfig(tt.kubeconfig)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error for kubeconfig %q, got nil", tt.kubeconfig)
+				} else if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("expected error containing %q, got %q", tt.errContains, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error for kubeconfig %q: %v", tt.kubeconfig, err)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		configPath  string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:       "valid config",
+			configPath: "../../dev/config.yaml",
+			wantErr:    false,
+		},
+		{
+			name:        "missing config",
+			configPath:  "/nonexistent/path/config.yaml",
+			wantErr:     true,
+			errContains: "config file not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateConfig(tt.configPath)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error for config %q, got nil", tt.configPath)
+				} else if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("expected error containing %q, got %q", tt.errContains, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error for config %q: %v", tt.configPath, err)
+				}
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,16 +3,11 @@ package config
 import (
 	"fmt"
 	"strings"
-	"sync"
 
-	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
-var registerFlagsOnce sync.Once
-
 func Load(filePath ...string) (*Config, error) {
-
 	if len(filePath) > 0 && filePath[0] != "" {
 		viper.SetConfigFile(filePath[0])
 	} else {
@@ -26,30 +21,15 @@ func Load(filePath ...string) (*Config, error) {
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_")) // allow SERVER_PORT for server.port
 	viper.AutomaticEnv()
 
-	registerFlagsOnce.Do(func() {
-		// This doesn't actually work for the current schema
-		pflag.String("device.name", "", "Device name")
-		// Add any other pflag definitions here
-	})
-
-	// Parse flags only if not already parsed (to avoid errors in tests)
-	if !pflag.Parsed() {
-		pflag.Parse()
-	}
-
-	if err := viper.BindPFlags(pflag.CommandLine); err != nil {
-		return nil, err
-	}
-
-	// 4. Read the file
+	// Read the config file
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
 			return nil, fmt.Errorf("error reading config file: %w", err)
 		}
-		// It's okay if file is missing; we can rely on ENV or Flags
+		// It's okay if file is missing; we can rely on ENV
 	}
 
-	// 5. Unmarshal into struct
+	// Unmarshal into struct
 	var cfg Config
 	if err := viper.UnmarshalExact(&cfg); err != nil {
 		return nil, fmt.Errorf("unable to decode into struct: %w", err)


### PR DESCRIPTION
## Description

This PR introduces Cobra-based CLI flag handling to allow runtime specification of configuration file paths, kubeconfig paths, and log levels. Previously, the config path was hardcoded to `/etc/virtual-kubelet/config.yaml`. This supersedes the #23 due to high change revision of UID logic. 

## Changes

### New Files

| File | Description |
|------|-------------|
| `cmd/virtual-kubelet/root.go` | Cobra command definition with CLI flags and validation functions |
| `cmd/virtual-kubelet/root_test.go` | Unit tests for validation logic |

### Modified Files

| File | Description |
|------|-------------|
| `cmd/virtual-kubelet/main.go` | Simplified to call `Execute()` (153 → 35 lines) |
| `internal/config/config.go` | Removed dead pflag code that was non-functional |

## New CLI Flags

| Flag | Short | Default | Description |
|------|-------|---------|-------------|
| `--config` | `-c` | `/etc/virtual-kubelet/config.yaml` | Path to config file |
| `--kubeconfig` | | `$KUBECONFIG` or in-cluster | Path to kubeconfig file |
| `--log-level` | | `$LOG_LEVEL` or `info` | Log level (debug, info, warn, error) |

### Precedence

- **Config**: `--config` flag → default path
- **Kubeconfig**: `--kubeconfig` flag → `$KUBECONFIG` env → in-cluster config
- **Log level**: `--log-level` flag → `$LOG_LEVEL` env → `info`

## Error Handling

Clear error messages are provided for common failure scenarios:

```bash
# Missing config file
$ ./cisco-vk
Error: config file not found: /etc/virtual-kubelet/config.yaml

Specify a config file with --config or -c flag, or create the default config at /etc/virtual-kubelet/config.yaml

# Invalid config path
$ ./cisco-vk -c /bad/path.yaml
Error: config file not found: /bad/path.yaml

Specify a config file with --config or -c flag, or create the default config at /etc/virtual-kubelet/config.yaml

# Invalid log level
$ ./cisco-vk -c ./dev/config.yaml --log-level verbose
Error: invalid log level: "verbose"

Valid options are: debug, info, warn, error

# Missing kubeconfig
$ ./cisco-vk -c ./dev/config.yaml --kubeconfig /bad/kubeconfig
Error: kubeconfig file not found: /bad/kubeconfig

Specify a valid kubeconfig with --kubeconfig flag or KUBECONFIG environment variable
```

## Testing

### Run Unit Tests

```bash
# Run all tests
go test ./...

# Run only the new CLI validation tests
go test ./cmd/virtual-kubelet/ -v
```

Expected output:
```
=== RUN   TestConfigFileValidation
=== RUN   TestConfigFileValidation/valid_config_file
=== RUN   TestConfigFileValidation/missing_config_file
=== RUN   TestConfigFileValidation/empty_path_uses_default
--- PASS: TestConfigFileValidation (0.00s)
=== RUN   TestLogLevelValidation
=== RUN   TestLogLevelValidation/valid_level_-_debug
=== RUN   TestLogLevelValidation/valid_level_-_info
...
--- PASS: TestLogLevelValidation (0.00s)
=== RUN   TestKubeconfigValidation
...
--- PASS: TestKubeconfigValidation (0.00s)
=== RUN   TestValidateConfig
...
--- PASS: TestValidateConfig (0.00s)
PASS
```

### Manual Testing

#### 1. Verify help output

```bash
go run ./cmd/virtual-kubelet/ --help
```

Expected:
```
Cisco Virtual Kubelet implements the Kubelet interface to deploy
containers on Cisco devices using AppHosting.

Usage:
  virtual-kubelet [flags]

Flags:
  -c, --config string       config file (default: /etc/virtual-kubelet/config.yaml)
  -h, --help                help for virtual-kubelet
      --kubeconfig string   path to kubeconfig file (default: $KUBECONFIG or in-cluster)
      --log-level string    log level: debug, info, warn, error (default: $LOG_LEVEL or info)
```

#### 2. Test with dev config

```bash
# Using the dev config file
go run ./cmd/virtual-kubelet/ -c ./dev/config.yaml --log-level debug
```

#### 3. Test error handling

```bash
# Missing config (should fail with clear message)
go run ./cmd/virtual-kubelet/

# Bad config path (should fail with clear message)
go run ./cmd/virtual-kubelet/ -c /nonexistent/config.yaml

# Invalid log level (should fail with clear message)
go run ./cmd/virtual-kubelet/ -c ./dev/config.yaml --log-level verbose

# Bad kubeconfig path (should fail with clear message)
go run ./cmd/virtual-kubelet/ -c ./dev/config.yaml --kubeconfig /nonexistent/kubeconfig
```

### Integration Testing (Okteto)

Follow the existing dev workflow in `dev/README.md`:

1. Deploy the dev environment:
   ```bash
   kubectl apply -f ./dev/dev-deployment.yaml
   ```

2. Start Okteto:
   ```bash
   okteto up -f ./dev/okteto.yaml
   ```

3. From the Okteto shell, test the new flags:
   ```bash
   # Default (uses mounted config at /etc/virtual-kubelet/config.yaml)
   go run ./cmd/virtual-kubelet/

   # Explicit config path
   go run ./cmd/virtual-kubelet/ -c /etc/virtual-kubelet/config.yaml --log-level debug
   ```

4. Verify node registration:
   ```bash
   kubectl get nodes
   kubectl label node cvk-dev-node kubernetes.io/hostname=cvk-dev-node
   kubectl apply -f dev/test-pod.yaml
   ```

## Compatibility 

- Default behavior unchanged: if no flags provided, uses `/etc/virtual-kubelet/config.yaml`
- Existing deployments with config mounted at default path will work without modification
- Environment variables (`KUBECONFIG`, `LOG_LEVEL`) continue to work as before


## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
