### PR TITLE
fix(engine): correct misleading driftPolicy=report status message

### DIFF
--- a/internal/drivers/iosxe/configdriver/engine/engine.go
+++ b/internal/drivers/iosxe/configdriver/engine/engine.go
@@ -908,7 +908,7 @@ func (e *Engine) reconcileFamily(ctx context.Context, family string, res *intent
 		return FamilyStatus{
 			Name: family, State: "Drifted",
 			OpCount: len(ops),
-			Message: safeMsg("%d op(s) would be applied under driftPolicy=revert", len(ops)),
+			Message: safeMsg("driftPolicy=report: %d op(s) detected as drift but not applied; switch to driftPolicy=revert to reconcile", len(ops)),
 		}
 	}
 


### PR DESCRIPTION
## Summary

- `engine.reconcileFamily` produced a status message that said *"%d op(s) would be applied under **driftPolicy=revert**"* — but that branch only fires when the active policy is `report`, so the message named the wrong policy and read as if revert had failed.
- Rewrite to lead with the actual policy and the operator action: *"driftPolicy=report: N op(s) detected as drift but not applied; switch to driftPolicy=revert to reconcile"*.
- No behaviour change. Status-surface only; no test asserts on the message text.

## Why

Surfaced while triaging the cat8kv/cat9k lab-CI failure on #117. The scenario in cvk-gitops polled `phase=InSync` while setting `driftPolicy: report`, which can never reach InSync once `len(ops) > 0`. The lab-CI scenario has been fixed (cvk-gitops `b850348`); this PR fixes the wording so the same misdiagnosis doesn't recur.

## Test plan

- [x] `go test ./internal/drivers/iosxe/configdriver/engine/...` — green
- [ ] Lab CI green on this PR