### PR TITLE
fix: pod lifecycle fixes (UpdatePod guard, STOPPED reconciler, pod re…

### DIFF
--- a/cmd/cisco-vk/run.go
+++ b/cmd/cisco-vk/run.go
@@ -23,6 +23,7 @@ import (
 	"path"
 	"runtime"
 	"syscall"
+	"time"
 
 	"github.com/cisco/virtual-kubelet-cisco/internal/config"
 	"github.com/cisco/virtual-kubelet-cisco/internal/drivers"
@@ -36,6 +37,7 @@ import (
 	"github.com/virtual-kubelet/virtual-kubelet/node/api"
 	"github.com/virtual-kubelet/virtual-kubelet/node/nodeutil"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -279,10 +281,20 @@ func runVirtualKubelet(cmd *cobra.Command, args []string) error {
 
 		return podHandler, nodeHandler, nil
 	}
+	// Recover pods that were marked Failed/NotFound during a previous VK restart.
+	// The upstream VK pod controller permanently ignores pods in Failed phase, so
+	// we must reset them to Pending before the pod controller starts syncing.
+	recoverStaleFailedPods(ctx, clientset, effectiveNodeName)
+
 	n, err := nodeutil.NewNode(effectiveNodeName, newProviderFunc, opts...)
 	if err != nil {
 		return fmt.Errorf("failed to create node: %w", err)
 	}
+
+	// Run a background recovery loop that resets Failed/NotFound pods.
+	// Uses exponential backoff: 15s → 30s → 60s → 5min cap. Resets to 15s
+	// when a recovery actually occurs.
+	go runPodRecoveryLoop(ctx, clientset, effectiveNodeName)
 
 	if err := n.Run(ctx); err != nil {
 		return fmt.Errorf("node run failed: %w", err)
@@ -290,4 +302,70 @@ func runVirtualKubelet(cmd *cobra.Command, args []string) error {
 
 	log.G(ctx).Info("Cisco Virtual Kubelet stopped")
 	return nil
+}
+
+// runPodRecoveryLoop periodically checks for Failed/NotFound pods and resets
+// them to Pending. Uses exponential backoff to reduce API server load once
+// all pods are healthy.
+func runPodRecoveryLoop(ctx context.Context, clientset kubernetes.Interface, nodeName string) {
+	const (
+		minInterval = 15 * time.Second
+		maxInterval = 5 * time.Minute
+	)
+	interval := minInterval
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(interval):
+			recovered := recoverStaleFailedPods(ctx, clientset, nodeName)
+			if recovered > 0 {
+				interval = minInterval // reset on activity
+			} else if interval < maxInterval {
+				interval = interval * 2
+				if interval > maxInterval {
+					interval = maxInterval
+				}
+			}
+		}
+	}
+}
+
+// recoverStaleFailedPods resets pods on our node that are stuck in Failed phase
+// with reason NotFound (or ProviderFailed) back to Pending so the VK pod
+// controller will pick them up again. Returns the number of pods recovered.
+func recoverStaleFailedPods(ctx context.Context, clientset kubernetes.Interface, nodeName string) int {
+	pods, err := clientset.CoreV1().Pods("").List(ctx, metav1.ListOptions{
+		FieldSelector: "spec.nodeName=" + nodeName + ",status.phase=Failed",
+	})
+	if err != nil {
+		log.G(ctx).WithError(err).Warn("Failed to list failed pods for recovery")
+		return 0
+	}
+
+	recovered := 0
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if pod.Status.Reason != "NotFound" && pod.Status.Reason != "ProviderFailed" {
+			continue
+		}
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
+
+		log.G(ctx).Infof("Recovering stuck pod %s/%s (reason=%s) → resetting to Pending",
+			pod.Namespace, pod.Name, pod.Status.Reason)
+
+		pod.Status.Phase = v1.PodPending
+		pod.Status.Reason = ""
+		pod.Status.Message = ""
+
+		if _, err := clientset.CoreV1().Pods(pod.Namespace).UpdateStatus(ctx, pod, metav1.UpdateOptions{}); err != nil {
+			log.G(ctx).WithError(err).Warnf("Failed to recover pod %s/%s", pod.Namespace, pod.Name)
+		} else {
+			recovered++
+		}
+	}
+	return recovered
 }

--- a/internal/drivers/iosxe/pod_lifecycle.go
+++ b/internal/drivers/iosxe/pod_lifecycle.go
@@ -64,16 +64,35 @@ func (d *XEDriver) DeployPod(ctx context.Context, pod *v1.Pod) error {
 	return nil
 }
 
-// UpdatePod handles pod update requests by performing a delete-and-redeploy cycle.
+// UpdatePod handles pod update requests.
 // IOS-XE AppHosting does not support in-place updates to running applications;
-// changes to image, resources, or environment require a full teardown and reinstall.
+// changes to image require a full teardown and reinstall. If the app already
+// exists on the device and no container images have changed, the update is a
+// no-op — the reconciliation loop inside GetPodStatus already handles
+// advancing apps to RUNNING state.
+//
+// The upstream VK pod controller calls UpdatePod whenever its podsEqual check
+// fails, which can happen for benign metadata/annotation/toleration changes.
+// A blind delete-and-redeploy would tear down RUNNING apps and create a
+// destructive cycle, so we guard against that here.
 func (d *XEDriver) UpdatePod(ctx context.Context, pod *v1.Pod) error {
+	// If the app already exists on the device, skip the destructive
+	// delete-and-redeploy. The upstream VK pod controller calls UpdatePod
+	// whenever its podsEqual check fails (benign metadata/annotation
+	// changes). IOS-XE does not support in-place image updates anyway;
+	// a true image change requires the user to delete and re-create the pod.
+	// The reconciliation loop in GetPodStatus handles advancing apps
+	// that are stuck in intermediate states (DEPLOYED, ACTIVATED).
+	discoveredContainers, err := d.GetPodContainers(ctx, pod)
+	if err == nil && len(discoveredContainers) > 0 {
+		log.G(ctx).Debugf("UpdatePod: app already exists on device for pod %s/%s, skipping delete-and-redeploy",
+			pod.Namespace, pod.Name)
+		return nil
+	}
+
 	log.G(ctx).Infof("UpdatePod: delete-and-redeploy for pod %s/%s", pod.Namespace, pod.Name)
 
 	if err := d.DeletePod(ctx, pod); err != nil {
-		// Log but don't block — partial cleanup is acceptable.
-		// DeployPod's CreateAppHostingApp will fail on conflict if
-		// any app still exists, which is a clearer error than aborting here.
 		log.G(ctx).Warnf("UpdatePod: cleanup had errors (will attempt redeploy): %v", err)
 	}
 

--- a/internal/drivers/iosxe/reconciler.go
+++ b/internal/drivers/iosxe/reconciler.go
@@ -31,6 +31,7 @@ import (
 //
 //	"" (no config)  → POST config + install RPC  → Converging
 //	"" (config, no oper) → re-issue install RPC   → Converging
+//	"STOPPED"       → start RPC                  → Converging
 //	"DEPLOYED"      → activate RPC               → Converging
 //	"ACTIVATED"     → start RPC                  → Converging
 //	"RUNNING"       → no-op                      → Ready
@@ -65,6 +66,17 @@ func (d *XEDriver) ReconcileApp(ctx context.Context, appConfig *AppHostingConfig
 			// ACTIVATED → start
 			appConfig.Status.Phase = AppPhaseConverging
 			appConfig.Status.Message = "Starting app"
+			if err := d.StartApp(ctx, appID); err != nil {
+				log.G(ctx).Warnf("ReconcileApp %s: start failed: %v", appID, err)
+				appConfig.Status.Phase = AppPhaseError
+				appConfig.Status.Message = fmt.Sprintf("start failed: %v", err)
+			}
+			return
+
+		case "STOPPED":
+			// STOPPED → start (can restart directly without re-activate)
+			appConfig.Status.Phase = AppPhaseConverging
+			appConfig.Status.Message = "Restarting stopped app"
 			if err := d.StartApp(ctx, appID); err != nil {
 				log.G(ctx).Warnf("ReconcileApp %s: start failed: %v", appID, err)
 				appConfig.Status.Phase = AppPhaseError

--- a/internal/drivers/iosxe/reconciler.go
+++ b/internal/drivers/iosxe/reconciler.go
@@ -31,6 +31,7 @@ import (
 //
 //	"" (no config)  → POST config + install RPC  → Converging
 //	"" (config, no oper) → re-issue install RPC   → Converging
+//	"INSTALLING"    → no-op (wait)               → Converging
 //	"STOPPED"       → start RPC                  → Converging
 //	"DEPLOYED"      → activate RPC               → Converging
 //	"ACTIVATED"     → start RPC                  → Converging
@@ -93,6 +94,15 @@ func (d *XEDriver) ReconcileApp(ctx context.Context, appConfig *AppHostingConfig
 				appConfig.Status.Phase = AppPhaseError
 				appConfig.Status.Message = fmt.Sprintf("activate failed: %v", err)
 			}
+			return
+
+		case "INSTALLING":
+			// Install is in progress on the device — wait for it to finish.
+			// Re-issuing the install RPC would restart the tar extraction
+			// and prevent the install from ever completing on slow devices.
+			appConfig.Status.Phase = AppPhaseConverging
+			appConfig.Status.Message = "Install in progress, waiting"
+			log.G(ctx).Infof("ReconcileApp %s: install in progress, waiting for DEPLOYED", appID)
 			return
 
 		default:

--- a/internal/drivers/iosxe/reconciler.go
+++ b/internal/drivers/iosxe/reconciler.go
@@ -31,7 +31,7 @@ import (
 //
 //	"" (no config)  → POST config + install RPC  → Converging
 //	"" (config, no oper) → re-issue install RPC   → Converging
-//	"INSTALLING"    → no-op (wait)               → Converging
+//	"INSTALLING"    → no-op (wait) or fail-fast   → Converging / Error
 //	"STOPPED"       → start RPC                  → Converging
 //	"DEPLOYED"      → activate RPC               → Converging
 //	"ACTIVATED"     → start RPC                  → Converging
@@ -48,7 +48,8 @@ func (d *XEDriver) ReconcileApp(ctx context.Context, appConfig *AppHostingConfig
 	desired := appConfig.Spec.DesiredState
 
 	// 1. Observe current device state.
-	state := d.getAppState(ctx, appID)
+	obs := d.getAppObservation(ctx, appID)
+	state := obs.State
 	appConfig.Status.ObservedState = state
 	appConfig.Status.LastTransition = time.Now()
 
@@ -100,6 +101,22 @@ func (d *XEDriver) ReconcileApp(ctx context.Context, appConfig *AppHostingConfig
 			// Install is in progress on the device — wait for it to finish.
 			// Re-issuing the install RPC would restart the tar extraction
 			// and prevent the install from ever completing on slow devices.
+
+			// Detect signature-validation failures: when the device requires
+			// signed packages but the tar is unsigned, the install gets stuck
+			// in INSTALLING with pkg-policy "invalid". Fail fast instead of
+			// waiting forever.
+			if obs.PkgPolicy == Cisco_IOS_XEAppHostingOper_IoxPkgPolicy_iox_pkg_policy_invalid {
+				msg := "app package policy is invalid (possible unsigned package on a device requiring signed packages)"
+				if notif := d.getAppInstallNotification(ctx, appID); notif != "" {
+					msg = strings.TrimSpace(notif)
+				}
+				log.G(ctx).Errorf("ReconcileApp %s: install blocked: %s", appID, msg)
+				appConfig.Status.Phase = AppPhaseError
+				appConfig.Status.Message = fmt.Sprintf("install blocked: %s", msg)
+				return
+			}
+
 			appConfig.Status.Phase = AppPhaseConverging
 			appConfig.Status.Message = "Install in progress, waiting"
 			log.G(ctx).Infof("ReconcileApp %s: install in progress, waiting for DEPLOYED", appID)
@@ -189,22 +206,53 @@ func (d *XEDriver) ReconcileApp(ctx context.Context, appConfig *AppHostingConfig
 	}
 }
 
-// getAppState returns the current operational state string for appID, or ""
-// if the app has no oper data or the state cannot be determined.
-func (d *XEDriver) getAppState(ctx context.Context, appID string) string {
+// appObservation holds the observed state and metadata for an app, collected
+// from device operational data during a reconciliation step.
+type appObservation struct {
+	State     string
+	PkgPolicy E_Cisco_IOS_XEAppHostingOper_IoxPkgPolicy
+}
+
+// getAppObservation returns the current operational state and package policy
+// for appID.  If the app has no oper data the returned State is "".
+func (d *XEDriver) getAppObservation(ctx context.Context, appID string) appObservation {
 	if d.client == nil {
-		return ""
+		return appObservation{}
 	}
 	allOper, err := d.GetAppOperationalData(ctx)
 	if err != nil {
 		log.G(ctx).Warnf("Could not fetch oper data to check state of app %s: %v", appID, err)
-		return ""
+		return appObservation{}
 	}
 	operData, ok := allOper[appID]
-	if !ok || operData == nil || operData.Details == nil || operData.Details.State == nil {
+	if !ok || operData == nil {
+		return appObservation{}
+	}
+	obs := appObservation{PkgPolicy: operData.PkgPolicy}
+	if operData.Details != nil && operData.Details.State != nil {
+		obs.State = *operData.Details.State
+	}
+	return obs
+}
+
+// getAppInstallNotification returns the most recent install notification
+// message for appID, or "" if none found.
+func (d *XEDriver) getAppInstallNotification(ctx context.Context, appID string) string {
+	if d.client == nil {
 		return ""
 	}
-	return *operData.Details.State
+	path := "/restconf/data/Cisco-IOS-XE-app-hosting-oper:app-hosting-oper-data?fields=app-notifications"
+	root := &Cisco_IOS_XEAppHostingOper_AppHostingOperData{}
+	if err := d.client.Get(ctx, path, root, d.getRestconfUnmarshaller()); err != nil {
+		log.G(ctx).Debugf("Could not fetch app notifications: %v", err)
+		return ""
+	}
+	for _, n := range root.AppNotifications {
+		if n.AppId != nil && *n.AppId == appID && n.Message != nil {
+			return *n.Message
+		}
+	}
+	return ""
 }
 
 // DeleteApp orchestrates a reconciler-driven teardown of the app lifecycle.

--- a/internal/drivers/iosxe/reconciler_test.go
+++ b/internal/drivers/iosxe/reconciler_test.go
@@ -63,11 +63,11 @@ func TestContainerImagePath_NotFound(t *testing.T) {
 //
 // ReconcileApp — declarative reconciler tests.
 //
-// ReconcileApp reads device state via getAppState (which calls
+// ReconcileApp reads device state via getAppObservation (which calls
 // GetAppOperationalData).  These tests validate the status updates
 // without a real device by using a nil client: since ReconcileApp
-// reads state first, and getAppState returns "" when the client
-// fails, the reconciler enters the "no oper data" path.
+// reads state first, and getAppObservation returns an empty observation
+// when the client is nil, the reconciler enters the "no oper data" path.
 // ─────────────────────────────────────────────────────────────────────────────
 
 func makeOperData(state string) *Cisco_IOS_XEAppHostingOper_AppHostingOperData_App {
@@ -84,7 +84,7 @@ func makeOperData(state string) *Cisco_IOS_XEAppHostingOper_AppHostingOperData_A
 
 // TestReconcileApp_RunningDesiredRunning_IsReady verifies that an app already
 // in RUNNING state with desired=Running is marked Ready with no RPCs issued.
-// (We can't easily inject a fake getAppState here without a mock client, so
+// (We can't easily inject a fake getAppObservation here without a mock client, so
 // this test validates the "no oper data + no image" error path instead.)
 func TestReconcileApp_NoOperDataNoImage_Error(t *testing.T) {
 	d := &XEDriver{}
@@ -93,7 +93,7 @@ func TestReconcileApp_NoOperDataNoImage_Error(t *testing.T) {
 		Spec:     AppHostingSpec{DesiredState: AppDesiredStateRunning, ImagePath: ""},
 		Status:   AppHostingStatus{Phase: AppPhaseConverging},
 	}
-	// nil client means getAppState returns "" (no oper data).
+	// nil client means getAppObservation returns empty observation (no oper data).
 	// No image path → should set Phase=Error.
 	d.ReconcileApp(testCtx(), appCfg)
 	if appCfg.Status.Phase != AppPhaseError {
@@ -164,14 +164,17 @@ func TestReconcileApp_ObservedStateUpdated(t *testing.T) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// getAppState
+// getAppObservation
 // ─────────────────────────────────────────────────────────────────────────────
 
-func TestGetAppState_NilClient(t *testing.T) {
+func TestGetAppObservation_NilClient(t *testing.T) {
 	d := &XEDriver{} // nil client
-	state := d.getAppState(testCtx(), "app1")
-	if state != "" {
-		t.Errorf("expected empty state with nil client, got %q", state)
+	obs := d.getAppObservation(testCtx(), "app1")
+	if obs.State != "" {
+		t.Errorf("expected empty state with nil client, got %q", obs.State)
+	}
+	if obs.PkgPolicy != Cisco_IOS_XEAppHostingOper_IoxPkgPolicy_UNSET {
+		t.Errorf("expected UNSET pkg policy with nil client, got %v", obs.PkgPolicy)
 	}
 }
 

--- a/internal/drivers/iosxe/status_transforms.go
+++ b/internal/drivers/iosxe/status_transforms.go
@@ -59,6 +59,7 @@ func (d *XEDriver) GetContainerStatus(ctx context.Context, pod *v1.Pod,
 
 	allReady := true
 	anyRunning := false
+	anyFailed := false
 
 	for containerName, appID := range discoveredContainers {
 		var containerSpec *v1.Container
@@ -104,6 +105,26 @@ func (d *XEDriver) GetContainerStatus(ctx context.Context, pod *v1.Pod,
 					},
 				}
 				allReady = false
+			case "INSTALLING":
+				if operData.PkgPolicy == Cisco_IOS_XEAppHostingOper_IoxPkgPolicy_iox_pkg_policy_invalid {
+					containerStatus.State = v1.ContainerState{
+						Terminated: &v1.ContainerStateTerminated{
+							ExitCode:   1,
+							Reason:     "PackagePolicyInvalid",
+							Message:    "Install blocked: unsigned package on a device requiring signed packages",
+							FinishedAt: now,
+						},
+					}
+					anyFailed = true
+				} else {
+					containerStatus.State = v1.ContainerState{
+						Waiting: &v1.ContainerStateWaiting{
+							Reason:  "ContainerCreating",
+							Message: fmt.Sprintf("App state: %s", state),
+						},
+					}
+				}
+				allReady = false
 			case "STOPPED", "Uninstalled":
 				containerStatus.State = v1.ContainerState{
 					Terminated: &v1.ContainerStateTerminated{
@@ -139,7 +160,11 @@ func (d *XEDriver) GetContainerStatus(ctx context.Context, pod *v1.Pod,
 		pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, containerStatus)
 	}
 
-	if anyRunning && allReady {
+	if anyFailed && !anyRunning {
+		pod.Status.Phase = v1.PodFailed
+		pod.Status.Reason = "PackagePolicyInvalid"
+		pod.Status.Message = "Install blocked: unsigned package on a device requiring signed packages"
+	} else if anyRunning && allReady {
 		pod.Status.Phase = v1.PodRunning
 		for i := range pod.Status.Conditions {
 			if pod.Status.Conditions[i].Type == v1.PodReady ||

--- a/internal/drivers/iosxe/status_transforms_test.go
+++ b/internal/drivers/iosxe/status_transforms_test.go
@@ -166,7 +166,7 @@ func TestGetContainerStatus_UnknownState(t *testing.T) {
 	pod := statusTestPod("app")
 	containers := map[string]string{"app": "app-id"}
 	operData := map[string]*Cisco_IOS_XEAppHostingOper_AppHostingOperData_App{
-		"app-id": operDataWithState("INSTALLING"),
+		"app-id": operDataWithState("MYSTERIOUS"),
 	}
 
 	if err := d.GetContainerStatus(testCtx(), pod, containers, operData); err != nil {
@@ -176,6 +176,50 @@ func TestGetContainerStatus_UnknownState(t *testing.T) {
 	cs := pod.Status.ContainerStatuses[0]
 	if cs.State.Waiting == nil || cs.State.Waiting.Reason != "Unknown" {
 		t.Error("expected Waiting/Unknown for unrecognised state")
+	}
+}
+
+func TestGetContainerStatus_Installing(t *testing.T) {
+	d := &XEDriver{config: &v1alpha1.DeviceSpec{Address: "10.0.0.1"}}
+	pod := statusTestPod("app")
+	containers := map[string]string{"app": "app-id"}
+	operData := map[string]*Cisco_IOS_XEAppHostingOper_AppHostingOperData_App{
+		"app-id": operDataWithState("INSTALLING"),
+	}
+
+	if err := d.GetContainerStatus(testCtx(), pod, containers, operData); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cs := pod.Status.ContainerStatuses[0]
+	if cs.State.Waiting == nil || cs.State.Waiting.Reason != "ContainerCreating" {
+		t.Error("expected Waiting/ContainerCreating for INSTALLING state")
+	}
+	if pod.Status.Phase != v1.PodPending {
+		t.Errorf("expected PodPending, got %s", pod.Status.Phase)
+	}
+}
+
+func TestGetContainerStatus_InstallingPkgPolicyInvalid(t *testing.T) {
+	d := &XEDriver{config: &v1alpha1.DeviceSpec{Address: "10.0.0.1"}}
+	pod := statusTestPod("app")
+	containers := map[string]string{"app": "app-id"}
+	od := operDataWithState("INSTALLING")
+	od.PkgPolicy = Cisco_IOS_XEAppHostingOper_IoxPkgPolicy_iox_pkg_policy_invalid
+	operData := map[string]*Cisco_IOS_XEAppHostingOper_AppHostingOperData_App{
+		"app-id": od,
+	}
+
+	if err := d.GetContainerStatus(testCtx(), pod, containers, operData); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cs := pod.Status.ContainerStatuses[0]
+	if cs.State.Terminated == nil || cs.State.Terminated.Reason != "PackagePolicyInvalid" {
+		t.Error("expected Terminated/PackagePolicyInvalid for invalid pkg-policy")
+	}
+	if pod.Status.Phase != v1.PodFailed {
+		t.Errorf("expected PodFailed, got %s", pod.Status.Phase)
 	}
 }
 


### PR DESCRIPTION
## Description

Fixes three pod provisioning lifecycle issues that cause pods to get stuck or cycle destructively on IOS-XE devices.

### 1. UpdatePod guard — skip delete-and-redeploy when app already exists

The upstream VK pod controller calls [UpdatePod](cci:1://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/drivers/iosxe/pod_lifecycle.go:66:0-99:1) whenever its `podsEqual` check fails, which triggers on benign metadata, annotation, or toleration changes. On `main`, [UpdatePod](cci:1://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/drivers/iosxe/pod_lifecycle.go:66:0-99:1) unconditionally performs [DeletePod](cci:1://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/drivers/iosxe/pod_lifecycle.go:234:0-270:1) → [DeployPod](cci:1://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/drivers/iosxe/pod_lifecycle.go:28:0-64:1), tearing down RUNNING apps and creating a destructive reprovisioning cycle.

**Fix:** Before performing the delete-and-redeploy, call [GetPodContainers](cci:1://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/drivers/iosxe/pod_lifecycle.go:101:0-232:1) to check if the app already exists on the device. If it does, return nil — the reconciliation loop inside [GetPodStatus](cci:1://file:///Users/johalley/Git/cisco-virtual-kubelet/internal/drivers/iosxe/pod_lifecycle.go:272:0-350:1) already handles advancing apps through intermediate lifecycle states (DEPLOYED → ACTIVATED → RUNNING).

`@/Users/johalley/Git/cisco-virtual-kubelet/internal/drivers/iosxe/pod_lifecycle.go:78-100`

### 2. STOPPED state in forward reconciliation path

The IOS-XE app lifecycle includes a STOPPED state (reached after `StopApp` or device restart). The forward reconciliation path had no explicit case for STOPPED, causing it to fall into the `default` branch which re-issued `InstallApp` — a no-op that left apps stuck permanently.

The correct IOS-XE lifecycle transition is: `STOPPED → StartApp → RUNNING` (not `ActivateApp`, which is only valid from DEPLOYED).

**Fix:** Add explicit `STOPPED` case calling `StartApp`.

`@/Users/johalley/Git/cisco-virtual-kubelet/internal/drivers/iosxe/reconciler.go:76-85`

### 3. Pod recovery loop with exponential backoff

When the VK pod restarts (e.g. Helm upgrade, node reboot), the Kubernetes node lifecycle controller marks pods on the unavailable node as `Failed` with reason `NotFound`. The upstream VK pod controller [permanently skips pods in Failed phase](https://github.com/virtual-kubelet/virtual-kubelet/blob/v1.12.0/node/podcontroller.go), so these pods are never re-synced.

**Fix:** 
- **One-shot recovery at startup:** [recoverStaleFailedPods](cci:1://file:///Users/johalley/Git/cisco-virtual-kubelet/cmd/cisco-vk/run.go:354:0-390:1) resets matching pods to `Pending` before the pod controller starts.
- **Background recovery loop:** [runPodRecoveryLoop](cci:1://file:///Users/johalley/Git/cisco-virtual-kubelet/cmd/cisco-vk/run.go:326:0-352:1) handles the race where the node lifecycle controller re-marks pods as Failed after VK startup recovery. Uses exponential backoff (15s → 30s → 60s → 5min cap), resetting to 15s when a recovery actually occurs, to minimise API server load once pods are healthy.

`@/Users/johalley/Git/cisco-virtual-kubelet/cmd/cisco-vk/run.go:307-371`

### Related context

- Upstream VK `syncPodInProvider` skips Failed/Succeeded pods: `virtual-kubelet/node/podcontroller.go`
- Upstream VK `podsEqual` triggers UpdatePod for metadata changes: `virtual-kubelet/node/pod.go`
- Deletion fixes (GetPod fallback, oper-data discovery, ParseCVKAppName) already merged in #91

---

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass

> **Note on test coverage:** The pod recovery loop and UpdatePod guard operate against a live Kubernetes API server and IOS-XE device — they have been verified manually on the `vk-ubuntu17` cluster with node `cat9000-2` (all 6 test pods reach Running with no destructive cycling). Unit tests for the recovery logic would require mocking the `kubernetes.Interface` clientset, which can be added as a follow-up.