### PR TITLE
fix panic(uniplemeneted) exceptions

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -150,27 +150,27 @@ func (p *AppHostingProvider) AttachToContainer(ctx context.Context, namespace, p
 
 // GetContainerLogs implements nodeutil.Provider.
 func (p *AppHostingProvider) GetContainerLogs(ctx context.Context, namespace string, podName string, containerName string, opts api.ContainerLogOpts) (io.ReadCloser, error) {
-	panic("unimplemented")
+	return nil, fmt.Errorf("GetContainerLogs is not supported by the Cisco Virtual Kubelet")
 }
 
 // GetMetricsResource implements nodeutil.Provider.
 func (p *AppHostingProvider) GetMetricsResource(context.Context) ([]*io_prometheus_client.MetricFamily, error) {
-	panic("unimplemented")
+	return nil, fmt.Errorf("GetMetricsResource is not supported by the Cisco Virtual Kubelet")
 }
 
 // GetStatsSummary implements nodeutil.Provider.
 func (p *AppHostingProvider) GetStatsSummary(context.Context) (*statsv1alpha1.Summary, error) {
-	panic("unimplemented")
+	return nil, fmt.Errorf("GetStatsSummary is not supported by the Cisco Virtual Kubelet")
 }
 
 // PortForward implements nodeutil.Provider.
 func (p *AppHostingProvider) PortForward(ctx context.Context, namespace string, pod string, port int32, stream io.ReadWriteCloser) error {
-	panic("unimplemented")
+	return fmt.Errorf("PortForward is not supported by the Cisco Virtual Kubelet")
 }
 
 // RunInContainer implements nodeutil.Provider.
 func (p *AppHostingProvider) RunInContainer(ctx context.Context, namespace string, podName string, containerName string, cmd []string, attach api.AttachIO) error {
-	panic("unimplemented")
+	return fmt.Errorf("RunInContainer is not supported by the Cisco Virtual Kubelet")
 }
 
 // AppHostingNode implements node.NodeProvider for proper heartbeat management.


### PR DESCRIPTION
## Description

Replaces 5 `panic("unimplemented")` calls in [internal/provider/provider.go](cci:7://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/provider/provider.go:0:0-0:0) with graceful error returns.

The following provider methods used `panic("unimplemented")` as a placeholder, which crashes the entire Virtual Kubelet process if triggered:

| Method | Crash Trigger |
|--------|---------------|
| [GetContainerLogs](cci:1://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/provider/provider.go:150:0-153:1) | `kubectl logs` |
| [GetMetricsResource](cci:1://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/provider/provider.go:155:0-158:1) | Prometheus metrics scraping |
| [GetStatsSummary](cci:1://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/provider/provider.go:160:0-163:1) | kubelet stats API |
| [PortForward](cci:1://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/provider/provider.go:165:0-168:1) | `kubectl port-forward` |
| [RunInContainer](cci:1://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/provider/provider.go:170:0-173:1) | `kubectl exec` |

In production, any of these operations — including automated metrics collection — would terminate the VK pod, disrupting **all** pods managed by that instance. This is especially dangerous because metrics scrapers (e.g., Prometheus, kube-state-metrics) may automatically target all nodes including virtual kubelets.

### Fix

Each `panic` is replaced with a descriptive `fmt.Errorf(...)` return. The virtual-kubelet library's `errdefs` package (v1.12.0) only exposes `NotFound` and `InvalidInput` — there is no `NotSupported` sentinel. A plain error return is sufficient to prevent the crash and return a meaningful message to the caller.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass