### PR TITLE
add fix for pod updates - recreation

### DIFF
--- a/internal/drivers/iosxe/pod_lifecycle.go
+++ b/internal/drivers/iosxe/pod_lifecycle.go
@@ -64,10 +64,20 @@ func (d *XEDriver) DeployPod(ctx context.Context, pod *v1.Pod) error {
 	return nil
 }
 
-// UpdatePod handles pod update requests
+// UpdatePod handles pod update requests by performing a delete-and-redeploy cycle.
+// IOS-XE AppHosting does not support in-place updates to running applications;
+// changes to image, resources, or environment require a full teardown and reinstall.
 func (d *XEDriver) UpdatePod(ctx context.Context, pod *v1.Pod) error {
-	log.G(ctx).Info("Pod UpdateContainer request received")
-	return nil
+	log.G(ctx).Infof("UpdatePod: delete-and-redeploy for pod %s/%s", pod.Namespace, pod.Name)
+
+	if err := d.DeletePod(ctx, pod); err != nil {
+		// Log but don't block — partial cleanup is acceptable.
+		// DeployPod's CreateAppHostingApp will fail on conflict if
+		// any app still exists, which is a clearer error than aborting here.
+		log.G(ctx).Warnf("UpdatePod: cleanup had errors (will attempt redeploy): %v", err)
+	}
+
+	return d.DeployPod(ctx, pod)
 }
 
 // GetPodContainers retrieves all containers belonging to a specific pod from the device.


### PR DESCRIPTION
## Description

Replaces the silent no-op [UpdatePod](cci:1://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/drivers/iosxe/pod_lifecycle.go:66:0-80:1) implementation in the IOS-XE driver with a delete-and-redeploy cycle.

### Problem

[XEDriver.UpdatePod()](cci:1://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/drivers/iosxe/pod_lifecycle.go:66:0-80:1) previously logged a message and returned `nil`, silently discarding any pod spec changes (image, resources, environment variables). Kubernetes interpreted the `nil` return as a successful update, creating a drift between the desired state in the API server and the actual state on the device.

### Fix

IOS-XE AppHosting does not support in-place updates to running applications — changes to image, resources, or environment require a full teardown and reinstall. The new implementation:

1. Calls [DeletePod()](cci:1://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/drivers/iosxe/pod_lifecycle.go:178:0-214:1) to tear down existing apps via the reconciler-driven reverse lifecycle (`RUNNING → stop → ACTIVATED → deactivate → DEPLOYED → uninstall → config delete`)
2. Calls [DeployPod()](cci:1://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/drivers/iosxe/pod_lifecycle.go:28:0-64:1) to redeploy from the updated pod spec

If the delete phase encounters partial errors (e.g., one container of a multi-container pod fails to clean up), the redeploy is still attempted. The device will reject duplicate app configurations with a clear RESTCONF error, which is more actionable than silently aborting.

### Trade-offs

- **Downtime during update:** The workload is unavailable between delete and deploy. This is inherent to the IOS-XE AppHosting model.
- **Partial failure risk:** If [DeletePod](cci:1://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/drivers/iosxe/pod_lifecycle.go:178:0-214:1) succeeds but [DeployPod](cci:1://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/drivers/iosxe/pod_lifecycle.go:28:0-64:1) fails, the app is removed with no automatic recovery. The pod would need to be manually re-created.

### Related

- Identified as item 3.2 in the architecture & code review
- [DeleteApp](cci:1://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/drivers/iosxe/reconciler.go:176:0-213:1) reconciler handles all AppHosting lifecycle states (RUNNING, ACTIVATED, DEPLOYED, absent)

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass

> **Note:** One pre-existing test failure (`TestGetResourceConfig_FromRequests`) exists on `develop` due to the ephemeral-storage mapping bug tracked in `pr/johalley/storage-fix`. It is unrelated to this change.