### PR TITLE
(fix) Simplify Kubeconfig loading

### DIFF
--- a/cmd/virtual-kubelet/root.go
+++ b/cmd/virtual-kubelet/root.go
@@ -82,15 +82,28 @@ func validateLogLevel(level string) error {
 	}
 }
 
-// validateKubeconfig checks if the kubeconfig file exists (when path is provided)
-func validateKubeconfig(kubeconfigPath string) error {
-	if kubeconfigPath == "" {
-		return nil // empty is valid - will fall back to env or in-cluster
+func GetKubeConfig(kubeconfigFlag string) (*rest.Config, error) {
+
+	if kubeconfigFlag != "" {
+		if _, err := os.Stat(kubeconfigFlag); os.IsNotExist(err) {
+			return nil, fmt.Errorf("kubeconfig file not found: %s", kubeconfigFlag)
+		}
+		return clientcmd.BuildConfigFromFlags("", kubeconfigFlag)
 	}
-	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return fmt.Errorf("kubeconfig file not found: %s\n\nSpecify a valid kubeconfig with --kubeconfig flag or KUBECONFIG environment variable", kubeconfigPath)
+
+	kubeconfigEnv := os.Getenv("KUBECONFIG")
+	if kubeconfigEnv != "" {
+		if _, err := os.Stat(kubeconfigEnv); os.IsNotExist(err) {
+			return nil, fmt.Errorf("kubeconfig file from KUBECONFIG env not found: %s", kubeconfigEnv)
+		}
+		return clientcmd.BuildConfigFromFlags("", kubeconfigEnv)
 	}
-	return nil
+
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load in-cluster config and no kubeconfig provided: %w", err)
+	}
+	return config, nil
 }
 
 func runVirtualKubelet(cmd *cobra.Command, args []string) error {
@@ -156,30 +169,12 @@ func runVirtualKubelet(cmd *cobra.Command, args []string) error {
 	}()
 
 	// Kubeconfig: flag > env > in-cluster
-	kubeconfigPath := kubeconfig
-	if kubeconfigPath == "" {
-		kubeconfigPath = os.Getenv("KUBECONFIG")
+	kubeconfigCfg, err := GetKubeConfig(kubeconfig)
+	if err != nil {
+		return fmt.Errorf("failed to load kubeconfig: %w", err)
 	}
 
-	// Validate kubeconfig if path provided
-	if err := validateKubeconfig(kubeconfigPath); err != nil {
-		return err
-	}
-
-	var restconfig *rest.Config
-	if kubeconfigPath != "" {
-		restconfig, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
-		if err != nil {
-			return fmt.Errorf("failed to load kubeconfig from %s: %w", kubeconfigPath, err)
-		}
-	} else {
-		restconfig, err = rest.InClusterConfig()
-		if err != nil {
-			return fmt.Errorf("failed to load in-cluster kubeconfig (not running in a cluster?): %w\n\nSpecify a kubeconfig with --kubeconfig flag or KUBECONFIG environment variable", err)
-		}
-	}
-
-	clientset, err := kubernetes.NewForConfig(restconfig)
+	clientset, err := kubernetes.NewForConfig(kubeconfigCfg)
 	if err != nil {
 		return fmt.Errorf("failed to create Kubernetes client: %w", err)
 	}

--- a/cmd/virtual-kubelet/root_test.go
+++ b/cmd/virtual-kubelet/root_test.go
@@ -21,53 +21,6 @@ import (
 	"testing"
 )
 
-func TestConfigFileValidation(t *testing.T) {
-	tests := []struct {
-		name        string
-		configPath  string
-		wantErr     bool
-		errContains string
-	}{
-		{
-			name:        "valid config file",
-			configPath:  "../../dev/config.yaml",
-			wantErr:     false,
-			errContains: "",
-		},
-		{
-			name:        "missing config file",
-			configPath:  "/nonexistent/config.yaml",
-			wantErr:     true,
-			errContains: "config file not found",
-		},
-		{
-			name:        "empty path uses default",
-			configPath:  "",
-			wantErr:     true, // default path won't exist in test environment
-			errContains: "config file not found",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			configPath := tt.configPath
-			if configPath == "" {
-				configPath = "/etc/virtual-kubelet/config.yaml"
-			}
-
-			_, err := os.Stat(configPath)
-			gotErr := os.IsNotExist(err)
-
-			if tt.wantErr && !gotErr {
-				t.Errorf("expected error for path %q, but file exists", configPath)
-			}
-			if !tt.wantErr && gotErr {
-				t.Errorf("expected file to exist at %q, but got error", configPath)
-			}
-		})
-	}
-}
-
 func TestLogLevelValidation(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -144,58 +97,14 @@ func TestLogLevelValidation(t *testing.T) {
 	}
 }
 
-func TestKubeconfigValidation(t *testing.T) {
-	// Create a temporary kubeconfig file for testing
-	tmpDir := t.TempDir()
-	validKubeconfig := filepath.Join(tmpDir, "kubeconfig")
-	if err := os.WriteFile(validKubeconfig, []byte("apiVersion: v1\nkind: Config"), 0644); err != nil {
-		t.Fatalf("failed to create test kubeconfig: %v", err)
-	}
-
-	tests := []struct {
-		name        string
-		kubeconfig  string
-		wantErr     bool
-		errContains string
-	}{
-		{
-			name:       "valid kubeconfig file",
-			kubeconfig: validKubeconfig,
-			wantErr:    false,
-		},
-		{
-			name:        "missing kubeconfig file",
-			kubeconfig:  "/nonexistent/kubeconfig",
-			wantErr:     true,
-			errContains: "kubeconfig file not found",
-		},
-		{
-			name:       "empty path (will try in-cluster or env)",
-			kubeconfig: "",
-			wantErr:    false, // empty is valid - will fall back to env or in-cluster
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validateKubeconfig(tt.kubeconfig)
-
-			if tt.wantErr {
-				if err == nil {
-					t.Errorf("expected error for kubeconfig %q, got nil", tt.kubeconfig)
-				} else if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
-					t.Errorf("expected error containing %q, got %q", tt.errContains, err.Error())
-				}
-			} else {
-				if err != nil {
-					t.Errorf("unexpected error for kubeconfig %q: %v", tt.kubeconfig, err)
-				}
-			}
-		})
-	}
-}
-
 func TestValidateConfig(t *testing.T) {
+	// Create a temporary config file for testing
+	tmpDir := t.TempDir()
+	validConfigPath := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(validConfigPath, []byte("test: config"), 0644); err != nil {
+		t.Fatalf("failed to create test config: %v", err)
+	}
+
 	tests := []struct {
 		name        string
 		configPath  string
@@ -204,7 +113,7 @@ func TestValidateConfig(t *testing.T) {
 	}{
 		{
 			name:       "valid config",
-			configPath: "../../dev/config.yaml",
+			configPath: validConfigPath,
 			wantErr:    false,
 		},
 		{
@@ -228,6 +137,67 @@ func TestValidateConfig(t *testing.T) {
 			} else {
 				if err != nil {
 					t.Errorf("unexpected error for config %q: %v", tt.configPath, err)
+				}
+			}
+		})
+	}
+}
+
+func TestGetKubeConfig(t *testing.T) {
+	// Save original env and restore after test
+	originalKubeconfig := os.Getenv("KUBECONFIG")
+	defer os.Setenv("KUBECONFIG", originalKubeconfig)
+
+	tests := []struct {
+		name        string
+		flagValue   string
+		envValue    string
+		wantErr     bool
+		errContains string
+		setupEnv    bool
+	}{
+		{
+			name:        "flag provided with invalid path",
+			flagValue:   "/nonexistent/kubeconfig",
+			wantErr:     true,
+			errContains: "kubeconfig file not found",
+		},
+		{
+			name:        "no flag, env var with invalid path",
+			flagValue:   "",
+			envValue:    "/nonexistent/kubeconfig",
+			setupEnv:    true,
+			wantErr:     true,
+			errContains: "kubeconfig file from KUBECONFIG env not found",
+		},
+		{
+			name:        "no flag, no env - in-cluster expected",
+			flagValue:   "",
+			envValue:    "",
+			setupEnv:    true,
+			wantErr:     true, // Will fail in test environment without service account
+			errContains: "failed to load in-cluster config",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setupEnv {
+				os.Setenv("KUBECONFIG", tt.envValue)
+				defer os.Unsetenv("KUBECONFIG")
+			}
+
+			_, err := GetKubeConfig(tt.flagValue)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				} else if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("expected error containing %q, got %q", tt.errContains, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
 				}
 			}
 		})


### PR DESCRIPTION
## Description

Fixes Issue #42.

In 'prod' scenarios we envisage to be running inside a k8s cluster and using the service account token.  For local dev we can set the KUBECONFIG env in the local shell.  I have omitted automatically falling back to `~/.kube/config` as this could have consequences for accidental or unintentional loading of a users current context (e.g. some random k8s cluster). 

With this PR we should:

1. Check if the user provided the `--kubeconfig` override flag
2. Check if the KUBECONFIG environment var is set
3. Try to build an in-cluster config

If we don't succeed by 3. execution fails:

```
Error: failed to load kubeconfig: failed to load in-cluster config and no kubeconfig provided: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined
Usage:
  virtual-kubelet [flags]

Flags:
  -c, --config string       config file (default: /etc/virtual-kubelet/config.yaml)
  -h, --help                help for virtual-kubelet
      --kubeconfig string   path to kubeconfig file (default: $KUBECONFIG or in-cluster)
      --log-level string    log level: debug, info, warn, error (default: $LOG_LEVEL or info)

Error: failed to load kubeconfig: failed to load in-cluster config and no kubeconfig provided: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined
exit status 1
```

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
