### PR TITLE
fix: guard PackagePolicyInvalid false positive with allowUnsignedApps CRD field

### DIFF
--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -134,6 +134,16 @@ type DeviceSpec struct {
 	// +kubebuilder:validation:Optional
 	OTEL *OTELConfig `json:"otel,omitempty" mapstructure:"otel,omitempty"`
 
+	// AllowUnsignedApps indicates the device permits unsigned application packages.
+	// When true, the reconciler will not fail pods based on a transient
+	// iox-pkg-policy-invalid value during the INSTALLING state.
+	// When false (default), the reconciler treats iox-pkg-policy-invalid during
+	// INSTALLING as a terminal failure only when confirmed by an install
+	// notification from the device.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	AllowUnsignedApps bool `json:"allowUnsignedApps,omitempty" mapstructure:"allowUnsignedApps"`
+
 	// --- Driver-specific networking configuration (union) ---
 	// Only the section matching Driver should be set.
 

--- a/charts/cisco-virtual-kubelet/crds/cisco.vk_ciscodevices.yaml
+++ b/charts/cisco-virtual-kubelet/crds/cisco.vk_ciscodevices.yaml
@@ -62,6 +62,16 @@ spec:
               address:
                 description: Address is the management IP or hostname of the device.
                 type: string
+              allowUnsignedApps:
+                default: false
+                description: |-
+                  AllowUnsignedApps indicates the device permits unsigned application packages.
+                  When true, the reconciler will not fail pods based on a transient
+                  iox-pkg-policy-invalid value during the INSTALLING state.
+                  When false (default), the reconciler treats iox-pkg-policy-invalid during
+                  INSTALLING as a terminal failure only when confirmed by an install
+                  notification from the device.
+                type: boolean
               credentialSecretRef:
                 description: |-
                   CredentialSecretRef references a Secret containing device credentials.

--- a/cmd/cisco-vk/run.go
+++ b/cmd/cisco-vk/run.go
@@ -374,7 +374,7 @@ func recoverStaleFailedPods(ctx context.Context, clientset kubernetes.Interface,
 	recovered := 0
 	for i := range pods.Items {
 		pod := &pods.Items[i]
-		if pod.Status.Reason != "NotFound" && pod.Status.Reason != "ProviderFailed" {
+		if pod.Status.Reason != "NotFound" && pod.Status.Reason != "ProviderFailed" && pod.Status.Reason != "PackagePolicyInvalid" {
 			continue
 		}
 		if pod.DeletionTimestamp != nil {

--- a/config/crd/cisco.vk_ciscodevices.yaml
+++ b/config/crd/cisco.vk_ciscodevices.yaml
@@ -62,6 +62,16 @@ spec:
               address:
                 description: Address is the management IP or hostname of the device.
                 type: string
+              allowUnsignedApps:
+                default: false
+                description: |-
+                  AllowUnsignedApps indicates the device permits unsigned application packages.
+                  When true, the reconciler will not fail pods based on a transient
+                  iox-pkg-policy-invalid value during the INSTALLING state.
+                  When false (default), the reconciler treats iox-pkg-policy-invalid during
+                  INSTALLING as a terminal failure only when confirmed by an install
+                  notification from the device.
+                type: boolean
               credentialSecretRef:
                 description: |-
                   CredentialSecretRef references a Secret containing device credentials.

--- a/internal/drivers/iosxe/reconciler.go
+++ b/internal/drivers/iosxe/reconciler.go
@@ -102,19 +102,24 @@ func (d *XEDriver) ReconcileApp(ctx context.Context, appConfig *AppHostingConfig
 			// Re-issuing the install RPC would restart the tar extraction
 			// and prevent the install from ever completing on slow devices.
 
-			// Detect signature-validation failures: when the device requires
-			// signed packages but the tar is unsigned, the install gets stuck
-			// in INSTALLING with pkg-policy "invalid". Fail fast instead of
-			// waiting forever.
+			// pkg-policy starts as "invalid" (YANG default) during the first
+			// seconds of every install and resolves once validation completes.
+			// Only treat it as a terminal failure when:
+			//  1. The device does NOT allow unsigned apps, AND
+			//  2. A confirming install notification exists (device has actually
+			//     evaluated and rejected the package).
 			if obs.PkgPolicy == Cisco_IOS_XEAppHostingOper_IoxPkgPolicy_iox_pkg_policy_invalid {
-				msg := "app package policy is invalid (possible unsigned package on a device requiring signed packages)"
-				if notif := d.getAppInstallNotification(ctx, appID); notif != "" {
-					msg = strings.TrimSpace(notif)
+				if d.config.AllowUnsignedApps {
+					log.G(ctx).Debugf("ReconcileApp %s: pkg-policy invalid (transient, allowUnsignedApps=true), waiting", appID)
+				} else if notif := d.getAppInstallNotification(ctx, appID); notif != "" {
+					msg := strings.TrimSpace(notif)
+					log.G(ctx).Errorf("ReconcileApp %s: install blocked: %s", appID, msg)
+					appConfig.Status.Phase = AppPhaseError
+					appConfig.Status.Message = fmt.Sprintf("install blocked: %s", msg)
+					return
+				} else {
+					log.G(ctx).Warnf("ReconcileApp %s: pkg-policy invalid but no confirming notification yet, waiting", appID)
 				}
-				log.G(ctx).Errorf("ReconcileApp %s: install blocked: %s", appID, msg)
-				appConfig.Status.Phase = AppPhaseError
-				appConfig.Status.Message = fmt.Sprintf("install blocked: %s", msg)
-				return
 			}
 
 			appConfig.Status.Phase = AppPhaseConverging

--- a/internal/drivers/iosxe/status_transforms.go
+++ b/internal/drivers/iosxe/status_transforms.go
@@ -106,7 +106,8 @@ func (d *XEDriver) GetContainerStatus(ctx context.Context, pod *v1.Pod,
 				}
 				allReady = false
 			case "INSTALLING":
-				if operData.PkgPolicy == Cisco_IOS_XEAppHostingOper_IoxPkgPolicy_iox_pkg_policy_invalid {
+				if operData.PkgPolicy == Cisco_IOS_XEAppHostingOper_IoxPkgPolicy_iox_pkg_policy_invalid &&
+					!d.config.AllowUnsignedApps {
 					containerStatus.State = v1.ContainerState{
 						Terminated: &v1.ContainerStateTerminated{
 							ExitCode:   1,

--- a/internal/drivers/iosxe/status_transforms_test.go
+++ b/internal/drivers/iosxe/status_transforms_test.go
@@ -200,8 +200,8 @@ func TestGetContainerStatus_Installing(t *testing.T) {
 	}
 }
 
-func TestGetContainerStatus_InstallingPkgPolicyInvalid(t *testing.T) {
-	d := &XEDriver{config: &v1alpha1.DeviceSpec{Address: "10.0.0.1"}}
+func TestGetContainerStatus_InstallingPkgPolicyInvalid_SigningRequired(t *testing.T) {
+	d := &XEDriver{config: &v1alpha1.DeviceSpec{Address: "10.0.0.1", AllowUnsignedApps: false}}
 	pod := statusTestPod("app")
 	containers := map[string]string{"app": "app-id"}
 	od := operDataWithState("INSTALLING")
@@ -216,10 +216,33 @@ func TestGetContainerStatus_InstallingPkgPolicyInvalid(t *testing.T) {
 
 	cs := pod.Status.ContainerStatuses[0]
 	if cs.State.Terminated == nil || cs.State.Terminated.Reason != "PackagePolicyInvalid" {
-		t.Error("expected Terminated/PackagePolicyInvalid for invalid pkg-policy")
+		t.Error("expected Terminated/PackagePolicyInvalid for invalid pkg-policy when signing required")
 	}
 	if pod.Status.Phase != v1.PodFailed {
 		t.Errorf("expected PodFailed, got %s", pod.Status.Phase)
+	}
+}
+
+func TestGetContainerStatus_InstallingPkgPolicyInvalid_UnsignedAllowed(t *testing.T) {
+	d := &XEDriver{config: &v1alpha1.DeviceSpec{Address: "10.0.0.1", AllowUnsignedApps: true}}
+	pod := statusTestPod("app")
+	containers := map[string]string{"app": "app-id"}
+	od := operDataWithState("INSTALLING")
+	od.PkgPolicy = Cisco_IOS_XEAppHostingOper_IoxPkgPolicy_iox_pkg_policy_invalid
+	operData := map[string]*Cisco_IOS_XEAppHostingOper_AppHostingOperData_App{
+		"app-id": od,
+	}
+
+	if err := d.GetContainerStatus(testCtx(), pod, containers, operData); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cs := pod.Status.ContainerStatuses[0]
+	if cs.State.Waiting == nil || cs.State.Waiting.Reason != "ContainerCreating" {
+		t.Error("expected Waiting/ContainerCreating when allowUnsignedApps=true (transient invalid)")
+	}
+	if pod.Status.Phase != v1.PodPending {
+		t.Errorf("expected PodPending, got %s", pod.Status.Phase)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #101 — During app installation, IOS-XE transiently reports `pkg-policy = iox-pkg-policy-invalid` (the YANG default/uninitialized value) for the first 1–3 seconds before signature validation completes. The current code immediately fails the pod, producing a false `PackagePolicyInvalid` terminal failure even on devices that allow unsigned packages.

## Changes

### New CRD field: `allowUnsignedApps`

Added an optional boolean to `DeviceSpec` (`api/v1alpha1/types.go`) that declares whether the device permits unsigned application packages:

```yaml
spec:
  allowUnsignedApps: true
```

### Two-tier reconciler guard (`reconciler.go`)

When `iox-pkg-policy-invalid` is observed during INSTALLING:

1. **`allowUnsignedApps: true`** → skip (transient, continue waiting)
2. **`allowUnsignedApps: false`** → only fail if a confirming install notification exists from the device (genuine rejection). Otherwise wait — the value is likely still the YANG default.

### Status transform guard (`status_transforms.go`)

Same logic: only mark the container as `Terminated/PackagePolicyInvalid` when `allowUnsignedApps` is false.

### Recovery loop defense-in-depth (`run.go`)

Added `PackagePolicyInvalid` to the set of recoverable pod failure reasons alongside `NotFound` and `ProviderFailed`.

### CRD manifests regenerated

- `config/crd/cisco.vk_ciscodevices.yaml`
- `charts/cisco-virtual-kubelet/crds/cisco.vk_ciscodevices.yaml`

## Tests

- `TestGetContainerStatus_InstallingPkgPolicyInvalid_SigningRequired` — verifies `Failed/PackagePolicyInvalid` when `allowUnsignedApps=false`
- `TestGetContainerStatus_InstallingPkgPolicyInvalid_UnsignedAllowed` — verifies `Pending/ContainerCreating` when `allowUnsignedApps=true` (transient invalid is ignored)
- All existing tests pass (`go test ./...`)

## Verification

Deployed and tested on **vk-ubuntu17** cluster with **cat9000-2** (C9300-24P, IOS-XE 17.18.2, app-signing disabled):

### Install test
- Deployed 6 pods concurrently with `allowUnsignedApps: true`
- **Zero** `PackagePolicyInvalid` false positives (previously ~30% hit rate)
- All 6 pods reached Running

### Resilience test (RESTCONF-driven disruptions)
Each app was externally forced into a degraded state via device RPCs:

| Pod | Disruption | Device State | Recovery |
|-----|-----------|-------------|----------|
| serial-test-1 | stop | STOPPED | ✅ → RUNNING (~5s) |
| serial-test-2 | stop | STOPPED | ✅ → RUNNING (~5s) |
| serial-test-3 | stop + deactivate | DEPLOYED | ✅ → RUNNING (~15s) |
| serial-test-4 | stop + deactivate + uninstall | absent | ✅ → RUNNING (~2min, full reinstall) |
| serial-test-5 | stop + deactivate | DEPLOYED | ✅ → RUNNING (~15s) |
| serial-test-6 | control (untouched) | RUNNING | ✅ stayed Running |

All 6 pods and device apps confirmed RUNNING after recovery.