### PR TITLE
ci: deploy documentation from main instead of develop

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: CI build develop documentation
+name: CI build and deploy documentation
 on:
   push:
     branches:
-      - develop
+      - main
 permissions:
   contents: write
 jobs:


### PR DESCRIPTION
## Summary

- Switches the documentation deployment workflow (`develop.yml`) to trigger on pushes to `main` instead of `develop`
- Updates the workflow name from "CI build develop documentation" to "CI build and deploy documentation"
- The `develop` branch has diverged significantly from `main` and is no longer kept in sync, meaning documentation updates on `main` (PRs #94–#98) were never deployed to GitHub Pages
- No changes to the build process itself — still builds the Next.js website and MkDocs docs, combines them, and pushes to `gh-pages`

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe)

CI/CD pipeline update — aligns documentation deployment with the project's primary branch.

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] All new and existing tests pass