### PR TITLE
fix(iosxe): partial container discovery + recovery for missing apps

### DIFF
--- a/internal/drivers/common/naming.go
+++ b/internal/drivers/common/naming.go
@@ -95,6 +95,40 @@ func ExtractContainerNameFromLabels(runOptsLine string) string {
 	return ExtractLabelValue(runOptsLine, LabelContainerName)
 }
 
+// PodIdentityFromRunOpts walks all RunOpts lines and accumulates the four
+// pod-identity values. Labels emitted by distributeRunOpts may land on any
+// line, so callers that need to verify pod ownership must check across the
+// full set rather than a single line.
+//
+// Each value is taken from the first line in which it appears; once set it is
+// not overwritten by later lines. Any value that is never seen is returned as
+// the empty string.
+func PodIdentityFromRunOpts(lines []string) (namespace, name, uid, container string) {
+	for _, line := range lines {
+		if namespace == "" {
+			if v := ExtractLabelValue(line, LabelPodNamespace); v != "" {
+				namespace = v
+			}
+		}
+		if name == "" {
+			if v := ExtractLabelValue(line, LabelPodName); v != "" {
+				name = v
+			}
+		}
+		if uid == "" {
+			if v := ExtractLabelValue(line, LabelPodUID); v != "" {
+				uid = v
+			}
+		}
+		if container == "" {
+			if v := ExtractContainerNameFromLabels(line); v != "" {
+				container = v
+			}
+		}
+	}
+	return
+}
+
 // ExtractLabelValue extracts a label value from RunOpts labels string.
 // Returns the value if found, empty string otherwise.
 func ExtractLabelValue(runOptsLine, labelKey string) string {

--- a/internal/drivers/common/naming_test.go
+++ b/internal/drivers/common/naming_test.go
@@ -287,3 +287,82 @@ func TestIsCVKManagedApp(t *testing.T) {
 		t.Error("IsCVKManagedApp should return false for non-CVK app name")
 	}
 }
+
+func TestPodIdentityFromRunOpts(t *testing.T) {
+	const (
+		ns   = "default"
+		name = "thousandeyes-agent"
+		uid  = "0ab6b5c3-f13c-483c-ad8c-bee9c740f8ba"
+		ctr  = "te-agent"
+	)
+
+	tests := []struct {
+		name      string
+		lines     []string
+		wantNS    string
+		wantName  string
+		wantUID   string
+		wantCtr   string
+	}{
+		{
+			name: "all labels on a single line",
+			lines: []string{
+				"--label io.kubernetes.pod.name=" + name +
+					" --label io.kubernetes.pod.namespace=" + ns +
+					" --label io.kubernetes.pod.uid=" + uid +
+					" --label io.kubernetes.container.name=" + ctr,
+			},
+			wantNS: ns, wantName: name, wantUID: uid, wantCtr: ctr,
+		},
+		{
+			name: "labels split across two lines",
+			lines: []string{
+				"--label io.kubernetes.pod.name=" + name +
+					" --label io.kubernetes.pod.namespace=" + ns,
+				"--label io.kubernetes.pod.uid=" + uid +
+					" --label io.kubernetes.container.name=" + ctr,
+			},
+			wantNS: ns, wantName: name, wantUID: uid, wantCtr: ctr,
+		},
+		{
+			name: "labels distributed across many lines",
+			lines: []string{
+				"-e FOO=1",
+				"--label io.kubernetes.pod.namespace=" + ns,
+				"-e BAR=2",
+				"--label io.kubernetes.pod.name=" + name,
+				"-e BAZ=3",
+				"--label io.kubernetes.container.name=" + ctr,
+				"--label io.kubernetes.pod.uid=" + uid,
+			},
+			wantNS: ns, wantName: name, wantUID: uid, wantCtr: ctr,
+		},
+		{
+			name:    "no labels at all",
+			lines:   []string{"-e FOO=1", "-e BAR=2"},
+			wantNS:  "",
+			wantName: "",
+			wantUID: "",
+			wantCtr: "",
+		},
+		{
+			name: "first occurrence wins (later duplicate ignored)",
+			lines: []string{
+				"--label io.kubernetes.pod.name=" + name,
+				"--label io.kubernetes.pod.name=other-pod",
+			},
+			wantName: name,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotNS, gotName, gotUID, gotCtr := PodIdentityFromRunOpts(tt.lines)
+			if gotNS != tt.wantNS || gotName != tt.wantName || gotUID != tt.wantUID || gotCtr != tt.wantCtr {
+				t.Errorf("PodIdentityFromRunOpts() = (%q, %q, %q, %q), want (%q, %q, %q, %q)",
+					gotNS, gotName, gotUID, gotCtr,
+					tt.wantNS, tt.wantName, tt.wantUID, tt.wantCtr)
+			}
+		})
+	}
+}

--- a/internal/drivers/iosxe/driver.go
+++ b/internal/drivers/iosxe/driver.go
@@ -50,7 +50,11 @@ type XEDriver struct {
 	configMapLister corev1listers.ConfigMapNamespaceLister
 	recoveryMu     sync.RWMutex
 	recoveringPods map[string]bool // keyed by pod UID
-	eventRecorder  record.EventRecorder
+
+	installMu       sync.Mutex
+	installInFlight map[string]bool // keyed by appID; prevents duplicate background recovery installs
+
+	eventRecorder record.EventRecorder
 }
 
 // NewAppHostingDriver creates a new IOS-XE AppHosting driver instance
@@ -107,9 +111,10 @@ func NewAppHostingDriver(ctx context.Context, spec *v1alpha1.DeviceSpec) (*XEDri
 	)
 
 	d := &XEDriver{
-		config:         spec,
-		client:         Client,
-		recoveringPods: make(map[string]bool),
+		config:          spec,
+		client:          Client,
+		recoveringPods:  make(map[string]bool),
+		installInFlight: make(map[string]bool),
 	}
 
 	protocol := "restconf"
@@ -227,6 +232,28 @@ func (d *XEDriver) isPodRecovering(podUID string) bool {
 	d.recoveryMu.RLock()
 	defer d.recoveryMu.RUnlock()
 	return d.recoveringPods[podUID]
+}
+
+// tryMarkInstallInFlight atomically reserves the right to drive a recovery
+// install for the given appID. Returns true if the caller has now claimed
+// the slot and must release it via clearInstallInFlight when done; returns
+// false if another goroutine already holds it. Used by GetPodStatus to
+// dedupe per-app recovery attempts across status cycles.
+func (d *XEDriver) tryMarkInstallInFlight(appID string) bool {
+	d.installMu.Lock()
+	defer d.installMu.Unlock()
+	if d.installInFlight[appID] {
+		return false
+	}
+	d.installInFlight[appID] = true
+	return true
+}
+
+// clearInstallInFlight releases an in-flight install slot.
+func (d *XEDriver) clearInstallInFlight(appID string) {
+	d.installMu.Lock()
+	defer d.installMu.Unlock()
+	delete(d.installInFlight, appID)
 }
 
 // SetEventRecorder wires a Kubernetes event recorder into the driver so it can

--- a/internal/drivers/iosxe/install_inflight_test.go
+++ b/internal/drivers/iosxe/install_inflight_test.go
@@ -1,0 +1,44 @@
+// Copyright © 2026 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iosxe
+
+import "testing"
+
+// TryMarkInstallInFlight is the dedup primitive that prevents
+// recoverMissingContainers from spawning duplicate background installs
+// when GetPodStatus is called concurrently for the same pod.
+func TestTryMarkInstallInFlight(t *testing.T) {
+	d := &XEDriver{installInFlight: make(map[string]bool)}
+
+	if !d.tryMarkInstallInFlight("appA") {
+		t.Fatal("first mark for appA should succeed")
+	}
+	if d.tryMarkInstallInFlight("appA") {
+		t.Fatal("second mark for appA must be rejected while still in flight")
+	}
+	// A different appID is independent.
+	if !d.tryMarkInstallInFlight("appB") {
+		t.Fatal("first mark for appB should succeed (different appID)")
+	}
+
+	// Clearing appA frees the slot for retry.
+	d.clearInstallInFlight("appA")
+	if !d.tryMarkInstallInFlight("appA") {
+		t.Fatal("mark after clear should succeed")
+	}
+
+	// Clearing an unknown id is a no-op (map delete on missing key).
+	d.clearInstallInFlight("never-set")
+}

--- a/internal/drivers/iosxe/pod_lifecycle.go
+++ b/internal/drivers/iosxe/pod_lifecycle.go
@@ -341,6 +341,20 @@ func (d *XEDriver) GetPodStatus(ctx context.Context, pod *v1.Pod) (*v1.Pod, erro
 	}
 
 	if len(discoveredContainers) == 0 {
+		// All containers are missing. If the pod is still alive in K8s and the
+		// driver has the listers it needs, spawn recovery installs and surface a
+		// synthesised Pending pod so the VK framework does not loop on
+		// NotFound. The next status cycle will pick up the apps via normal
+		// discovery once installs land.
+		if pod.DeletionTimestamp == nil && d.secretLister != nil && d.configMapLister != nil {
+			log.G(ctx).Infof("All containers missing for pod %s/%s; driving full recovery", pod.Namespace, pod.Name)
+			d.recoverMissingContainers(ctx, pod, discoveredContainers)
+			statusPod := pod.DeepCopy()
+			if statusErr := d.GetContainerStatus(ctx, statusPod, discoveredContainers, nil); statusErr != nil {
+				return nil, fmt.Errorf("failed to synthesise status for recovering pod: %w", statusErr)
+			}
+			return statusPod, nil
+		}
 		log.G(ctx).Warnf("No containers found on device for pod %s/%s", pod.Namespace, pod.Name)
 		return nil, fmt.Errorf("no containers found for pod %s/%s", pod.Namespace, pod.Name)
 	}

--- a/internal/drivers/iosxe/pod_lifecycle.go
+++ b/internal/drivers/iosxe/pod_lifecycle.go
@@ -201,33 +201,24 @@ func (d *XEDriver) GetPodContainers(ctx context.Context, pod *v1.Pod) (map[strin
 
 		log.G(ctx).Debugf("Found app %s with matching pod UID", appName)
 
-		// Extract container name from RunOpts labels
+		// Extract pod identity by accumulating labels across every RunOpts
+		// line — distributeRunOpts may split labels across lines, so a
+		// single-line check would silently drop the container.
 		var containerName string
-		var runOptsLine string
-
+		var runOptsLines []string
 		if app.RunOptss != nil {
 			for _, opt := range app.RunOptss.RunOpts {
 				if opt.LineRunOpts != nil {
-					line := *opt.LineRunOpts
-					runOptsLine = line
-
-					log.G(ctx).Debugf("App %s RunOpts: %s", appName, line)
-
-					// Verify this app belongs to our pod by checking all pod labels
-					if strings.Contains(line, fmt.Sprintf("%s=%s", common.LabelPodName, pod.Name)) &&
-						strings.Contains(line, fmt.Sprintf("%s=%s", common.LabelPodNamespace, pod.Namespace)) &&
-						strings.Contains(line, fmt.Sprintf("%s=%s", common.LabelPodUID, pod.UID)) {
-
-						// Extract the container name from the label
-						containerName = common.ExtractContainerNameFromLabels(line)
-
-						if containerName != "" {
-							log.G(ctx).Debugf("Extracted container name: %s from app %s", containerName, appName)
-						} else {
-							log.G(ctx).Warnf("App %s has pod labels but no container name label in line: %s", appName, line)
-						}
-						break
-					}
+					runOptsLines = append(runOptsLines, *opt.LineRunOpts)
+				}
+			}
+		}
+		if len(runOptsLines) > 0 {
+			ns, name, uid, ctr := common.PodIdentityFromRunOpts(runOptsLines)
+			if ns == pod.Namespace && name == pod.Name && uid == string(pod.UID) {
+				containerName = ctr
+				if containerName == "" {
+					log.G(ctx).Warnf("App %s has pod labels but no container name label across RunOpts lines: %v", appName, runOptsLines)
 				}
 			}
 		}
@@ -248,8 +239,8 @@ func (d *XEDriver) GetPodContainers(ctx context.Context, pod *v1.Pod) (map[strin
 			containerToAppID[containerName] = appName
 			log.G(ctx).Infof("Found container %s -> app %s", containerName, appName)
 		} else {
-			log.G(ctx).Warnf("Found app %s with pod UID but couldn't extract container name from labels. RunOpts: %s",
-				appName, runOptsLine)
+			log.G(ctx).Warnf("Found app %s with pod UID but couldn't extract container name from labels. RunOpts: %v",
+				appName, runOptsLines)
 		}
 	}
 
@@ -335,11 +326,17 @@ func (d *XEDriver) GetPodStatus(ctx context.Context, pod *v1.Pod) (*v1.Pod, erro
 		return statusPod, nil
 	}
 
-	// Get containers for this pod
+	// Get containers for this pod. GetPodContainers may return a partial map
+	// alongside an error when some expected containers have not yet been
+	// created on the device (e.g. multi-container pods mid-deployment, or the
+	// two-phase DockerResource flow where alpha is in DEPLOYED while beta has
+	// not been installed yet). The partial map is still useful — we surface
+	// a Pending pod with the in-flight containers as ContainerCreating
+	// instead of returning NotFound, which the VK framework would otherwise
+	// interpret as a missing pod and try to recreate.
 	discoveredContainers, err := d.GetPodContainers(ctx, pod)
 	if err != nil {
-		log.G(ctx).Debugf("failed to get pod containers: %v", err)
-		return nil, fmt.Errorf("apps for pod %s/%s not found on device", pod.Namespace, pod.Name)
+		log.G(ctx).Debugf("partial container discovery for pod %s/%s: %v", pod.Namespace, pod.Name, err)
 	}
 
 	if len(discoveredContainers) == 0 {
@@ -475,26 +472,13 @@ func (d *XEDriver) ListPods(ctx context.Context) ([]*v1.Pod, error) {
 		var podNamespace, podName, podUID, containerName string
 
 		if app.RunOptss != nil {
+			lines := make([]string, 0, len(app.RunOptss.RunOpts))
 			for _, opt := range app.RunOptss.RunOpts {
 				if opt.LineRunOpts != nil {
-					line := *opt.LineRunOpts
-					log.G(ctx).Debugf("Discovery: App %s RunOpts line: %s", appName, line)
-
-					// Extract pod labels and accumulate across all lines
-					if val := common.ExtractLabelValue(line, common.LabelPodNamespace); val != "" && podNamespace == "" {
-						podNamespace = val
-					}
-					if val := common.ExtractLabelValue(line, common.LabelPodName); val != "" && podName == "" {
-						podName = val
-					}
-					if val := common.ExtractLabelValue(line, common.LabelPodUID); val != "" && podUID == "" {
-						podUID = val
-					}
-					if val := common.ExtractContainerNameFromLabels(line); val != "" && containerName == "" {
-						containerName = val
-					}
+					lines = append(lines, *opt.LineRunOpts)
 				}
 			}
+			podNamespace, podName, podUID, containerName = common.PodIdentityFromRunOpts(lines)
 			log.G(ctx).Debugf("Discovery: App %s final extracted namespace=%s, name=%s, uid=%s, container=%s",
 				appName, podNamespace, podName, podUID, containerName)
 		} else {

--- a/internal/drivers/iosxe/pod_lifecycle.go
+++ b/internal/drivers/iosxe/pod_lifecycle.go
@@ -18,12 +18,13 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/cisco/virtual-kubelet-cisco/internal/drivers/common"
 	"github.com/virtual-kubelet/virtual-kubelet/log"
 	v1 "k8s.io/api/core/v1"
-	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 )
 
 // DeployPod creates and deploys all containers in a pod to the device
@@ -393,6 +394,15 @@ func (d *XEDriver) GetPodStatus(ctx context.Context, pod *v1.Pod) (*v1.Pod, erro
 			}
 			d.ReconcileApp(ctx, appCfg)
 		}
+
+		// Drive recovery for any spec containers that are missing from the
+		// device. Without this, a container that failed to install or was
+		// deleted out-of-band would stay in ContainerCreating indefinitely
+		// because the loop above only iterates discoveredContainers.
+		// Each missing container is installed in a background goroutine so
+		// the status path stays non-blocking; tryMarkInstallInFlight prevents
+		// duplicate installs from concurrent status cycles.
+		d.recoverMissingContainers(ctx, pod, discoveredContainers)
 	} else {
 		log.G(ctx).Debugf("Pod %s/%s has DeletionTimestamp set; skipping forward reconciliation", pod.Namespace, pod.Name)
 	}
@@ -406,6 +416,81 @@ func (d *XEDriver) GetPodStatus(ctx context.Context, pod *v1.Pod) (*v1.Pod, erro
 	}
 
 	return statusPod, nil
+}
+
+// recoverMissingContainers kicks off a background install for any container
+// in pod.Spec that is not present in discoveredContainers. This complements
+// the synthesised ContainerCreating status emitted by GetContainerStatus —
+// without an actual install the container would stay Waiting forever.
+//
+// Each install is dedup'd by appID via tryMarkInstallInFlight so concurrent
+// GetPodStatus calls do not stack duplicate goroutines. CreateAppHostingApp
+// is non-blocking from the caller's perspective (runs in its own goroutine
+// with a fresh context); a failed install clears the in-flight flag so the
+// next status cycle retries.
+//
+// If the secret/configmap listers haven't been populated yet (cvk just
+// started up and DeployPod hasn't run for this pod), recovery is skipped —
+// the necessary env-var resolution would fail. The next status cycle will
+// retry once listers are wired up.
+func (d *XEDriver) recoverMissingContainers(ctx context.Context, pod *v1.Pod, discoveredContainers map[string]string) {
+	var missingNames []string
+	for i := range pod.Spec.Containers {
+		name := pod.Spec.Containers[i].Name
+		if _, found := discoveredContainers[name]; !found {
+			missingNames = append(missingNames, name)
+		}
+	}
+	if len(missingNames) == 0 {
+		return
+	}
+
+	if d.secretLister == nil || d.configMapLister == nil {
+		log.G(ctx).Warnf("Cannot drive recovery for missing containers in pod %s/%s: secret/configmap listers not yet initialised (will retry next status cycle)",
+			pod.Namespace, pod.Name)
+		return
+	}
+
+	appConfigs, err := d.ConvertPodToAppConfigs(pod)
+	if err != nil {
+		log.G(ctx).Warnf("Failed to build recovery app configs for pod %s/%s: %v", pod.Namespace, pod.Name, err)
+		return
+	}
+
+	byContainer := make(map[string]*AppHostingConfig, len(appConfigs))
+	for i := range appConfigs {
+		byContainer[appConfigs[i].ContainerName()] = &appConfigs[i]
+	}
+
+	for _, name := range missingNames {
+		cfg, ok := byContainer[name]
+		if !ok {
+			log.G(ctx).Warnf("Recovery: no app config produced for missing container %s of pod %s/%s",
+				name, pod.Namespace, pod.Name)
+			continue
+		}
+		if !d.tryMarkInstallInFlight(cfg.AppName()) {
+			log.G(ctx).Debugf("Recovery: install already in flight for container %s (appID=%s)", name, cfg.AppName())
+			continue
+		}
+		// Copy the config — the slice it points into is local to this
+		// function and the goroutine outlives the call.
+		cfgCopy := *cfg
+		log.G(ctx).Infof("Recovery: spawning install for missing container %s (appID=%s) of pod %s/%s",
+			name, cfgCopy.AppName(), pod.Namespace, pod.Name)
+		go func() {
+			bgCtx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+			defer cancel()
+			defer d.clearInstallInFlight(cfgCopy.AppName())
+			if err := d.CreateAppHostingApp(bgCtx, &cfgCopy); err != nil {
+				log.G(bgCtx).Warnf("Recovery: install failed for container %s of pod %s/%s: %v",
+					cfgCopy.ContainerName(), pod.Namespace, pod.Name, err)
+				return
+			}
+			log.G(bgCtx).Infof("Recovery: install succeeded for container %s of pod %s/%s",
+				cfgCopy.ContainerName(), pod.Namespace, pod.Name)
+		}()
+	}
 }
 
 // ListPods discovers all pods currently running on the device by analyzing app configurations.

--- a/internal/drivers/iosxe/status_transforms.go
+++ b/internal/drivers/iosxe/status_transforms.go
@@ -161,6 +161,30 @@ func (d *XEDriver) GetContainerStatus(ctx context.Context, pod *v1.Pod,
 		pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, containerStatus)
 	}
 
+	// Surface containers declared in pod.Spec but not yet seen on the device
+	// (e.g. multi-container pod mid-deployment) as ContainerCreating. Without
+	// this, the resulting pod has fewer ContainerStatuses than declared
+	// containers and the VK framework treats it as malformed.
+	for i := range pod.Spec.Containers {
+		name := pod.Spec.Containers[i].Name
+		if _, found := discoveredContainers[name]; found {
+			continue
+		}
+		pod.Status.ContainerStatuses = append(pod.Status.ContainerStatuses, v1.ContainerStatus{
+			Name:    name,
+			Image:   pod.Spec.Containers[i].Image,
+			ImageID: pod.Spec.Containers[i].Image,
+			Ready:   false,
+			State: v1.ContainerState{
+				Waiting: &v1.ContainerStateWaiting{
+					Reason:  "ContainerCreating",
+					Message: "Container has not yet been created on the device",
+				},
+			},
+		})
+		allReady = false
+	}
+
 	if anyFailed && !anyRunning {
 		pod.Status.Phase = v1.PodFailed
 		pod.Status.Reason = "PackagePolicyInvalid"

--- a/internal/drivers/iosxe/status_transforms_test.go
+++ b/internal/drivers/iosxe/status_transforms_test.go
@@ -370,3 +370,52 @@ func TestGetContainerStatus_ScheduledConditionTrue(t *testing.T) {
 		}
 	}
 }
+
+// Issue #109: containers declared in pod.Spec but missing from
+// discoveredContainers (e.g. multi-container pod mid-deployment) must
+// surface as ContainerCreating, not silently disappear.
+func TestGetContainerStatus_PartialDiscoveryMissingContainer(t *testing.T) {
+	d := &XEDriver{config: &v1alpha1.DeviceSpec{Address: "10.0.0.1"}}
+	pod := statusTestPod("alpha", "beta")
+	// Only alpha was discovered; beta is missing (still being created).
+	containers := map[string]string{"alpha": "alpha-id"}
+	operData := map[string]*Cisco_IOS_XEAppHostingOper_AppHostingOperData_App{
+		"alpha-id": operDataWithState("RUNNING"),
+	}
+
+	if err := d.GetContainerStatus(testCtx(), pod, containers, operData); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(pod.Status.ContainerStatuses) != 2 {
+		t.Fatalf("expected 2 container statuses, got %d", len(pod.Status.ContainerStatuses))
+	}
+
+	// Locate beta's status — order is not guaranteed because alpha comes
+	// from a map iteration.
+	var betaCS *v1.ContainerStatus
+	for i := range pod.Status.ContainerStatuses {
+		if pod.Status.ContainerStatuses[i].Name == "beta" {
+			betaCS = &pod.Status.ContainerStatuses[i]
+		}
+	}
+	if betaCS == nil {
+		t.Fatal("beta container status was not synthesised")
+	}
+	if betaCS.Ready {
+		t.Error("missing container must not be Ready")
+	}
+	if betaCS.State.Waiting == nil {
+		t.Fatal("missing container state should be Waiting")
+	}
+	if betaCS.State.Waiting.Reason != "ContainerCreating" {
+		t.Errorf("Reason = %q, want ContainerCreating", betaCS.State.Waiting.Reason)
+	}
+	// One container running, one waiting → not all ready, so phase must
+	// not be PodRunning with PodReady=True.
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == v1.PodReady && cond.Status == v1.ConditionTrue {
+			t.Error("PodReady should not be True while a container is still ContainerCreating")
+		}
+	}
+}


### PR DESCRIPTION
## Description

Fixes two pre-existing fragilities in the IOS-XE pod-lifecycle code, plus a recovery path for apps that disappear from the device while the K8s pod is still alive. Both bugs were latent on `main` but became reachable in practice after #107 (env-var support) introduced multi-line `RunOpts` distribution.

Related issues: closes #108, closes #109. Related PR for context: #107.

### `GetPodContainers` accumulates labels across every `RunOpts` line (#108)

Previously the function required `LabelPodName`, `LabelPodNamespace` and `LabelPodUID` to all appear on the **same** `LineRunOpts` to confirm app ownership. With `distributeRunOpts` splitting opts across multiple lines, the check fails silently and the container is dropped from discovery.

- New helper `common.PodIdentityFromRunOpts(lines []string) (namespace, name, uid, container string)` accumulates the four identity labels across every line, first-occurrence-wins.
- `GetPodContainers` and `ListPods` now both extract identity through the helper, so the two paths agree on what counts as a CVK-managed app.

### `GetPodStatus` no longer collapses partial discovery to `NotFound` (#109)

`GetPodContainers` deliberately returns a partial map alongside an error when only some expected containers are visible on the device. The previous caller threw the partial map away and returned `nil, fmt.Errorf("apps for pod ... not found")`, which the VK framework interprets as a missing pod and would drive a delete/recreate cycle.

- `GetPodStatus` now keeps the partial map and only returns `NotFound` when zero containers were discovered.
- `GetContainerStatus` synthesises a `ContainerStatus` with `Waiting` reason `ContainerCreating` for every container declared in `pod.Spec` but missing from the discovered map, so the resulting status has the right number of `ContainerStatuses` and the framework sees a clean `Pending` pod.

### Recovery for permanently missing containers

If a container is removed from the device out-of-band (e.g. `app-hosting uninstall` + `no app-hosting appid …`), the existing reconcile loop in `GetPodStatus` would never re-install it because that loop only iterates `discoveredContainers`. Synthesising `ContainerCreating` without a corresponding install would leave the pod stuck indefinitely.

- New per-driver in-flight set (`installInFlight` / `tryMarkInstallInFlight` / `clearInstallInFlight`) dedupes recovery attempts across status cycles.
- New `recoverMissingContainers` builds full `AppHostingConfig` objects via `ConvertPodToAppConfigs` (so env-var resolution and run-opts distribution match the initial deploy) and spawns one background `CreateAppHostingApp` per missing container.
- Wired into `GetPodStatus` for both partial discovery and the `len == 0` case (single-container pod fully gone). When the pod is being deleted or the secret/configmap listers are not yet wired up, the recovery is skipped — `NotFound` is still returned in those edge cases.

### Test plan

**Unit**

- `TestPodIdentityFromRunOpts` — single-line, two-line, fully distributed, no-labels, and first-occurrence-wins.
- `TestGetContainerStatus_PartialDiscoveryMissingContainer` — 2-container pod with one container undiscovered yields two ContainerStatuses, the missing one `Waiting`/`ContainerCreating`, and `PodReady != True`.
- `TestTryMarkInstallInFlight` — mark rejected while in-flight, succeeds after clear, independent appIDs.

**Integration on a Cat9k lab device (`flash:/hello-app.iosxe.tar`)**

- *Initial deploy* — pod transitions `INSTALLING` → `DEPLOYED` → `ACTIVATED` → `RUNNING` with no `apps for pod ... not found` errors during transitions.
- *Out-of-band uninstall (config persists briefly)* — handled by the existing `ReconcileApp` no-oper-data branch; pod returned to `Running` in ~30s.
- *Out-of-band uninstall + `no app-hosting appid <id>`* — the deepest possible teardown, both config-data and oper-data are gone. Controller logs the new path:
  - `All containers missing for pod default/recovery-test; driving full recovery`
  - `Recovery: spawning install for missing container hello (appID=cvk0000_…)`

  followed by the regular `DEPLOYED` → `ACTIVATED` → `RUNNING` lifecycle. Pod returned to `Running` in ~3 minutes (dominated by the device-side install).

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
