### PR TITLE
fix: secure device credentials — use Secret injection instead of ConfigMap

### DIFF
--- a/cmd/cisco-vk/run.go
+++ b/cmd/cisco-vk/run.go
@@ -143,6 +143,13 @@ func runVirtualKubelet(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to load config from %s: %w", configPath, err)
 	}
 
+	// Resolve device password from environment variable when the controller
+	// injects it via a Kubernetes Secret (VK_DEVICE_PASSWORD). This keeps
+	// credentials out of the ConfigMap.
+	if envPass := os.Getenv("VK_DEVICE_PASSWORD"); envPass != "" {
+		appCfg.Device.Password = envPass
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/internal/controller/ciscodevice_controller.go
+++ b/internal/controller/ciscodevice_controller.go
@@ -177,12 +177,36 @@ func (r *CiscoDeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			},
 		}
 
+		// Build credential env vars. When a Secret reference is provided,
+		// use valueFrom so the kubelet resolves the password at pod startup
+		// (the controller never reads the Secret itself). Otherwise fall back
+		// to injecting the plaintext password as a direct env var for backward
+		// compatibility with CRDs that set spec.password directly.
+		var credEnv []corev1.EnvVar
+		if device.Spec.CredentialSecretRef != nil {
+			credEnv = append(credEnv, corev1.EnvVar{
+				Name: "VK_DEVICE_PASSWORD",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: *device.Spec.CredentialSecretRef,
+						Key:                  "password",
+					},
+				},
+			})
+		} else if device.Spec.Password != "" {
+			credEnv = append(credEnv, corev1.EnvVar{
+				Name:  "VK_DEVICE_PASSWORD",
+				Value: device.Spec.Password,
+			})
+		}
+
 		deploy.Spec.Template.Spec = corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
 					Name:  "cisco-vk",
 					Image: image,
 					Args:  vkContainerArgs(device.Name, device.Spec.LogLevel),
+					Env:   credEnv,
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "device-config",
@@ -252,15 +276,25 @@ func (r *CiscoDeviceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // renderDeviceConfig marshals the DeviceSpec into the YAML format expected
 // by the VK binary (wrapped under a "device:" key).
+// Credentials are stripped from the output so they never appear in the
+// ConfigMap (and therefore etcd). The controller injects them separately
+// via environment variables on the VK Deployment.
 func renderDeviceConfig(spec *ciskov1.DeviceSpec) (string, error) {
 	// The VK config loader expects:
 	//   device:
 	//     driver: ...
 	//     address: ...
+
+	// Copy the spec so we don't mutate the caller's object, then redact
+	// fields that must not be persisted in a ConfigMap.
+	sanitized := *spec
+	sanitized.Password = ""
+	sanitized.CredentialSecretRef = nil
+
 	wrapper := struct {
 		Device ciskov1.DeviceSpec `json:"device"`
 	}{
-		Device: *spec,
+		Device: sanitized,
 	}
 	out, err := yaml.Marshal(wrapper)
 	if err != nil {

--- a/internal/controller/ciscodevice_controller_test.go
+++ b/internal/controller/ciscodevice_controller_test.go
@@ -409,6 +409,32 @@ func TestRenderDeviceConfig_ContainsExpectedFields(t *testing.T) {
 	}
 }
 
+func TestRenderDeviceConfig_StripsPassword(t *testing.T) {
+	spec := &ciskov1.DeviceSpec{
+		Driver:   ciskov1.DeviceDriverXE,
+		Address:  "10.0.0.1",
+		Username: "admin",
+		Password: "supersecret",
+		CredentialSecretRef: &corev1.LocalObjectReference{
+			Name: "my-creds",
+		},
+	}
+	out, err := renderDeviceConfig(spec)
+	if err != nil {
+		t.Fatalf("renderDeviceConfig error: %v", err)
+	}
+	if strings.Contains(out, "supersecret") {
+		t.Errorf("password should be stripped from ConfigMap output; got:\n%s", out)
+	}
+	if strings.Contains(out, "my-creds") {
+		t.Errorf("credentialSecretRef should be stripped from ConfigMap output; got:\n%s", out)
+	}
+	// Original spec must not be mutated.
+	if spec.Password != "supersecret" {
+		t.Errorf("renderDeviceConfig mutated the original spec password")
+	}
+}
+
 func TestRenderDeviceConfig_ZeroValueSpec(t *testing.T) {
 	_, err := renderDeviceConfig(&ciskov1.DeviceSpec{})
 	if err != nil {
@@ -419,6 +445,109 @@ func TestRenderDeviceConfig_ZeroValueSpec(t *testing.T) {
 // ─────────────────────────────────────────────────────────────────────────────
 // Pure helper: shortHash
 // ─────────────────────────────────────────────────────────────────────────────
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Reconcile - credential injection
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestReconcile_SecretRefInjectsEnvFromSecret(t *testing.T) {
+	device := newDevice("router-sec", "default")
+	device.Spec.Password = ""
+	device.Spec.CredentialSecretRef = &corev1.LocalObjectReference{Name: "device-creds"}
+	r := reconcilerFor(t, device)
+	ctx := context.Background()
+
+	if _, err := r.Reconcile(ctx, reconcileRequest("default", "router-sec")); err != nil {
+		t.Fatalf("Reconcile error: %v", err)
+	}
+
+	var deploy appsv1.Deployment
+	if err := r.Get(ctx, types.NamespacedName{Namespace: "default", Name: "router-sec" + deploymentSuffix}, &deploy); err != nil {
+		t.Fatalf("Deployment not found: %v", err)
+	}
+
+	env := deploy.Spec.Template.Spec.Containers[0].Env
+	if len(env) != 1 || env[0].Name != "VK_DEVICE_PASSWORD" {
+		t.Fatalf("expected VK_DEVICE_PASSWORD env var, got %v", env)
+	}
+	if env[0].ValueFrom == nil || env[0].ValueFrom.SecretKeyRef == nil {
+		t.Fatal("expected VK_DEVICE_PASSWORD to use valueFrom.secretKeyRef")
+	}
+	if env[0].ValueFrom.SecretKeyRef.Name != "device-creds" {
+		t.Errorf("expected secretKeyRef name 'device-creds', got %q", env[0].ValueFrom.SecretKeyRef.Name)
+	}
+	if env[0].ValueFrom.SecretKeyRef.Key != "password" {
+		t.Errorf("expected secretKeyRef key 'password', got %q", env[0].ValueFrom.SecretKeyRef.Key)
+	}
+}
+
+func TestReconcile_DirectPasswordInjectsEnvValue(t *testing.T) {
+	device := newDevice("router-pw", "default")
+	device.Spec.Password = "directpass"
+	device.Spec.CredentialSecretRef = nil
+	r := reconcilerFor(t, device)
+	ctx := context.Background()
+
+	if _, err := r.Reconcile(ctx, reconcileRequest("default", "router-pw")); err != nil {
+		t.Fatalf("Reconcile error: %v", err)
+	}
+
+	var deploy appsv1.Deployment
+	if err := r.Get(ctx, types.NamespacedName{Namespace: "default", Name: "router-pw" + deploymentSuffix}, &deploy); err != nil {
+		t.Fatalf("Deployment not found: %v", err)
+	}
+
+	env := deploy.Spec.Template.Spec.Containers[0].Env
+	if len(env) != 1 || env[0].Name != "VK_DEVICE_PASSWORD" {
+		t.Fatalf("expected VK_DEVICE_PASSWORD env var, got %v", env)
+	}
+	if env[0].Value != "directpass" {
+		t.Errorf("expected direct password value 'directpass', got %q", env[0].Value)
+	}
+}
+
+func TestReconcile_NoPasswordNoSecretRef_NoEnvVars(t *testing.T) {
+	device := newDevice("router-nopass", "default")
+	device.Spec.Password = ""
+	device.Spec.CredentialSecretRef = nil
+	r := reconcilerFor(t, device)
+	ctx := context.Background()
+
+	if _, err := r.Reconcile(ctx, reconcileRequest("default", "router-nopass")); err != nil {
+		t.Fatalf("Reconcile error: %v", err)
+	}
+
+	var deploy appsv1.Deployment
+	if err := r.Get(ctx, types.NamespacedName{Namespace: "default", Name: "router-nopass" + deploymentSuffix}, &deploy); err != nil {
+		t.Fatalf("Deployment not found: %v", err)
+	}
+
+	env := deploy.Spec.Template.Spec.Containers[0].Env
+	if len(env) != 0 {
+		t.Errorf("expected no env vars when neither password nor secretRef is set, got %v", env)
+	}
+}
+
+func TestReconcile_PasswordStrippedFromConfigMap(t *testing.T) {
+	device := newDevice("router-strip", "default")
+	device.Spec.Password = "shouldnotappear"
+	r := reconcilerFor(t, device)
+	ctx := context.Background()
+
+	if _, err := r.Reconcile(ctx, reconcileRequest("default", "router-strip")); err != nil {
+		t.Fatalf("Reconcile error: %v", err)
+	}
+
+	var cm corev1.ConfigMap
+	if err := r.Get(ctx, types.NamespacedName{Namespace: "default", Name: "router-strip" + configMapSuffix}, &cm); err != nil {
+		t.Fatalf("ConfigMap not found: %v", err)
+	}
+
+	data := cm.Data[configFileName]
+	if strings.Contains(data, "shouldnotappear") {
+		t.Errorf("password should not appear in ConfigMap data; got:\n%s", data)
+	}
+}
 
 func TestShortHash_Deterministic(t *testing.T) {
 	if h1, h2 := shortHash("hello world"), shortHash("hello world"); h1 != h2 {


### PR DESCRIPTION
## Summary

- Strips `password` and `credentialSecretRef` from the ConfigMap so device credentials never appear in plaintext in etcd
- When `credentialSecretRef` is set on the CiscoDevice, the controller injects `VK_DEVICE_PASSWORD` as an env var using `valueFrom.secretKeyRef` — the controller itself never reads the Secret
- Falls back to injecting `spec.password` as a direct env var for backward compatibility
- VK runtime reads `VK_DEVICE_PASSWORD` at startup to override the config-file password
- Each CiscoDevice can reference a different Secret, supporting per-device credentials

### Usage

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: device-creds
stringData:
  password: cisco
---
apiVersion: cisco.vk/v1alpha1
kind: CiscoDevice
metadata:
  name: edge-9k
spec:
  driver: XE
  address: "192.168.129.2"
  username: cisco
  credentialSecretRef:
    name: device-creds
```

## Test plan

- [x] `TestRenderDeviceConfig_StripsPassword` — password and secretRef removed from ConfigMap output
- [x] `TestReconcile_SecretRefInjectsEnvFromSecret` — Deployment gets `VK_DEVICE_PASSWORD` with `secretKeyRef`
- [x] `TestReconcile_DirectPasswordInjectsEnvValue` — backward compat: direct password becomes env var
- [x] `TestReconcile_NoPasswordNoSecretRef_NoEnvVars` — no env vars when neither is set
- [x] `TestReconcile_PasswordStrippedFromConfigMap` — full reconcile confirms password absent from ConfigMap
- [x] All 22 controller tests pass
- [x] Full test suite passes (`go test ./...`)