### PR TITLE
Fix test for ephemeral storage

### DIFF
--- a/internal/drivers/iosxe/pod_transforms_test.go
+++ b/internal/drivers/iosxe/pod_transforms_test.go
@@ -994,9 +994,9 @@ func TestGetResourceConfig_FromRequests(t *testing.T) {
 		Name: "app",
 		Resources: v1.ResourceRequirements{
 			Requests: v1.ResourceList{
-				v1.ResourceCPU:     resource.MustParse("500m"),
-				v1.ResourceMemory:  resource.MustParse("256Mi"),
-				v1.ResourceStorage: resource.MustParse("2Gi"),
+				v1.ResourceCPU:              resource.MustParse("500m"),
+				v1.ResourceMemory:           resource.MustParse("256Mi"),
+				v1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
 			},
 		},
 	}


### PR DESCRIPTION
## Description

Fixes the failing [TestGetResourceConfig_FromRequests](cci:1://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/drivers/iosxe/pod_transforms_test.go:990:0-1013:1) test by aligning the test's resource key with the source code.

### Problem

The test was using `v1.ResourceStorage` (the Kubernetes resource key for PersistentVolumeClaims) in the container resource requests:

```go
v1.ResourceStorage: resource.MustParse("2Gi"),
```

However, the source function [getResourceConfig](cci:1://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/drivers/iosxe/pod_transforms.go:332:0-380:1) in [pod_transforms.go](cci:7://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/drivers/iosxe/pod_transforms.go:0:0-0:0) correctly reads `v1.ResourceEphemeralStorage` — the standard container-level disk resource. Because the keys didn't match, the storage request was never parsed and `diskMB` fell through to the default value of `1024`, causing the assertion `diskMB = 1024, want 2048` to fail.

This is a companion fix to the ephemeral-storage mapping change in [pod_transforms.go](cci:7://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/drivers/iosxe/pod_transforms.go:0:0-0:0) (see `pr/johalley/storage-fix` / #XX) which corrected the source from `v1.ResourceStorage` to `v1.ResourceEphemeralStorage`. The test was not updated at the same time.

### Fix

Single-line change in the test: `v1.ResourceStorage` → `v1.ResourceEphemeralStorage`.

### Related

- `pr/johalley/storage-fix` — source code fix for ephemeral-storage mapping in [getResourceConfig](cci:1://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/drivers/iosxe/pod_transforms.go:332:0-380:1)
- Identified during architecture & code review verification

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass