### PR TITLE
Harden gNOI lifecycle surfaces after PR 121

### DIFF
--- a/.github/workflows/yang-drift.yml
+++ b/.github/workflows/yang-drift.yml
@@ -16,9 +16,8 @@ name: yang-drift
 
 on:
   workflow_dispatch: {}
-  # Production cron remains disabled until Phase 3.3/3.4 are stable.
-  # schedule:
-  #   - cron: '0 8 * * 1'
+  schedule:
+    - cron: '0 8 * * 1'
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ bin
 .claude/
 site/
 /cisco-vk
+0001-fix-normalize-desired-through-yangFetchShape-before-.patch
+kubectl-ciscovk

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -1,5 +1,0 @@
-FROM gcr.io/distroless/static-debian12
-COPY bin/cisco-vk-linux-amd64 /usr/local/bin/cisco-vk
-USER nonroot:nonroot
-
-ENTRYPOINT ["/usr/local/bin/cisco-vk"]

--- a/api/ops/v1alpha1/iosxeoperationalaction_types.go
+++ b/api/ops/v1alpha1/iosxeoperationalaction_types.go
@@ -73,6 +73,8 @@ type IOSXEOperationalAction struct {
 }
 
 // IOSXEOperationalActionSpec declares a write-class operation.
+//
+// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="IOSXEOperationalAction spec is immutable after creation"
 type IOSXEOperationalActionSpec struct {
 	// DeviceRef targets the CiscoDevice the action runs against.
 	// +kubebuilder:validation:Required
@@ -91,6 +93,13 @@ type IOSXEOperationalActionSpec struct {
 }
 
 // ActionRequest carries the kind + typed inputs.
+//
+// +kubebuilder:validation:XValidation:rule="(self.kind == 'Reboot') == has(self.reboot)",message="kind Reboot requires only the reboot args block"
+// +kubebuilder:validation:XValidation:rule="(self.kind == 'CancelReboot') == has(self.cancelReboot)",message="kind CancelReboot requires only the cancelReboot args block"
+// +kubebuilder:validation:XValidation:rule="(self.kind == 'KillProcess') == has(self.killProcess)",message="kind KillProcess requires only the killProcess args block"
+// +kubebuilder:validation:XValidation:rule="(self.kind == 'FilePut') == has(self.filePut)",message="kind FilePut requires only the filePut args block"
+// +kubebuilder:validation:XValidation:rule="(self.kind == 'FileRemove') == has(self.fileRemove)",message="kind FileRemove requires only the fileRemove args block"
+// +kubebuilder:validation:XValidation:rule="(self.kind == 'FactoryReset') == has(self.factoryReset)",message="kind FactoryReset requires only the factoryReset args block"
 type ActionRequest struct {
 	// Kind names the action variant.
 	// +kubebuilder:validation:Required
@@ -130,6 +139,7 @@ type RebootActionArgs struct {
 	// DelaySeconds before the reboot fires. Zero means immediate.
 	// +optional
 	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=604800
 	DelaySeconds int64 `json:"delaySeconds,omitempty"`
 	// +optional
 	Message string `json:"message,omitempty"`
@@ -174,6 +184,7 @@ type FilePutArgs struct {
 
 	// Permissions is the UNIX octal mode (default 0o644).
 	// +optional
+	// +kubebuilder:validation:Maximum=511
 	Permissions uint32 `json:"permissions,omitempty"`
 }
 
@@ -214,6 +225,11 @@ type IOSXEOperationalActionStatus struct {
 	Message string `json:"message,omitempty"`
 	// +optional
 	FailureReason string `json:"failureReason,omitempty"`
+	// InvocationID is set before the device-side RPC is dispatched. If the
+	// controller crashes while phase=Running, the next reconcile treats the
+	// action as already invoked and will not dispatch a second destructive RPC.
+	// +optional
+	InvocationID string `json:"invocationID,omitempty"`
 	// Result holds structured device-side output where applicable
 	// (e.g. RebootStatus snapshot post-CancelReboot). JSON-encoded.
 	// +optional

--- a/api/ops/v1alpha1/iosxesoftwareupgrade_types.go
+++ b/api/ops/v1alpha1/iosxesoftwareupgrade_types.go
@@ -30,7 +30,7 @@ import (
 // Activating → gNOI OS.Activate; per spec this reboots the device unless NoReboot
 // AwaitingReachability → device unreachable while it boots the new image
 // Verifying → gNOI OS.Verify + gNMI cross-check
-// RollingBack → reserved for future boot-variable rollback implementation
+// RollingBack → activating the previously observed version after verify failure
 // Terminal phases: Succeeded, Failed, PreflightFailed, ValidationFailed,
 // RolledBack, RebootTimeout, Cancelled.
 //
@@ -141,10 +141,9 @@ type IOSXESoftwareUpgradeSpec struct {
 	// +kubebuilder:default=Reload
 	Strategy UpgradeStrategy `json:"strategy,omitempty"`
 
-	// RollbackOnFailure, when true, currently fails closed with
-	// RollbackNotImplemented if post-Verify the device is running a
-	// different version. Future releases will wire boot-variable rewrite
-	// plus System.Reboot behind this field. Default true.
+	// RollbackOnFailure, when true, attempts to reactivate the version
+	// that was running before this upgrade began when post-Verify reports
+	// a different version than TargetVersion. Default true.
 	// +optional
 	// +kubebuilder:default=true
 	RollbackOnFailure *bool `json:"rollbackOnFailure,omitempty"`
@@ -266,6 +265,12 @@ type IOSXESoftwareUpgradeStatus struct {
 	// Verifying.
 	// +optional
 	RunningVersion string `json:"runningVersion,omitempty"`
+
+	// PreviousVersion is the device-reported OS version captured before
+	// image activation. It is used as the rollback target when
+	// RollbackOnFailure is enabled.
+	// +optional
+	PreviousVersion string `json:"previousVersion,omitempty"`
 
 	// ValidatedVersion is the exact device-reported OS version returned
 	// by gNOI OS.Install Validated. IOS XE may require this exact value

--- a/api/ops/v1alpha1/iosxesoftwareupgrade_types.go
+++ b/api/ops/v1alpha1/iosxesoftwareupgrade_types.go
@@ -30,7 +30,7 @@ import (
 // Activating → gNOI OS.Activate; per spec this reboots the device unless NoReboot
 // AwaitingReachability → device unreachable while it boots the new image
 // Verifying → gNOI OS.Verify + gNMI cross-check
-// RollingBack → set boot variable to prior image and reload once
+// RollingBack → reserved for future boot-variable rollback implementation
 // Terminal phases: Succeeded, Failed, PreflightFailed, ValidationFailed,
 // RolledBack, RebootTimeout, Cancelled.
 //
@@ -141,10 +141,10 @@ type IOSXESoftwareUpgradeSpec struct {
 	// +kubebuilder:default=Reload
 	Strategy UpgradeStrategy `json:"strategy,omitempty"`
 
-	// RollbackOnFailure, when true, drives the RollingBack phase if
-	// post-Verify the device is running a different version. The
-	// fallback uses the device's prior boot variable plus one
-	// System.Reboot. Default true.
+	// RollbackOnFailure, when true, currently fails closed with
+	// RollbackNotImplemented if post-Verify the device is running a
+	// different version. Future releases will wire boot-variable rewrite
+	// plus System.Reboot behind this field. Default true.
 	// +optional
 	// +kubebuilder:default=true
 	RollbackOnFailure *bool `json:"rollbackOnFailure,omitempty"`
@@ -215,6 +215,14 @@ type UpgradeImageSource struct {
 	// +optional
 	// +kubebuilder:validation:Pattern=`^(flash|bootflash|harddisk):`
 	LocalPath string `json:"localPath,omitempty"`
+
+	// LocalPathSHA256 optionally verifies the staged flash image before
+	// activation by reading it through gNOI File.Get and comparing the
+	// device-supplied SHA256. Strongly recommended for production LocalPath
+	// upgrades.
+	// +optional
+	// +kubebuilder:validation:Pattern=`^[a-f0-9]{64}$`
+	LocalPathSHA256 string `json:"localPathSHA256,omitempty"`
 }
 
 // UpgradeWindow bounds when the upgrade may proceed past Pending.

--- a/charts/cisco-virtual-kubelet/crds/ops.cisco.vk_iosxeoperationalactions.yaml
+++ b/charts/cisco-virtual-kubelet/crds/ops.cisco.vk_iosxeoperationalactions.yaml
@@ -94,6 +94,7 @@ spec:
                       permissions:
                         description: Permissions is the UNIX octal mode (default 0o644).
                         format: int32
+                        maximum: 511
                         type: integer
                     required:
                     - configMapName
@@ -144,6 +145,7 @@ spec:
                         description: DelaySeconds before the reboot fires. Zero means
                           immediate.
                         format: int64
+                        maximum: 604800
                         minimum: 0
                         type: integer
                       force:
@@ -163,6 +165,19 @@ spec:
                 required:
                 - kind
                 type: object
+                x-kubernetes-validations:
+                - message: kind Reboot requires only the reboot args block
+                  rule: (self.kind == 'Reboot') == has(self.reboot)
+                - message: kind CancelReboot requires only the cancelReboot args block
+                  rule: (self.kind == 'CancelReboot') == has(self.cancelReboot)
+                - message: kind KillProcess requires only the killProcess args block
+                  rule: (self.kind == 'KillProcess') == has(self.killProcess)
+                - message: kind FilePut requires only the filePut args block
+                  rule: (self.kind == 'FilePut') == has(self.filePut)
+                - message: kind FileRemove requires only the fileRemove args block
+                  rule: (self.kind == 'FileRemove') == has(self.fileRemove)
+                - message: kind FactoryReset requires only the factoryReset args block
+                  rule: (self.kind == 'FactoryReset') == has(self.factoryReset)
               confirm:
                 description: |-
                   Confirm must equal the target device's metadata.name. This is a
@@ -185,6 +200,9 @@ spec:
             - confirm
             - deviceRef
             type: object
+            x-kubernetes-validations:
+            - message: IOSXEOperationalAction spec is immutable after creation
+              rule: self == oldSelf
           status:
             description: IOSXEOperationalActionStatus carries observed state.
             properties:
@@ -248,6 +266,12 @@ spec:
                   type: object
                 type: array
               failureReason:
+                type: string
+              invocationID:
+                description: |-
+                  InvocationID is set before the device-side RPC is dispatched. If the
+                  controller crashes while phase=Running, the next reconcile treats the
+                  action as already invoked and will not dispatch a second destructive RPC.
                 type: string
               message:
                 type: string

--- a/charts/cisco-virtual-kubelet/crds/ops.cisco.vk_iosxesoftwareupgrades.yaml
+++ b/charts/cisco-virtual-kubelet/crds/ops.cisco.vk_iosxesoftwareupgrades.yaml
@@ -195,10 +195,9 @@ spec:
               rollbackOnFailure:
                 default: true
                 description: |-
-                  RollbackOnFailure, when true, currently fails closed with
-                  RollbackNotImplemented if post-Verify the device is running a
-                  different version. Future releases will wire boot-variable rewrite
-                  plus System.Reboot behind this field. Default true.
+                  RollbackOnFailure, when true, attempts to reactivate the version
+                  that was running before this upgrade began when post-Verify reports
+                  a different version than TargetVersion. Default true.
                 type: boolean
               strategy:
                 default: Reload
@@ -341,6 +340,12 @@ spec:
                 - RolledBack
                 - RebootTimeout
                 - Cancelled
+                type: string
+              previousVersion:
+                description: |-
+                  PreviousVersion is the device-reported OS version captured before
+                  image activation. It is used as the rollback target when
+                  RollbackOnFailure is enabled.
                 type: string
               retryCount:
                 description: RetryCount tracks TransferInterrupted retries.

--- a/charts/cisco-virtual-kubelet/crds/ops.cisco.vk_iosxesoftwareupgrades.yaml
+++ b/charts/cisco-virtual-kubelet/crds/ops.cisco.vk_iosxesoftwareupgrades.yaml
@@ -106,6 +106,14 @@ spec:
                       Path must be an absolute IOS-XE filesystem path.
                     pattern: '^(flash|bootflash|harddisk):'
                     type: string
+                  localPathSHA256:
+                    description: |-
+                      LocalPathSHA256 optionally verifies the staged flash image before
+                      activation by reading it through gNOI File.Get and comparing the
+                      device-supplied SHA256. Strongly recommended for production LocalPath
+                      upgrades.
+                    pattern: ^[a-f0-9]{64}$
+                    type: string
                   sha256:
                     description: |-
                       SHA256 is the lowercase hex SHA-256 digest the reconciler asserts
@@ -187,10 +195,10 @@ spec:
               rollbackOnFailure:
                 default: true
                 description: |-
-                  RollbackOnFailure, when true, drives the RollingBack phase if
-                  post-Verify the device is running a different version. The
-                  fallback uses the device's prior boot variable plus one
-                  System.Reboot. Default true.
+                  RollbackOnFailure, when true, currently fails closed with
+                  RollbackNotImplemented if post-Verify the device is running a
+                  different version. Future releases will wire boot-variable rewrite
+                  plus System.Reboot behind this field. Default true.
                 type: boolean
               strategy:
                 default: Reload

--- a/charts/cisco-virtual-kubelet/templates/deployment.yaml
+++ b/charts/cisco-virtual-kubelet/templates/deployment.yaml
@@ -113,6 +113,14 @@ spec:
             - name: CISCO_VK_GNOI_DISABLED
               value: "1"
             {{- end }}
+            {{- if .Values.gnoi.enableSoftwareUpgrade }}
+            - name: CISCO_VK_ENABLE_IOSXE_SOFTWARE_UPGRADE
+              value: "1"
+            {{- end }}
+            {{- if .Values.gnoi.enableWriteClass }}
+            - name: CISCO_VK_ENABLE_WRITE_CLASS_GNOI
+              value: "1"
+            {{- end }}
             {{- if .Values.config.leaseNamespace }}
             # Shared cluster namespace for the per-(device,family)
             # arbitration leases. When set, every cisco-vk pod the

--- a/charts/cisco-virtual-kubelet/templates/vk-rbac.yaml
+++ b/charts/cisco-virtual-kubelet/templates/vk-rbac.yaml
@@ -159,10 +159,13 @@ rules:
   # --enable-write-class-gnoi on the per-device VK pod.
   - apiGroups: ["ops.cisco.vk"]
     resources: ["iosxeoperationalactions"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["ops.cisco.vk"]
     resources: ["iosxeoperationalactions/status"]
     verbs: ["get", "update", "patch"]
+  - apiGroups: ["ops.cisco.vk"]
+    resources: ["iosxeoperationalactions/finalizers"]
+    verbs: ["update"]
 ---
 # ClusterRoleBinding for the VK service account.
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/cisco-virtual-kubelet/values.schema.json
+++ b/charts/cisco-virtual-kubelet/values.schema.json
@@ -134,7 +134,7 @@
     "gnoi": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["insecure", "port", "disabled"],
+      "required": ["insecure", "port", "disabled", "enableSoftwareUpgrade", "enableWriteClass"],
       "properties": {
         "insecure": {
           "type": "boolean",
@@ -147,6 +147,14 @@
         "disabled": {
           "type": "boolean",
           "description": "Disable the per-device gNOI client even when the binary includes gNOI support."
+        },
+        "enableSoftwareUpgrade": {
+          "type": "boolean",
+          "description": "Enable the IOSXESoftwareUpgrade gNOI OS install/activate reconciler on per-device VK pods."
+        },
+        "enableWriteClass": {
+          "type": "boolean",
+          "description": "Enable write-class IOSXEOperationalAction gNOI operations such as Reboot, FactoryReset, FilePut, and FileRemove."
         }
       }
     },

--- a/charts/cisco-virtual-kubelet/values.yaml
+++ b/charts/cisco-virtual-kubelet/values.yaml
@@ -118,6 +118,14 @@ gnoi:
   # disabled sets CISCO_VK_GNOI_DISABLED and prevents CVK from constructing
   # the per-device gNOI client.
   disabled: false
+  # enableSoftwareUpgrade opts per-device VK pods into the IOSXESoftwareUpgrade
+  # reconciler. Disabled by default so a read-only gNOI deployment does not
+  # implicitly gain OS install/activate authority.
+  enableSoftwareUpgrade: false
+  # enableWriteClass opts per-device VK pods into IOSXEOperationalAction
+  # destructive/write-class gNOI operations such as Reboot, FactoryReset,
+  # FilePut, and FileRemove. Disabled by default.
+  enableWriteClass: false
 
 collector:
   # enabled deploys a small in-cluster OpenTelemetry Collector intended for

--- a/cmd/cisco-vk/config_reconciler.go
+++ b/cmd/cisco-vk/config_reconciler.go
@@ -74,20 +74,6 @@ import (
 	telemetryyang "github.com/cisco/virtual-kubelet-cisco/internal/telemetry/yang"
 )
 
-// staticGNOIProvider adapts a pre-built *gnoi.Client into the
-// {deviceoperation,softwareupgrade,operationalaction}.GNOIProvider
-// interfaces. The same client is shared across all three reconcilers
-// — the gNOI service stubs are stateless and the underlying conn is
-// pool-managed.
-type staticGNOIProvider struct{ c *gnoi.Client }
-
-func (s *staticGNOIProvider) GNOIClient(context.Context) (*gnoi.Client, error) {
-	if s == nil || s.c == nil {
-		return nil, fmt.Errorf("gnoi client not initialized")
-	}
-	return s.c, nil
-}
-
 // configReconcilerOptions is what startConfigReconciler needs from the
 // surrounding cisco-vk-run setup: device spec (for transport build) and
 // resolved password.
@@ -403,10 +389,11 @@ func startConfigReconciler(ctx context.Context, cfg *rest.Config, deviceName str
 	// wire the three reconcilers that consume it.
 	//
 	// Pool lifetime is bound to the surrounding ctx (the VK pod's run
-	// context). Control + bulk-transfer leases are held for the pod
-	// lifetime; releases fire on ctx.Done. If the gNOI server is not
-	// reachable at startup the dial is lazy — the conn materialises
-	// on first RPC, so a device that comes up after the VK pod is fine.
+	// context). Control is leased on first use, and bulk-transfer
+	// conns are leased only for File.Get/Put and OS.Install streams.
+	// If the gNOI server is not reachable at startup the dial is lazy
+	// — the conn materialises on first RPC, so a device that comes up
+	// after the VK pod is fine.
 	gnoiProv, gnoiCleanup := setupGNOI(ctx, opts)
 	if gnoiCleanup != nil {
 		go func() {

--- a/cmd/cisco-vk/config_reconciler.go
+++ b/cmd/cisco-vk/config_reconciler.go
@@ -59,6 +59,7 @@ import (
 	"github.com/cisco/virtual-kubelet-cisco/internal/drivers/iosxe"
 	"github.com/cisco/virtual-kubelet-cisco/internal/drivers/iosxe/configdriver/engine"
 	"github.com/cisco/virtual-kubelet-cisco/internal/drivers/iosxe/configdriver/transport"
+	"github.com/cisco/virtual-kubelet-cisco/internal/drivers/iosxe/devicegrpc"
 	"github.com/cisco/virtual-kubelet-cisco/internal/drivers/iosxe/gnoi"
 	"github.com/cisco/virtual-kubelet-cisco/internal/drivers/iosxe/telemetry"
 	"github.com/cisco/virtual-kubelet-cisco/internal/otelproviders"
@@ -93,6 +94,13 @@ func (s *staticGNOIProvider) GNOIClient(context.Context) (*gnoi.Client, error) {
 type configReconcilerOptions struct {
 	Spec     *ciskov1.DeviceSpec
 	Password string
+	// EnableWriteClassGNOI opt-ins destructive IOSXEOperationalAction
+	// handling. Default false keeps a gNOI-enabled read-only deployment
+	// from gaining reboot/factory-reset/file-write authority implicitly.
+	EnableWriteClassGNOI bool
+	// EnableIOSXESoftwareUpgrade opt-ins the multi-phase gNOI OS upgrade
+	// reconciler. Default false keeps upgrade RBAC and behavior explicit.
+	EnableIOSXESoftwareUpgrade bool
 	// SessionLock optionally serialises config-driver traffic
 	// against the apphosting driver. Recommended in production.
 	SessionLock *sync.Mutex
@@ -152,6 +160,10 @@ func startConfigReconciler(ctx context.Context, cfg *rest.Config, deviceName str
 	// in-process callers) won't double-register.
 	engine.RegisterMetrics(metrics.Registry)
 	transport.RegisterTransportMetrics(metrics.Registry)
+	gnoi.RegisterMetrics(metrics.Registry)
+	devicegrpc.RegisterMetrics(metrics.Registry)
+	softwareupgrade.RegisterMetrics(metrics.Registry)
+	operationalaction.RegisterMetrics(metrics.Registry)
 
 	// Event recorder: the reconciler emits one event per non-trivial
 	// per-family outcome and a terminal event per tick. The broadcaster
@@ -422,7 +434,7 @@ func startConfigReconciler(ctx context.Context, cfg *rest.Config, deviceName str
 		return fmt.Errorf("device operation SetupWithManager: %w", err)
 	}
 
-	if gnoiProv != nil {
+	if gnoiProv != nil && opts.EnableIOSXESoftwareUpgrade {
 		upgradeReconciler := &softwareupgrade.Reconciler{
 			Client:          mgr.GetClient(),
 			Reader:          mgr.GetAPIReader(),
@@ -437,7 +449,11 @@ func startConfigReconciler(ctx context.Context, cfg *rest.Config, deviceName str
 		if err := upgradeReconciler.SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("software upgrade SetupWithManager: %w", err)
 		}
+	} else if gnoiProv != nil {
+		log.G(ctx).Info("IOSXESoftwareUpgrade reconciler not registered; enable with --enable-iosxesoftwareupgrade or CISCO_VK_ENABLE_IOSXE_SOFTWARE_UPGRADE=true")
+	}
 
+	if gnoiProv != nil && opts.EnableWriteClassGNOI {
 		actionReconciler := &operationalaction.Reconciler{
 			Client:          mgr.GetClient(),
 			Reader:          mgr.GetAPIReader(),
@@ -450,6 +466,8 @@ func startConfigReconciler(ctx context.Context, cfg *rest.Config, deviceName str
 		if err := actionReconciler.SetupWithManager(mgr); err != nil {
 			return fmt.Errorf("operational action SetupWithManager: %w", err)
 		}
+	} else if gnoiProv != nil {
+		log.G(ctx).Info("IOSXEOperationalAction reconciler not registered; enable with --enable-write-class-gnoi or CISCO_VK_ENABLE_WRITE_CLASS_GNOI=true")
 	}
 
 	telemetryFactory, err := telemetry.NewDefaultSubscribeClientFactoryForDevice(opts.Spec, opts.Password)

--- a/cmd/cisco-vk/gnoi_wiring.go
+++ b/cmd/cisco-vk/gnoi_wiring.go
@@ -17,11 +17,14 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/virtual-kubelet/virtual-kubelet/log"
+	"google.golang.org/grpc"
 
 	ciskov1 "github.com/cisco/virtual-kubelet-cisco/api/v1alpha1"
 	"github.com/cisco/virtual-kubelet-cisco/internal/drivers/iosxe/devicegrpc"
@@ -44,20 +47,21 @@ const gNOIPortEnv = "CISCO_VK_GNOI_PORT"
 // `gnxi server` (insecure) line rather than `gnxi secure-server`.
 const gNOIInsecureEnv = "CISCO_VK_GNOI_INSECURE"
 
-// setupGNOI builds the per-device gRPC pool, leases the ClassControl
-// and ClassBulkTransfer connections, and assembles a *gnoi.Client.
-// The returned cleanup function releases both leases and closes the
-// pool; it is invoked by the caller when the surrounding ctx is done.
+// setupGNOI builds the per-device gRPC pool and returns a lazy,
+// resettable gNOI provider. The provider leases ClassControl on first
+// use and ClassBulkTransfer only for the duration of File.Get/Put or
+// OS.Install streams. The returned cleanup function releases leases
+// and closes the pool when the surrounding ctx is done.
 //
 // Returns (nil, nil) when:
 //   - The device spec is missing the address (defensive — usually
 //     caught earlier in startup).
 //   - Operators have set CISCO_VK_GNOI_DISABLED=1 to opt out.
 //
-// A nil GNOIProvider signals to the reconcilers that the gNOI
+// A nil gnoi.Provider signals to the reconcilers that the gNOI
 // dispatch path is unavailable; they fail fast with reason
 // GNOIUnsupported on any CR they receive.
-func setupGNOI(ctx context.Context, opts configReconcilerOptions) (*staticGNOIProvider, func()) {
+func setupGNOI(ctx context.Context, opts configReconcilerOptions) (gnoi.Provider, func()) {
 	if v := os.Getenv(gNOIDisabledEnv); v == "1" || strings.EqualFold(v, "true") {
 		log.G(ctx).Info("gNOI pillar disabled by CISCO_VK_GNOI_DISABLED")
 		return nil, nil
@@ -87,45 +91,88 @@ func setupGNOI(ctx context.Context, opts configReconcilerOptions) (*staticGNOIPr
 	pool := devicegrpc.New(dialCfg, nil)
 	key := devicegrpc.DeviceKey{Address: opts.Spec.Address, Port: port}
 
-	// Lease the two conns we hold for the lifetime of the VK pod.
-	// Bulk transfer is leased eagerly so OS.Install / File.Put can
-	// stream into it without re-dialing; the gRPC layer holds the
-	// underlying TCP connection idle until first use, so the cost
-	// of a held-but-unused lease is just a map entry.
-	controlLease, err := pool.Lease(ctx, key, devicegrpc.ClassControl)
-	if err != nil {
-		log.G(ctx).WithError(err).Warn("gNOI: ClassControl lease failed; gNOI pillar disabled for this device")
-		_ = pool.Close()
-		return nil, nil
-	}
-	bulkLease, err := pool.Lease(ctx, key, devicegrpc.ClassBulkTransfer)
-	if err != nil {
-		controlLease.Release()
-		_ = pool.Close()
-		log.G(ctx).WithError(err).Warn("gNOI: ClassBulkTransfer lease failed; gNOI pillar disabled for this device")
-		return nil, nil
+	provider := &pooledGNOIProvider{
+		pool:    pool,
+		key:     key,
+		auth:    dialCfg.AuthContext(),
+		address: opts.Spec.Address,
+		port:    port,
+		tls:     dialCfg.TLSConfig != nil,
 	}
 
+	log.G(ctx).Infof("gNOI: pillar enabled (%s:%d, tls=%v, lazy_bulk=true)", opts.Spec.Address, port, dialCfg.TLSConfig != nil)
+	return provider, provider.Close
+}
+
+type pooledGNOIProvider struct {
+	mu      sync.Mutex
+	pool    devicegrpc.Pool
+	key     devicegrpc.DeviceKey
+	auth    gnoi.AuthContext
+	address string
+	port    int
+	tls     bool
+
+	controlLease *devicegrpc.Lease
+	client       *gnoi.Client
+	closed       bool
+}
+
+func (p *pooledGNOIProvider) GNOIClient(ctx context.Context) (*gnoi.Client, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		return nil, fmt.Errorf("gnoi provider closed")
+	}
+	if p.client != nil {
+		return p.client, nil
+	}
+	controlLease, err := p.pool.Lease(ctx, p.key, devicegrpc.ClassControl)
+	if err != nil {
+		return nil, fmt.Errorf("gnoi ClassControl lease: %w", err)
+	}
 	client, err := gnoi.New(controlLease.Conn, gnoi.Options{
-		Auth:     dialCfg.AuthContext(),
-		BulkConn: bulkLease.Conn,
+		Auth:             p.auth,
+		BulkConnProvider: p.bulkConn,
 	})
 	if err != nil {
 		controlLease.Release()
-		bulkLease.Release()
-		_ = pool.Close()
-		log.G(ctx).WithError(err).Warn("gNOI: client construct failed; gNOI pillar disabled for this device")
-		return nil, nil
+		return nil, fmt.Errorf("gnoi client construct: %w", err)
 	}
+	p.controlLease = controlLease
+	p.client = client
+	return client, nil
+}
 
-	log.G(ctx).Infof("gNOI: pillar enabled (%s:%d, tls=%v)", opts.Spec.Address, port, dialCfg.TLSConfig != nil)
-
-	cleanup := func() {
-		controlLease.Release()
-		bulkLease.Release()
-		_ = pool.Close()
+func (p *pooledGNOIProvider) ResetGNOIClient(ctx context.Context) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.controlLease != nil {
+		p.controlLease.Release()
+		p.controlLease = nil
 	}
-	return &staticGNOIProvider{c: client}, cleanup
+	p.client = nil
+	log.G(ctx).Infof("gNOI: reset client leases for %s:%d", p.address, p.port)
+}
+
+func (p *pooledGNOIProvider) Close() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.closed = true
+	if p.controlLease != nil {
+		p.controlLease.Release()
+		p.controlLease = nil
+	}
+	p.client = nil
+	_ = p.pool.Close()
+}
+
+func (p *pooledGNOIProvider) bulkConn(ctx context.Context) (*grpc.ClientConn, func(), error) {
+	lease, err := p.pool.Lease(ctx, p.key, devicegrpc.ClassBulkTransfer)
+	if err != nil {
+		return nil, nil, fmt.Errorf("gnoi ClassBulkTransfer lease: %w", err)
+	}
+	return lease.Conn, lease.Release, nil
 }
 
 // gnoiPortForSpec picks the device-side gNOI port. Same heuristic the

--- a/cmd/cisco-vk/run.go
+++ b/cmd/cisco-vk/run.go
@@ -22,6 +22,7 @@ import (
 	"os/signal"
 	"path"
 	"runtime"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -62,6 +63,14 @@ var (
 	nodeName    string
 	tlsCertFile string
 	tlsKeyFile  string
+
+	enableWriteClassGNOI       bool
+	enableIOSXESoftwareUpgrade bool
+)
+
+const (
+	envEnableWriteClassGNOI       = "CISCO_VK_ENABLE_WRITE_CLASS_GNOI"
+	envEnableIOSXESoftwareUpgrade = "CISCO_VK_ENABLE_IOSXE_SOFTWARE_UPGRADE"
 )
 
 var runCmd = &cobra.Command{
@@ -85,6 +94,10 @@ func init() {
 		fmt.Sprintf("path to TLS certificate for the kubelet HTTPS listener (default: %s)", tlsutil.DefaultCertFile))
 	runCmd.Flags().StringVar(&tlsKeyFile, "tls-key-file", "",
 		fmt.Sprintf("path to TLS private key for the kubelet HTTPS listener (default: %s)", tlsutil.DefaultKeyFile))
+	runCmd.Flags().BoolVar(&enableWriteClassGNOI, "enable-write-class-gnoi", false,
+		"enable write-class gNOI reconcilers such as IOSXEOperationalAction (default: false)")
+	runCmd.Flags().BoolVar(&enableIOSXESoftwareUpgrade, "enable-iosxesoftwareupgrade", false,
+		"enable IOSXESoftwareUpgrade gNOI OS upgrade reconciler (default: false)")
 }
 
 // validateConfig checks if the config file exists at the given path
@@ -103,6 +116,18 @@ func validateLogLevel(level string) error {
 	default:
 		return fmt.Errorf("invalid log level: %q\n\nValid options are: debug, info, warn, error", level)
 	}
+}
+
+func flagOrEnvBool(flagValue bool, envName string) bool {
+	if flagValue {
+		return true
+	}
+	raw := os.Getenv(envName)
+	if raw == "" {
+		return false
+	}
+	parsed, err := strconv.ParseBool(raw)
+	return err == nil && parsed
 }
 
 func GetKubeConfig(kubeconfigFlag string) (*rest.Config, error) {
@@ -388,12 +413,14 @@ func runVirtualKubelet(cmd *cobra.Command, args []string) error {
 	if v := os.Getenv("DISABLE_IN_POD_CONFIG_RECONCILER"); v == "true" || v == "1" {
 		log.G(ctx).Info("DISABLE_IN_POD_CONFIG_RECONCILER set; skipping in-pod ConfigReconciler (aggregator-mode topology)")
 	} else if err := startConfigReconciler(ctx, kubeconfigCfg, effectiveNodeName, configReconcilerOptions{
-		Spec:               &appCfg.Device,
-		Password:           appCfg.Device.Password,
-		TelemetryProviders: telemetryProviders,
-		StateCache:         mdtStateCache,
-		AppEventConsumer:   appEventConsumer,
-		CorrelationCache:   traceCorrelationCache,
+		Spec:                       &appCfg.Device,
+		Password:                   appCfg.Device.Password,
+		EnableWriteClassGNOI:       flagOrEnvBool(enableWriteClassGNOI, envEnableWriteClassGNOI),
+		EnableIOSXESoftwareUpgrade: flagOrEnvBool(enableIOSXESoftwareUpgrade, envEnableIOSXESoftwareUpgrade),
+		TelemetryProviders:         telemetryProviders,
+		StateCache:                 mdtStateCache,
+		AppEventConsumer:           appEventConsumer,
+		CorrelationCache:           traceCorrelationCache,
 	}); err != nil {
 		log.G(ctx).WithError(err).Warn("IOSXEConfig reconciler not started; continuing without declarative config")
 	}

--- a/config/crd/ops.cisco.vk_iosxeoperationalactions.yaml
+++ b/config/crd/ops.cisco.vk_iosxeoperationalactions.yaml
@@ -94,6 +94,7 @@ spec:
                       permissions:
                         description: Permissions is the UNIX octal mode (default 0o644).
                         format: int32
+                        maximum: 511
                         type: integer
                     required:
                     - configMapName
@@ -144,6 +145,7 @@ spec:
                         description: DelaySeconds before the reboot fires. Zero means
                           immediate.
                         format: int64
+                        maximum: 604800
                         minimum: 0
                         type: integer
                       force:
@@ -163,6 +165,19 @@ spec:
                 required:
                 - kind
                 type: object
+                x-kubernetes-validations:
+                - message: kind Reboot requires only the reboot args block
+                  rule: (self.kind == 'Reboot') == has(self.reboot)
+                - message: kind CancelReboot requires only the cancelReboot args block
+                  rule: (self.kind == 'CancelReboot') == has(self.cancelReboot)
+                - message: kind KillProcess requires only the killProcess args block
+                  rule: (self.kind == 'KillProcess') == has(self.killProcess)
+                - message: kind FilePut requires only the filePut args block
+                  rule: (self.kind == 'FilePut') == has(self.filePut)
+                - message: kind FileRemove requires only the fileRemove args block
+                  rule: (self.kind == 'FileRemove') == has(self.fileRemove)
+                - message: kind FactoryReset requires only the factoryReset args block
+                  rule: (self.kind == 'FactoryReset') == has(self.factoryReset)
               confirm:
                 description: |-
                   Confirm must equal the target device's metadata.name. This is a
@@ -185,6 +200,9 @@ spec:
             - confirm
             - deviceRef
             type: object
+            x-kubernetes-validations:
+            - message: IOSXEOperationalAction spec is immutable after creation
+              rule: self == oldSelf
           status:
             description: IOSXEOperationalActionStatus carries observed state.
             properties:
@@ -248,6 +266,12 @@ spec:
                   type: object
                 type: array
               failureReason:
+                type: string
+              invocationID:
+                description: |-
+                  InvocationID is set before the device-side RPC is dispatched. If the
+                  controller crashes while phase=Running, the next reconcile treats the
+                  action as already invoked and will not dispatch a second destructive RPC.
                 type: string
               message:
                 type: string

--- a/config/crd/ops.cisco.vk_iosxesoftwareupgrades.yaml
+++ b/config/crd/ops.cisco.vk_iosxesoftwareupgrades.yaml
@@ -195,10 +195,9 @@ spec:
               rollbackOnFailure:
                 default: true
                 description: |-
-                  RollbackOnFailure, when true, currently fails closed with
-                  RollbackNotImplemented if post-Verify the device is running a
-                  different version. Future releases will wire boot-variable rewrite
-                  plus System.Reboot behind this field. Default true.
+                  RollbackOnFailure, when true, attempts to reactivate the version
+                  that was running before this upgrade began when post-Verify reports
+                  a different version than TargetVersion. Default true.
                 type: boolean
               strategy:
                 default: Reload
@@ -341,6 +340,12 @@ spec:
                 - RolledBack
                 - RebootTimeout
                 - Cancelled
+                type: string
+              previousVersion:
+                description: |-
+                  PreviousVersion is the device-reported OS version captured before
+                  image activation. It is used as the rollback target when
+                  RollbackOnFailure is enabled.
                 type: string
               retryCount:
                 description: RetryCount tracks TransferInterrupted retries.

--- a/config/crd/ops.cisco.vk_iosxesoftwareupgrades.yaml
+++ b/config/crd/ops.cisco.vk_iosxesoftwareupgrades.yaml
@@ -106,6 +106,14 @@ spec:
                       Path must be an absolute IOS-XE filesystem path.
                     pattern: '^(flash|bootflash|harddisk):'
                     type: string
+                  localPathSHA256:
+                    description: |-
+                      LocalPathSHA256 optionally verifies the staged flash image before
+                      activation by reading it through gNOI File.Get and comparing the
+                      device-supplied SHA256. Strongly recommended for production LocalPath
+                      upgrades.
+                    pattern: ^[a-f0-9]{64}$
+                    type: string
                   sha256:
                     description: |-
                       SHA256 is the lowercase hex SHA-256 digest the reconciler asserts
@@ -187,10 +195,10 @@ spec:
               rollbackOnFailure:
                 default: true
                 description: |-
-                  RollbackOnFailure, when true, drives the RollingBack phase if
-                  post-Verify the device is running a different version. The
-                  fallback uses the device's prior boot variable plus one
-                  System.Reboot. Default true.
+                  RollbackOnFailure, when true, currently fails closed with
+                  RollbackNotImplemented if post-Verify the device is running a
+                  different version. Future releases will wire boot-variable rewrite
+                  plus System.Reboot behind this field. Default true.
                 type: boolean
               strategy:
                 default: Reload

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -463,8 +463,9 @@ reconciler does *not* follow with `System.Reboot`. The `NoReboot`
 strategy short-circuits to Succeeded; the `Reload` strategy enters
 `AwaitingReachability` and polls `System.Time` until the device is
 back, then runs `OS.Verify`. Verify mismatch with
-`RollbackOnFailure=true` fails closed with `RollbackNotImplemented`
-until boot-variable rewrite rollback is implemented.
+`RollbackOnFailure=true` enters `RollingBack`, re-activates the
+previously observed running version, and verifies that version before
+terminating as `RolledBack`.
 
 **IOS-XE capability matrix.** Per the IOS-XE 17.15 Programmability
 Guide, only OS, Cert, Bootstrapping, and FactoryReset are

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -441,8 +441,12 @@ and short-circuits subsequent calls with a typed `*ErrServiceUnsupported`.
 The split lets operators grant `DeviceOperation` access to dashboards
 or low-trust automation without giving them mutation power on the
 device. The write-class `IOSXEOperationalAction` is gated by
-`--enable-write-class-gnoi` on the per-device VK pod and requires a
-`spec.confirm` field matching the target device's name as a typo guard.
+`--enable-write-class-gnoi` / Helm `gnoi.enableWriteClass` on the
+per-device VK pod and requires a `spec.confirm` field matching the
+target device's name as a typo guard. `IOSXESoftwareUpgrade` is gated
+separately by `--enable-iosxesoftwareupgrade` / Helm
+`gnoi.enableSoftwareUpgrade`, so read-only gNOI access does not
+implicitly enable reboot, factory-reset, file-write, or OS activation.
 
 **Software upgrade state machine** (IOSXESoftwareUpgrade):
 
@@ -450,17 +454,17 @@ device. The write-class `IOSXEOperationalAction` is gated by
 Pending → Resolving → Transferring → Activating → AwaitingReachability → Verifying → Succeeded
    │            │           │            │                 │                 │
    ↓            ↓           ↓            ↓                 ↓                 ↓
-PreflightFailed │      TransferInterrupted ─┘         RebootTimeout      RollingBack → RolledBack
-              Failed                                                          ↓
-                                                                            Failed
+PreflightFailed │      TransferInterrupted ─┘         RebootTimeout       Failed
+              Failed                                                   (rollback pending)
 ```
 
 `OS.Activate` reboots the device itself per the gNOI spec; the
 reconciler does *not* follow with `System.Reboot`. The `NoReboot`
 strategy short-circuits to Succeeded; the `Reload` strategy enters
 `AwaitingReachability` and polls `System.Time` until the device is
-back, then runs `OS.Verify`. Verify mismatch with `RollbackOnFailure=true`
-enters `RollingBack` (boot-variable rewrite is a Phase D follow-up).
+back, then runs `OS.Verify`. Verify mismatch with
+`RollbackOnFailure=true` fails closed with `RollbackNotImplemented`
+until boot-variable rewrite rollback is implemented.
 
 **IOS-XE capability matrix.** Per the IOS-XE 17.15 Programmability
 Guide, only OS, Cert, Bootstrapping, and FactoryReset are

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -127,6 +127,23 @@ All metrics are type `gauge`. The base set works on any driver; the topology-der
 | `cisco_device_storage_used_bytes` | — | IOx subsystem storage in use |
 | `cisco_device_storage_total_bytes` | — | IOx subsystem storage quota |
 
+#### gNOI lifecycle metrics
+
+These metrics are registered when the corresponding controllers and gNOI
+client packages are linked into the process. The write-class and software
+upgrade reconcilers still require their enablement flags before they act on
+CRs.
+
+| Metric | Labels | Notes |
+|---|---|---|
+| `cisco_vk_gnoi_rpc_total` | `service`, `outcome` | gNOI RPC outcomes, including `ok`, `unimplemented`, `unavailable`, and other error classes. |
+| `cisco_vk_gnoi_capability_cache_total` | `service`, `result` | Capability cache hit, miss, expiration, pin, and fail-fast decisions. |
+| `cisco_vk_devicegrpc_lease_events_total` | `class`, `event` | Workload-classed gRPC pool lease and release events. |
+| `cisco_vk_devicegrpc_outstanding_leases` | `class` | Current outstanding gRPC pool leases. |
+| `cisco_vk_devicegrpc_close_leak_detected_total` | `class` | Outstanding leases observed when a pool closes. |
+| `cisco_vk_iosxe_software_upgrade_phase_transitions_total` | `device`, `target_version`, `from`, `to`, `reason` | Software upgrade state transitions. |
+| `cisco_vk_iosxe_operational_action_transitions_total` | `device`, `kind`, `phase`, `reason` | Write-class action phase transitions and terminal outcomes. |
+
 #### Interfaces (TopologyProvider)
 
 | Metric | Labels | Notes |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -52,7 +52,10 @@ truncated preview in `.status.outputs[].output` and records
 `configmap://default/capture-output/output`. Captures larger than 900 KiB are
 rejected with `Ready=False, reason=ArtifactTooLarge`.
 
-Write-class operations such as reload, factory reset, and config push are intentionally not implemented. They require the later multi-tenancy, admission, and RBAC split described in the unified architecture plan.
+Write-class gNOI operations are implemented as a separate
+`IOSXEOperationalAction` CRD. They are disabled unless the per-device VK is
+started with `--enable-write-class-gnoi` / `CISCO_VK_ENABLE_WRITE_CLASS_GNOI`.
+Keep the flag off for read-only DeviceOperation deployments.
 
 ## Implementation Boundary
 
@@ -60,11 +63,84 @@ The v1alpha1 controller intentionally keeps the three read-only kinds in one
 small reconciler because they share the same validation, transport, redaction,
 inline output, TTL, and status machinery.
 
-That is not the intended shape for write-class operations. Before any operation
-can change device state, each kind must move behind its own reconciler or
-capability-specific dispatcher with independent validation, RBAC, audit policy,
-idempotency, cancellation, and artifact handling. This is the planned split for
-reload, config push, factory reset, and future packet-capture setup flows.
+Write-class operations intentionally do not reuse this reconciler. They are
+handled by `IOSXEOperationalAction`, which has its own RBAC, finalizer,
+confirmation guard, invocation ID, Kubernetes events, and one-shot dispatch
+rules.
+
+## Write-Class Actions
+
+`IOSXEOperationalAction` supports:
+
+- `Reboot`
+- `CancelReboot`
+- `KillProcess`
+- `FilePut`
+- `FileRemove`
+- `FactoryReset`
+
+Every action targets exactly one `CiscoDevice` and must set
+`spec.confirm` to the target device name. The spec is immutable after create,
+and the action request must contain exactly the args block matching
+`spec.action.kind`.
+
+Example reboot:
+
+```yaml
+apiVersion: ops.cisco.vk/v1alpha1
+kind: IOSXEOperationalAction
+metadata:
+  name: reload-cat9k-smoke
+spec:
+  deviceRef:
+    name: cat9k-smoke
+  confirm: cat9k-smoke
+  action:
+    kind: Reboot
+    reboot:
+      method: COLD
+      delaySeconds: 0
+      message: "maintenance reload"
+```
+
+Lifecycle:
+
+- `Pending` action CRs are validated and marked `Running` before the gNOI RPC
+  is dispatched.
+- A `Running` action is never dispatched a second time. If the controller dies
+  after the device-side invocation, operators must create a new CR to retry.
+- Terminal phases are `Succeeded`, `Failed`, and `Rejected`.
+- The finalizer is retained while an invocation is in progress so a delete
+  request cannot erase the audit trail before completion.
+- Normal events are emitted for `Running` and `Succeeded`; Warning events are
+  emitted for `Rejected`, `Failed`, and delete-pending audit preservation.
+
+`FactoryReset` should be enabled last in any rollout. Prefer namespace-scoped
+RBAC for the operators allowed to create these CRs, and keep read-only
+`DeviceOperation` RBAC separate from write-class action RBAC.
+
+## Software Upgrades
+
+`IOSXESoftwareUpgrade` drives the gNOI OS install, activate, reachability, and
+verify flow. It is disabled unless the per-device VK is started with
+`--enable-iosxesoftwareupgrade` /
+`CISCO_VK_ENABLE_IOSXE_SOFTWARE_UPGRADE`.
+
+Use exactly one image source:
+
+- `url` plus `sha256`
+- `configMapRef`
+- `localPath`
+
+For `localPath`, use `localPathSHA256` when the device supports gNOI File.Get
+hash reporting. Without that field, CVK can activate a staged image but cannot
+verify the local flash file before activation.
+
+Rollback is intentionally fail-closed today. If `rollbackOnFailure` is true
+and post-activation verification does not converge, the reconciler reports
+`RollbackNotImplemented` instead of pretending to have rewritten boot
+variables. Treat rollback as an operator-run recovery step until boot-variable
+rollback is implemented.
 
 ## RBAC
 
@@ -75,9 +151,8 @@ only for `ttlSecondsAfterFinished` cleanup. Operation results are written
 through `deviceoperations/status`.
 
 Operators who create `DeviceOperation` objects directly should receive their
-own namespace-scoped RBAC. Write-class operations will require separate
-resources or verbs plus admission policy; they should not reuse the read-only
-v1alpha1 permission set.
+own namespace-scoped RBAC. Write-class actions and software upgrades use
+separate CRDs and should receive separate RBAC grants.
 
 ## Admin Exec Wrapper
 
@@ -95,8 +170,10 @@ completion.
 The following items are deliberately outside the current read-only v1alpha1
 surface:
 
-- Per-kind reconcilers and capability maps before write operations.
-- Tenant ownership/admission checks before write-class CRDs.
+- Tenant ownership/admission checks before promoting write-class CRDs beyond
+  tightly controlled namespaces.
 - Conversion webhook scaffolding before promotion beyond `v1alpha1`.
 - External artifact sinks beyond the in-namespace ConfigMap backing for large
   packet-capture output.
+- Automatic software-upgrade rollback. Current behavior is fail-closed with
+  `RollbackNotImplemented`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -136,11 +136,10 @@ For `localPath`, use `localPathSHA256` when the device supports gNOI File.Get
 hash reporting. Without that field, CVK can activate a staged image but cannot
 verify the local flash file before activation.
 
-Rollback is intentionally fail-closed today. If `rollbackOnFailure` is true
-and post-activation verification does not converge, the reconciler reports
-`RollbackNotImplemented` instead of pretending to have rewritten boot
-variables. Treat rollback as an operator-run recovery step until boot-variable
-rollback is implemented.
+If `rollbackOnFailure` is true and post-activation verification reports a
+different running version than the requested target, the reconciler enters
+`RollingBack`, re-activates the previously observed running version, and
+terminates as `RolledBack` once `OS.Verify` confirms that version.
 
 ## RBAC
 
@@ -175,5 +174,5 @@ surface:
 - Conversion webhook scaffolding before promotion beyond `v1alpha1`.
 - External artifact sinks beyond the in-namespace ConfigMap backing for large
   packet-capture output.
-- Automatic software-upgrade rollback. Current behavior is fail-closed with
-  `RollbackNotImplemented`.
+- Cross-device or multi-supervisor rollback policy beyond re-activating the
+  previously observed single-device version.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -179,6 +179,73 @@ Expected setup: your Prometheus is already scraping kubelets (`kube-prometheus-s
 kubectl get --raw "/api/v1/nodes/<name>/proxy/metrics/resource" | grep cisco_device
 ```
 
+---
+
+## gNOI actions or software upgrades do nothing
+
+Both write-class gNOI surfaces are opt-in on the per-device VK pod:
+
+- `IOSXEOperationalAction` requires `--enable-write-class-gnoi` or
+  `CISCO_VK_ENABLE_WRITE_CLASS_GNOI=true`.
+- `IOSXESoftwareUpgrade` requires `--enable-iosxesoftwareupgrade` or
+  `CISCO_VK_ENABLE_IOSXE_SOFTWARE_UPGRADE=true`.
+
+Check the VK pod args and logs:
+
+```bash
+kubectl -n <device-namespace> get deploy <device-name>-vk -o yaml | grep -E "enable-write-class-gnoi|enable-iosxesoftwareupgrade"
+kubectl -n <device-namespace> logs deploy/<device-name>-vk --tail=200 | grep -i gnoi
+```
+
+If the CR remains untouched, verify the `spec.deviceRef.name` matches the
+device worker's `CiscoDevice` name and that the VK service account can update
+the CR status and finalizer subresources.
+
+---
+
+## IOSXEOperationalAction is rejected
+
+Common rejection reasons:
+
+- `ConfirmMismatch` — `spec.confirm` must exactly equal
+  `spec.deviceRef.name`.
+- `InvalidAction` — exactly one typed args block must match
+  `spec.action.kind`.
+- Kubernetes admission rejects updates because `spec` is immutable after
+  creation. Create a new action CR for a changed request.
+
+For actions that reach `Running` and then fail, inspect both events and status:
+
+```bash
+kubectl describe iosxeoperationalaction <name>
+kubectl get events --field-selector involvedObject.name=<name>
+```
+
+`Running` means the controller may already have invoked the device-side RPC.
+The reconciler will not dispatch the same CR again after a restart.
+
+---
+
+## IOSXESoftwareUpgrade fails during image resolution or transfer
+
+For URL sources, `imageSource.sha256` is required. Credential-bearing URLs are
+redacted before they are written to CR status, events, or logs. For SCP/SFTP,
+host-key verification is required unless the operator explicitly enables the
+lab-only escape hatch:
+
+```bash
+CISCO_VK_UPGRADE_ALLOW_INSECURE_SSH=true
+```
+
+When using `localPath`, add `localPathSHA256` if the device supports gNOI
+File.Get. A mismatch fails before activation with `LocalPathHashMismatch`.
+
+Transfer interruptions move to `TransferInterrupted` and retry according to
+`spec.maxRetries` unless `spec.resumePolicy: Abort` is set.
+
+Rollback is not automatic. A verify mismatch with `rollbackOnFailure: true`
+currently fails closed with `RollbackNotImplemented`.
+
 **If the raw endpoint returns metrics but Prometheus doesn't see them:**
 
 - The node ServiceMonitor isn't matching (check labels).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -243,8 +243,9 @@ File.Get. A mismatch fails before activation with `LocalPathHashMismatch`.
 Transfer interruptions move to `TransferInterrupted` and retry according to
 `spec.maxRetries` unless `spec.resumePolicy: Abort` is set.
 
-Rollback is not automatic. A verify mismatch with `rollbackOnFailure: true`
-currently fails closed with `RollbackNotImplemented`.
+With `rollbackOnFailure: true`, a verify mismatch enters `RollingBack` and
+attempts to re-activate the previously observed running version. If no previous
+version was captured, the CR fails with `RollbackVersionMissing`.
 
 **If the raw endpoint returns metrics but Prometheus doesn't see them:**
 

--- a/internal/controller/ciscodevice_controller.go
+++ b/internal/controller/ciscodevice_controller.go
@@ -65,6 +65,12 @@ const (
 	DefaultImage = "ghcr.io/cisco/virtual-kubelet-cisco:latest"
 	// DefaultServiceAccount is the shared service account used by all VK deployments.
 	DefaultServiceAccount = "cisco-virtual-kubelet"
+	// virtualKubeletNodeLabelKey/Value are applied to nodes registered by the
+	// per-device VK process. The controller-created per-device VK pods must
+	// avoid those nodes or Kubernetes can recursively schedule one device's VK
+	// process as an app-hosted workload on another device.
+	virtualKubeletNodeLabelKey   = "type"
+	virtualKubeletNodeLabelValue = "virtual-kubelet"
 	// ForcePrereqsSkipAnnotation lets an operator unblock CiscoDevice deletion
 	// when prereq relinquish cannot converge and accepted orphaned config.
 	ForcePrereqsSkipAnnotation    = "config.cisco.vk/force-prereqs-skip"
@@ -491,6 +497,7 @@ func (r *CiscoDeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			},
 			// Use shared service account with VK RBAC permissions
 			ServiceAccountName: serviceAccount,
+			Affinity:           perDeviceVKNodeAffinity(),
 		}
 
 		return controllerutil.SetControllerReference(&device, deploy, r.Scheme)
@@ -600,6 +607,26 @@ func perDeviceDeploymentLabels(deviceName string) map[string]string {
 		"app.kubernetes.io/name":       "cisco-vk",
 		"app.kubernetes.io/instance":   deviceName,
 		"app.kubernetes.io/managed-by": "ciscodevice-controller",
+	}
+}
+
+func perDeviceVKNodeAffinity() *corev1.Affinity {
+	return &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      virtualKubeletNodeLabelKey,
+								Operator: corev1.NodeSelectorOpNotIn,
+								Values:   []string{virtualKubeletNodeLabelValue},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 }
 

--- a/internal/controller/ciscodevice_controller.go
+++ b/internal/controller/ciscodevice_controller.go
@@ -80,6 +80,8 @@ const (
 	envCVKGNOIInsecure          = "CISCO_VK_GNOI_INSECURE"
 	envCVKGNOIPort              = "CISCO_VK_GNOI_PORT"
 	envCVKGNOIDisabled          = "CISCO_VK_GNOI_DISABLED"
+	envCVKEnableWriteClassGNOI  = "CISCO_VK_ENABLE_WRITE_CLASS_GNOI"
+	envCVKEnableSoftwareUpgrade = "CISCO_VK_ENABLE_IOSXE_SOFTWARE_UPGRADE"
 	envConfigYANGValidation     = "CONFIG_YANG_VALIDATION"
 )
 
@@ -107,6 +109,8 @@ var telemetryEnvPropagationNames = []string{
 	envCVKGNOIInsecure,
 	envCVKGNOIPort,
 	envCVKGNOIDisabled,
+	envCVKEnableWriteClassGNOI,
+	envCVKEnableSoftwareUpgrade,
 	envConfigYANGValidation,
 }
 

--- a/internal/controller/ciscodevice_controller_test.go
+++ b/internal/controller/ciscodevice_controller_test.go
@@ -196,6 +196,21 @@ func TestReconcile_CreatesDeployment(t *testing.T) {
 	if got := deploy.Spec.Template.Spec.ServiceAccountName; got != "test-sa" {
 		t.Errorf("expected service account test-sa, got %q", got)
 	}
+	affinity := deploy.Spec.Template.Spec.Affinity
+	if affinity == nil ||
+		affinity.NodeAffinity == nil ||
+		affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil ||
+		len(affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms) != 1 ||
+		len(affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions) != 1 {
+		t.Fatalf("expected per-device VK pod to exclude virtual-kubelet nodes, got affinity=%#v", affinity)
+	}
+	requirement := affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions[0]
+	if requirement.Key != virtualKubeletNodeLabelKey ||
+		requirement.Operator != corev1.NodeSelectorOpNotIn ||
+		len(requirement.Values) != 1 ||
+		requirement.Values[0] != virtualKubeletNodeLabelValue {
+		t.Fatalf("unexpected virtual-kubelet node exclusion requirement: %#v", requirement)
+	}
 	args := deploy.Spec.Template.Spec.Containers[0].Args
 	if len(args) == 0 || args[0] != "run" {
 		t.Errorf("expected first arg to be 'run', got %v", args)

--- a/internal/drivers/iosxe/client.go
+++ b/internal/drivers/iosxe/client.go
@@ -64,7 +64,14 @@ func (d *XEDriver) CreateAppHostingApp(ctx context.Context, appConfig *AppHostin
 	cfgPath := "/restconf/data/Cisco-IOS-XE-app-hosting-cfg:app-hosting-cfg-data/apps"
 
 	if err := d.client.Post(ctx, cfgPath, appConfig.Spec.DeviceConfig, d.marshaller); err != nil {
-		return fmt.Errorf("AppHosting config failed for app %s: %w", appConfig.AppName(), err)
+		if isRESTCONFDataExists(err) {
+			log.G(ctx).Infof("AppHosting config for app %s already exists; reconciling existing app", appConfig.AppName())
+			if handled, convergeErr := d.convergeExistingApp(ctx, appConfig, timeout); handled {
+				return convergeErr
+			}
+		} else {
+			return fmt.Errorf("AppHosting config failed for app %s: %w", appConfig.AppName(), err)
+		}
 	}
 
 	// For all paths (local and HTTP), call InstallApp
@@ -164,6 +171,43 @@ func (d *XEDriver) activateAndStart(ctx context.Context, appConfig *AppHostingCo
 		return fmt.Errorf("app %s did not reach RUNNING: %w", appConfig.AppName(), err)
 	}
 	return nil
+}
+
+func (d *XEDriver) startAndWait(ctx context.Context, appConfig *AppHostingConfig, timeout time.Duration) error {
+	if err := d.StartApp(ctx, appConfig.AppName()); err != nil {
+		return fmt.Errorf("failed to start app %s: %w", appConfig.AppName(), err)
+	}
+	if err := d.WaitForAppStatus(ctx, appConfig.AppName(), "RUNNING", timeout); err != nil {
+		return fmt.Errorf("app %s did not reach RUNNING after start: %w", appConfig.AppName(), err)
+	}
+	return nil
+}
+
+func (d *XEDriver) convergeExistingApp(ctx context.Context, appConfig *AppHostingConfig, timeout time.Duration) (bool, error) {
+	obs := d.getAppObservation(ctx, appConfig.AppName())
+	switch obs.State {
+	case "RUNNING":
+		return true, nil
+	case "ACTIVATED", "STOPPED":
+		return true, d.startAndWait(ctx, appConfig, timeout)
+	case "DEPLOYED":
+		return true, d.activateAndStart(ctx, appConfig, timeout)
+	case "INSTALLING":
+		if err := d.WaitForAppStatus(ctx, appConfig.AppName(), "DEPLOYED", timeout); err != nil {
+			return true, fmt.Errorf("app %s did not reach DEPLOYED while reconciling existing config: %w", appConfig.AppName(), err)
+		}
+		return true, d.activateAndStart(ctx, appConfig, timeout)
+	default:
+		return false, nil
+	}
+}
+
+func isRESTCONFDataExists(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "409 Conflict") && strings.Contains(msg, "data-exists")
 }
 
 // copyFallbackToFlash performs the HTTP-to-flash copy fallback sequence:

--- a/internal/drivers/iosxe/client_test.go
+++ b/internal/drivers/iosxe/client_test.go
@@ -449,6 +449,59 @@ func TestCreateAppHostingApp_DockerResource_FlashImage(t *testing.T) {
 	}
 }
 
+func TestCreateAppHostingApp_ConfigAlreadyExistsActivatedStartsAndWaits(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		started bool
+	)
+	cfgPath := "/restconf/data/Cisco-IOS-XE-app-hosting-cfg:app-hosting-cfg-data/apps"
+	rpcPath := "/restconf/operations/Cisco-IOS-XE-rpc:app-hosting"
+
+	fc := &fakeNetworkClient{}
+	fc.postHook = func(path string, payload any) error {
+		mu.Lock()
+		defer mu.Unlock()
+		if path == cfgPath {
+			return errors.New(`request failed with status 409 Conflict: {"ietf-restconf:errors":{"error":[{"error-tag":"data-exists"}]}}`)
+		}
+		if path == rpcPath {
+			if m, ok := payload.(map[string]interface{}); ok {
+				if _, isStart := m["start"]; isStart {
+					started = true
+				}
+			}
+		}
+		return nil
+	}
+	fc.getHook = func(_ string, result any) error {
+		root, ok := result.(*Cisco_IOS_XEAppHostingOper_AppHostingOperData)
+		if !ok {
+			return nil
+		}
+		mu.Lock()
+		s := started
+		mu.Unlock()
+		if s {
+			*root = *operResponse("test-app", "RUNNING")
+		} else {
+			*root = *operResponse("test-app", "ACTIVATED")
+		}
+		return nil
+	}
+
+	d := newTestDriver(fc)
+	cfg := minimalDockerResourceConfig("flash:app.tar", v1.PullIfNotPresent, 200*time.Millisecond)
+
+	if err := d.CreateAppHostingApp(context.Background(), cfg); err != nil {
+		t.Fatalf("CreateAppHostingApp: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if !started {
+		t.Fatal("expected existing ACTIVATED app to be started")
+	}
+}
+
 func TestCreateAppHostingApp_DockerResource_HTTPPrimarySuccess(t *testing.T) {
 	// DockerResource + HTTP: device pull succeeds → DEPLOYED → ActivateApp → StartApp → RUNNING
 	var (

--- a/internal/drivers/iosxe/client_test.go
+++ b/internal/drivers/iosxe/client_test.go
@@ -32,9 +32,10 @@ import (
 // ── Test infrastructure ───────────────────────────────────────────────────────
 
 type fakeNetworkClient struct {
-	mu       sync.Mutex
-	postHook func(path string, payload any) error
-	getHook  func(path string, result any) error
+	mu         sync.Mutex
+	postHook   func(path string, payload any) error
+	getHook    func(path string, result any) error
+	deleteHook func(path string) error
 }
 
 func (f *fakeNetworkClient) Post(_ context.Context, path string, payload any, _ func(any) ([]byte, error)) error {
@@ -61,7 +62,13 @@ func (f *fakeNetworkClient) Patch(_ context.Context, _ string, _ any, _ func(any
 	return nil
 }
 
-func (f *fakeNetworkClient) Delete(_ context.Context, _ string) error {
+func (f *fakeNetworkClient) Delete(_ context.Context, path string) error {
+	f.mu.Lock()
+	h := f.deleteHook
+	f.mu.Unlock()
+	if h != nil {
+		return h(path)
+	}
 	return nil
 }
 

--- a/internal/drivers/iosxe/configdriver/engine/metrics.go
+++ b/internal/drivers/iosxe/configdriver/engine/metrics.go
@@ -81,7 +81,7 @@ func RecordDriftTruncated(device string, dropped int) {
 
 // RecordDriftTruncatedForRelease bumps the truncation counter with an
 // explicit YANG release label. Older callers use RecordDriftTruncated
-// and land on release=unknown.
+// and land on an empty release label.
 func RecordDriftTruncatedForRelease(device, release string, dropped int) {
 	if driftEntriesTruncated == nil || dropped <= 0 {
 		return
@@ -224,7 +224,7 @@ func transportKindLabel(t transport.Interface) string {
 
 func releaseLabel(release string) string {
 	if release == "" {
-		return "unknown"
+		return ""
 	}
 	return release
 }

--- a/internal/drivers/iosxe/configdriver/transport/metrics.go
+++ b/internal/drivers/iosxe/configdriver/transport/metrics.go
@@ -66,7 +66,7 @@ func recordSubscribeDropped(device string) {
 
 func releaseLabel(release string) string {
 	if release == "" {
-		return "unknown"
+		return ""
 	}
 	return release
 }

--- a/internal/drivers/iosxe/configdriver/transport/ssh_cli.go
+++ b/internal/drivers/iosxe/configdriver/transport/ssh_cli.go
@@ -134,11 +134,10 @@ func runShowCommandsViaSSH(cfg sshCLIConfig, commands []string) ([]CommandResult
 		return nil, fmt.Errorf("ssh-cli: shell: %w", err)
 	}
 
-	// Match the IOS prompt at end-of-line. IOS prompts look like
-	// `Edge-9K#` or `Edge-9K(config)#`; we accept both. Anchor on
-	// `\n<word>(...)#?\s*$` (or `>` for non-enable) and tolerate
-	// trailing whitespace.
-	promptRe := regexp.MustCompile(`(?m)^[A-Za-z0-9._-]+(?:\([^)]+\))?[#>]\s*$`)
+	// Match only a prompt on the final line of the accumulated buffer.
+	// Using multiline `$` here lets a stale prompt at the top of a PTY
+	// transcript terminate the read before the command output arrives.
+	promptRe := iosPromptAtEndRe
 
 	rb := newSSHReadBuffer(stdout, timeout)
 
@@ -291,5 +290,6 @@ func trimEchoAndPrompt(body, cmd string) string {
 }
 
 var ciscoPromptRe = regexp.MustCompile(`^[A-Za-z0-9._-]+(?:\([^)]+\))?[#>]\s*$`)
+var iosPromptAtEndRe = regexp.MustCompile(`(?:^|\r?\n)[A-Za-z0-9._-]+(?:\([^)]+\))?[#>][ \t\r\n]*$`)
 
 func isCiscoPrompt(line string) bool { return ciscoPromptRe.MatchString(line) }

--- a/internal/drivers/iosxe/configdriver/transport/ssh_cli_test.go
+++ b/internal/drivers/iosxe/configdriver/transport/ssh_cli_test.go
@@ -14,7 +14,11 @@
 
 package transport
 
-import "testing"
+import (
+	"strings"
+	"testing"
+	"time"
+)
 
 // TestIsCiscoPrompt covers the prompt patterns the SSH-CLI helper
 // matches against to decide where one command's output ends.
@@ -97,5 +101,16 @@ func TestTrimEchoAndPrompt(t *testing.T) {
 				t.Errorf("got:\n%q\nwant:\n%q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestReadUntilPromptRequiresFinalPrompt(t *testing.T) {
+	rb := newSSHReadBuffer(strings.NewReader("Edge-9K#\nCisco IOS XE Software, Version 17.18.2\nEdge-9K#"), time.Second)
+	got, err := rb.readUntilPromptOrTimeout(iosPromptAtEndRe)
+	if err != nil {
+		t.Fatalf("readUntilPromptOrTimeout: %v", err)
+	}
+	if !strings.Contains(got, "Cisco IOS XE Software") {
+		t.Fatalf("read stopped before command output; got %q", got)
 	}
 }

--- a/internal/drivers/iosxe/configdriver/writers/aaa.go
+++ b/internal/drivers/iosxe/configdriver/writers/aaa.go
@@ -93,24 +93,36 @@ var aaaLeaves = []aaaLeaf{
 	},
 }
 
-type aaaWriter struct{}
+type aaaWriter struct {
+	resolver *OverrideResolver
+}
 
 func init() { Override(aaaWriter{}) }
 
+func (w aaaWriter) withResolver(r *OverrideResolver) SectionWriter {
+	w.resolver = r
+	return w
+}
+
+func (w aaaWriter) resolverForUse() *OverrideResolver { return ensureResolver(w.resolver) }
+
 func (aaaWriter) Family() string { return "aaa" }
 
-func (aaaWriter) YANGPaths() []string {
+func (w aaaWriter) YANGPaths() []string {
+	resolver := w.resolverForUse()
 	out := make([]string, 0, len(aaaLeaves))
 	for _, l := range aaaLeaves {
-		out = append(out, l.yangPath)
+		out = append(out, resolver.ResolvedYANGPath("aaa", l.yangPath))
 	}
 	return out
 }
 
-func (aaaWriter) Fetch(ctx context.Context, c transport.Interface) (any, error) {
+func (w aaaWriter) Fetch(ctx context.Context, c transport.Interface) (any, error) {
+	resolver := w.resolverForUse()
 	out := map[string]any{}
 	for _, l := range aaaLeaves {
-		raw, err := c.Fetch(ctx, l.yangPath)
+		path := resolver.ResolvedYANGPath("aaa", l.yangPath)
+		raw, err := c.Fetch(ctx, path)
 		if err != nil {
 			if isRESTCONF404(err) {
 				continue
@@ -132,6 +144,9 @@ func (aaaWriter) Fetch(ctx context.Context, c transport.Interface) (any, error) 
 		if err := json.Unmarshal(body, &v); err != nil {
 			return nil, fmt.Errorf("aaa: decode %s leaf: %w", l.netKey, err)
 		}
+		if m, ok := v.(map[string]any); ok {
+			v = resolver.AutoReverseObservedBody("aaa", m)
+		}
 		if l.netKey == "new-model" {
 			out[l.netKey] = isTrue(v)
 			continue
@@ -141,7 +156,8 @@ func (aaaWriter) Fetch(ctx context.Context, c transport.Interface) (any, error) 
 	return out, nil
 }
 
-func (aaaWriter) Diff(desired, observed any) ([]transport.Op, error) {
+func (w aaaWriter) Diff(desired, observed any) ([]transport.Op, error) {
+	resolver := w.resolverForUse()
 	desiredMap, err := coerceMap(desired, "aaa.desired")
 	if err != nil {
 		return nil, err
@@ -173,7 +189,7 @@ func (aaaWriter) Diff(desired, observed any) ([]transport.Op, error) {
 			if !want {
 				ops = append(ops, transport.Op{
 					Verb: transport.VerbDelete,
-					Path: l.yangPath,
+					Path: resolver.ResolvedYANGPath("aaa", l.yangPath),
 				})
 				continue
 			}
@@ -183,7 +199,7 @@ func (aaaWriter) Diff(desired, observed any) ([]transport.Op, error) {
 			}
 			ops = append(ops, transport.Op{
 				Verb: transport.VerbMerge,
-				Path: l.yangPath,
+				Path: resolver.ResolvedYANGPath("aaa", l.yangPath),
 				Body: body,
 			})
 			continue
@@ -191,13 +207,17 @@ func (aaaWriter) Diff(desired, observed any) ([]transport.Op, error) {
 		if oHas && scalarEqual(dv, ov) {
 			continue
 		}
-		body, err := json.Marshal(map[string]any{l.yangField: dv})
+		projected := map[string]any{l.yangField: dv}
+		if o, ok := resolver.GetOverride("aaa"); ok {
+			projected = ApplyOverrideToBody(projected, o)
+		}
+		body, err := json.Marshal(projected)
 		if err != nil {
 			return nil, err
 		}
 		ops = append(ops, transport.Op{
 			Verb: transport.VerbMerge,
-			Path: l.yangPath,
+			Path: resolver.ResolvedYANGPath("aaa", l.yangPath),
 			Body: body,
 		})
 	}

--- a/internal/drivers/iosxe/configdriver/writers/dhcp.go
+++ b/internal/drivers/iosxe/configdriver/writers/dhcp.go
@@ -117,7 +117,6 @@ func (w dhcpWriter) Fetch(ctx context.Context, c transport.Interface) (any, erro
 	r := ensureResolver(w.resolver)
 	for i, entry := range list {
 		list[i] = r.AutoReverseObservedBody("dhcp", entry)
-		list[i] = dhcpFetchTransformPre1718(list[i])
 	}
 	return list, nil
 }
@@ -170,10 +169,10 @@ func (w dhcpWriter) Diff(desired, observed any) ([]transport.Op, error) {
 		entry := projectManagedLeaves(desired, dhcpPoolManagedLeaves)
 		entry["name"] = name
 
-		// IOS-XE 17.x exposes DHCP pools under the /ip/dhcp parent
-		// container with a Cisco-IOS-XE-dhcp:pool list keyed by id.
-		// Sending to /ip/dhcp/pool is rejected by 17.18.03 on C9300.
-		entry = dhcpBodyTransformPre1718(entry)
+		r := ensureResolver(w.resolver)
+		if o, ok := r.GetOverride("dhcp"); ok {
+			entry = ApplyOverrideToBody(entry, o)
+		}
 
 		body, err := wrapYANGPayload(dhcpParentEnvelopeKey, map[string]any{
 			w.resolvedEnvelopeKey(): []any{entry},
@@ -251,10 +250,11 @@ func (w dhcpWriter) PruneDiff(desired, observed any) ([]transport.Op, error) {
 
 	ops := make([]transport.Op, 0, len(names))
 	for _, name := range names {
+		keyField := w.resolvedKeyField()
 		ops = append(ops, transport.Op{
 			Verb:     transport.VerbDelete,
 			Path:     dhcpParentPath + "/" + w.resolvedEnvelopeKey() + "=" + name,
-			PathSpec: pathSpecForKeyedListEntry(dhcpParentPath+"/"+w.resolvedEnvelopeKey(), "id", name),
+			PathSpec: pathSpecForKeyedListEntry(dhcpParentPath+"/"+w.resolvedEnvelopeKey(), keyField, name),
 		})
 	}
 	return ops, nil

--- a/internal/drivers/iosxe/configdriver/writers/dhcp.go
+++ b/internal/drivers/iosxe/configdriver/writers/dhcp.go
@@ -37,7 +37,9 @@ import (
 //         default_router: 192.168.10.1
 //
 // YANG path: /Cisco-IOS-XE-native:native/ip/dhcp/pool
-// Key: name (baseline 17.18); overridden to "id" on < 17.18.
+// Key: name for the generic fallback shape; overridden to "id" on
+// validated IOS-XE releases whose DHCP YANG model uses the id-keyed pool
+// list, including 17.18.x and 26.01.
 //
 // DHCP is cataloged in families.yaml as a singleton family because the
 // netascode block owns the whole /ip/dhcp container. The writer

--- a/internal/drivers/iosxe/configdriver/writers/dhcp_version_overrides.go
+++ b/internal/drivers/iosxe/configdriver/writers/dhcp_version_overrides.go
@@ -21,9 +21,10 @@ import (
 )
 
 // ──────────────────────────────────────────────────────────────────
-// DHCP version-override transforms (IOS-XE < 17.18)
+// DHCP version-override transforms (IOS-XE 17.x through 17.18, and 26.01)
 //
-// On 17.15/17.16, the DHCP pool YANG model differs from 17.18:
+// On these releases, the DHCP pool YANG model differs from the generic
+// fallback shape:
 //   - List key is "id" (not "name")
 //   - Network uses nested: network.primary-network.{number, mask}
 //     (not flat network/prefix_length)
@@ -32,10 +33,10 @@ import (
 //   - Parent container /ip/dhcp must be created before pool PUT
 // ──────────────────────────────────────────────────────────────────
 
-// dhcpBodyTransformPre1718 converts the 17.18-baseline DHCP pool body
-// to the 17.15/17.16 YANG shape.
+// dhcpBodyTransformPre1718 converts the canonical NetAsCode DHCP pool
+// body to the id-keyed IOS-XE DHCP YANG shape.
 func dhcpBodyTransformPre1718(body map[string]any) map[string]any {
-	// Rename name → id (YANG list key on < 17.18)
+	// Rename name → id.
 	if name, ok := body["name"]; ok {
 		body["id"] = name
 		delete(body, "name")
@@ -66,7 +67,7 @@ func dhcpBodyTransformPre1718(body map[string]any) map[string]any {
 	return body
 }
 
-// dhcpFetchTransformPre1718 is the inverse: converts the 17.15 device
+// dhcpFetchTransformPre1718 is the inverse: converts the id-keyed device
 // response back to netascode canonical shape for Diff comparison.
 func dhcpFetchTransformPre1718(body map[string]any) map[string]any {
 	// Rename id → name

--- a/internal/drivers/iosxe/configdriver/writers/family_writers_test.go
+++ b/internal/drivers/iosxe/configdriver/writers/family_writers_test.go
@@ -168,6 +168,39 @@ func TestDHCPDiffLegacyUsesResolverTransform(t *testing.T) {
 	}
 }
 
+func TestDHCPDiff1718UsesResolverTransform(t *testing.T) {
+	t.Parallel()
+	w := dhcpWriter{resolver: NewOverrideResolverForMajorMinor(17, 18)}
+	desired := map[string]any{"pools": []any{
+		map[string]any{
+			"name": "192_168_99.0", "network": "192.168.99.0", "prefix_length": 24, "default_router": "192.168.99.1",
+		},
+	}}
+	ops, err := w.Diff(desired, []map[string]any{})
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if len(ops) != 1 || ops[0].Path != dhcpParentPath {
+		t.Fatalf("got %+v, want one op to DHCP parent", ops)
+	}
+	var body map[string]map[string][]map[string]any
+	if err := json.Unmarshal(ops[0].Body, &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	pools := body[dhcpParentEnvelopeKey][dhcpPoolEnvelopeKey]
+	if len(pools) != 1 || pools[0]["id"] != "192_168_99.0" {
+		t.Fatalf("body=%s, want 17.18 DHCP pool keyed by id", ops[0].Body)
+	}
+	if _, ok := pools[0]["default_router"]; ok {
+		t.Fatalf("body=%s, 17.18 body must not carry canonical default_router key", ops[0].Body)
+	}
+	if dr, ok := pools[0]["default-router"].(map[string]any); !ok {
+		t.Fatalf("body=%s, want 17.18 nested default-router", ops[0].Body)
+	} else if got := dr["default-router-list"]; !reflect.DeepEqual(got, []any{"192.168.99.1"}) {
+		t.Fatalf("default-router-list=%#v, want [192.168.99.1]", got)
+	}
+}
+
 func TestDHCPDiff2601UsesResolverTransform(t *testing.T) {
 	t.Parallel()
 	w := dhcpWriter{resolver: NewOverrideResolverForMajorMinor(26, 1)}

--- a/internal/drivers/iosxe/configdriver/writers/family_writers_test.go
+++ b/internal/drivers/iosxe/configdriver/writers/family_writers_test.go
@@ -126,8 +126,44 @@ func TestDHCPDiffCreatesMissing(t *testing.T) {
 		t.Fatalf("decode body: %v", err)
 	}
 	pools := body[dhcpParentEnvelopeKey][dhcpPoolEnvelopeKey]
-	if len(pools) != 1 || pools[0]["id"] != "IOX" {
-		t.Fatalf("body=%s, want DHCP pool keyed by id", ops[0].Body)
+	if len(pools) != 1 || pools[0]["name"] != "IOX" {
+		t.Fatalf("body=%s, want baseline DHCP pool keyed by name", ops[0].Body)
+	}
+}
+
+func TestDHCPDiffLegacyUsesResolverTransform(t *testing.T) {
+	t.Parallel()
+	w := dhcpWriter{resolver: NewOverrideResolverForMajorMinor(17, 16)}
+	desired := map[string]any{"pools": []any{
+		map[string]any{
+			"name": float64(198181000), "network": "198.18.100.0", "prefix_length": 24, "default_router": "198.18.100.1",
+		},
+	}}
+	ops, err := w.Diff(desired, []map[string]any{})
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if len(ops) != 1 || ops[0].Path != dhcpParentPath {
+		t.Fatalf("got %+v, want one op to DHCP parent", ops)
+	}
+	var body map[string]map[string][]map[string]any
+	if err := json.Unmarshal(ops[0].Body, &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	pools := body[dhcpParentEnvelopeKey][dhcpPoolEnvelopeKey]
+	if len(pools) != 1 || pools[0]["id"] != "198181000" {
+		t.Fatalf("body=%s, want legacy DHCP pool keyed by normalized id", ops[0].Body)
+	}
+	if _, ok := pools[0]["name"]; ok {
+		t.Fatalf("body=%s, legacy body must not carry name key", ops[0].Body)
+	}
+	network, ok := pools[0]["network"].(map[string]any)
+	if !ok {
+		t.Fatalf("body=%s, want legacy nested network", ops[0].Body)
+	}
+	primary, ok := network["primary-network"].(map[string]any)
+	if !ok || primary["mask"] != "255.255.255.0" {
+		t.Fatalf("body=%s, want legacy primary-network mask", ops[0].Body)
 	}
 }
 

--- a/internal/drivers/iosxe/configdriver/writers/family_writers_test.go
+++ b/internal/drivers/iosxe/configdriver/writers/family_writers_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -164,6 +165,39 @@ func TestDHCPDiffLegacyUsesResolverTransform(t *testing.T) {
 	primary, ok := network["primary-network"].(map[string]any)
 	if !ok || primary["mask"] != "255.255.255.0" {
 		t.Fatalf("body=%s, want legacy primary-network mask", ops[0].Body)
+	}
+}
+
+func TestDHCPDiff2601UsesResolverTransform(t *testing.T) {
+	t.Parallel()
+	w := dhcpWriter{resolver: NewOverrideResolverForMajorMinor(26, 1)}
+	desired := map[string]any{"pools": []any{
+		map[string]any{
+			"name": "192_168_99.0", "network": "192.168.99.0", "prefix_length": 24, "default_router": "192.168.99.1",
+		},
+	}}
+	ops, err := w.Diff(desired, []map[string]any{})
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if len(ops) != 1 || ops[0].Path != dhcpParentPath {
+		t.Fatalf("got %+v, want one op to DHCP parent", ops)
+	}
+	var body map[string]map[string][]map[string]any
+	if err := json.Unmarshal(ops[0].Body, &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	pools := body[dhcpParentEnvelopeKey][dhcpPoolEnvelopeKey]
+	if len(pools) != 1 || pools[0]["id"] != "192_168_99.0" {
+		t.Fatalf("body=%s, want 26.01 DHCP pool keyed by id", ops[0].Body)
+	}
+	if _, ok := pools[0]["default_router"]; ok {
+		t.Fatalf("body=%s, 26.01 body must not carry canonical default_router key", ops[0].Body)
+	}
+	if dr, ok := pools[0]["default-router"].(map[string]any); !ok {
+		t.Fatalf("body=%s, want 26.01 nested default-router", ops[0].Body)
+	} else if got := dr["default-router-list"]; !reflect.DeepEqual(got, []any{"192.168.99.1"}) {
+		t.Fatalf("default-router-list=%#v, want [192.168.99.1]", got)
 	}
 }
 

--- a/internal/drivers/iosxe/configdriver/writers/interface_ethernet.go
+++ b/internal/drivers/iosxe/configdriver/writers/interface_ethernet.go
@@ -71,16 +71,26 @@ var ethernetManagedLeaves = []string{
 	"ip_access_group_out",
 }
 
-type ethernetWriter struct{}
+type ethernetWriter struct {
+	resolver *OverrideResolver
+}
 
 func init() { Override(ethernetWriter{}) }
 
+func (w ethernetWriter) withResolver(r *OverrideResolver) SectionWriter {
+	w.resolver = r
+	return w
+}
+
+func (w ethernetWriter) resolverForUse() *OverrideResolver { return ensureResolver(w.resolver) }
+
 func (ethernetWriter) Family() string { return "interface_ethernet" }
 
-func (ethernetWriter) YANGPaths() []string {
+func (w ethernetWriter) YANGPaths() []string {
+	resolver := w.resolverForUse()
 	out := make([]string, 0, len(ethernetTypes))
 	for _, t := range ethernetTypes {
-		out = append(out, "/Cisco-IOS-XE-native:native/interface/"+t)
+		out = append(out, resolver.ResolvedYANGPath("interface_ethernet", "/Cisco-IOS-XE-native:native/interface/"+t))
 	}
 	return out
 }
@@ -89,10 +99,12 @@ func (ethernetWriter) YANGPaths() []string {
 // for Phase-1 to keep the transport lock simple), concatenating the
 // per-type lists into a single observed slice. Each entry is tagged
 // with its type so Diff can locate it later.
-func (ethernetWriter) Fetch(ctx context.Context, c transport.Interface) (any, error) {
+func (w ethernetWriter) Fetch(ctx context.Context, c transport.Interface) (any, error) {
+	resolver := w.resolverForUse()
 	var combined []map[string]any
 	for _, t := range ethernetTypes {
 		path := "/Cisco-IOS-XE-native:native/interface/" + t
+		path = resolver.ResolvedYANGPath("interface_ethernet", path)
 		raw, err := c.Fetch(ctx, path)
 		if err != nil {
 			if isRESTCONF404(err) {
@@ -112,6 +124,7 @@ func (ethernetWriter) Fetch(ctx context.Context, c transport.Interface) (any, er
 			return nil, fmt.Errorf("interface_ethernet: decode %s list: %w", t, err)
 		}
 		for _, el := range list {
+			el = resolver.AutoReverseObservedBody("interface_ethernet", el)
 			el = interfaceIPv4VRFFromYANG(el)
 			el["type"] = t
 			combined = append(combined, el)
@@ -120,7 +133,8 @@ func (ethernetWriter) Fetch(ctx context.Context, c transport.Interface) (any, er
 	return combined, nil
 }
 
-func (ethernetWriter) Diff(desired, observed any) ([]transport.Op, error) {
+func (w ethernetWriter) Diff(desired, observed any) ([]transport.Op, error) {
+	resolver := w.resolverForUse()
 	desiredList, err := coerceEthernetBlock(desired, "desired")
 	if err != nil {
 		return nil, err
@@ -172,6 +186,11 @@ func (ethernetWriter) Diff(desired, observed any) ([]transport.Op, error) {
 		proj := projectManagedLeaves(entry, ethernetManagedLeaves)
 		proj["name"] = k.name
 		proj = interfaceIPv4VRFToYANG(proj)
+		if o, ok := resolver.GetOverride("interface_ethernet"); ok {
+			proj = ApplyOverrideToBody(proj, o)
+		}
+		path := resolver.ResolvedYANGPath("interface_ethernet",
+			fmt.Sprintf("/Cisco-IOS-XE-native:native/interface/%s", k.typ))
 		body, err := json.Marshal(map[string]any{
 			"Cisco-IOS-XE-native:" + k.typ: []any{proj},
 		})
@@ -185,7 +204,7 @@ func (ethernetWriter) Diff(desired, observed any) ([]transport.Op, error) {
 			// builder doesn't split the key on the embedded slash.
 			// PathSpec carries the raw key value for the XML body
 			// (and gNMI Set/Delete via opToGNMIPath).
-			Path:     fmt.Sprintf("/Cisco-IOS-XE-native:native/interface/%s=%s", k.typ, encodeKeyValue(k.name)),
+			Path:     fmt.Sprintf("%s=%s", path, encodeKeyValue(k.name)),
 			PathSpec: pathSpecForInterface(k.typ, k.name),
 			Body:     body,
 		})

--- a/internal/drivers/iosxe/configdriver/writers/interface_ethernet.go
+++ b/internal/drivers/iosxe/configdriver/writers/interface_ethernet.go
@@ -69,6 +69,7 @@ var ethernetManagedLeaves = []string{
 	"mtu",
 	"ip_access_group_in",
 	"ip_access_group_out",
+	"ip_pim_sparse_mode",
 }
 
 type ethernetWriter struct {
@@ -208,6 +209,28 @@ func (w ethernetWriter) Diff(desired, observed any) ([]transport.Op, error) {
 			PathSpec: pathSpecForInterface(k.typ, k.name),
 			Body:     body,
 		})
+
+		// PIM sparse-mode must be applied at its own sub-path; IOS-XE
+		// rejects the pim augmentation when merged at the interface level.
+		if isTrue(entry["ip_pim_sparse_mode"]) {
+			pimPath := fmt.Sprintf("/Cisco-IOS-XE-native:native/interface/%s=%s/ip/pim",
+				k.typ, encodeKeyValue(k.name))
+			pimBody, err := json.Marshal(map[string]any{
+				"Cisco-IOS-XE-native:pim": map[string]any{
+					"Cisco-IOS-XE-multicast:pim-mode-choice-cfg": map[string]any{
+						"sparse-mode": []any{nil},
+					},
+				},
+			})
+			if err != nil {
+				return nil, err
+			}
+			ops = append(ops, transport.Op{
+				Verb: transport.VerbMerge,
+				Path: pimPath,
+				Body: pimBody,
+			})
+		}
 	}
 	return ops, nil
 }

--- a/internal/drivers/iosxe/configdriver/writers/interface_switchport.go
+++ b/internal/drivers/iosxe/configdriver/writers/interface_switchport.go
@@ -110,6 +110,8 @@ func (w switchportWriter) Fetch(ctx context.Context, c transport.Interface) (any
 			name, _ := ifr["name"].(string)
 			row := map[string]any{"type": t, "name": name}
 			for k, v := range sw {
+				// Strip module prefix so observed keys match desired.
+				k = stripSwitchPrefix(k)
 				row[k] = v
 			}
 			if o, ok := w.resolverForUse().GetOverride("interface_switchport"); ok {
@@ -121,6 +123,14 @@ func (w switchportWriter) Fetch(ctx context.Context, c transport.Interface) (any
 				for k := range modeMap {
 					row["mode"] = k
 					break
+				}
+			}
+			// Infer mode from presence of access/trunk if no explicit mode.
+			if _, hasMode := row["mode"]; !hasMode {
+				if _, ok := row["access"]; ok {
+					row["mode"] = "access"
+				} else if _, ok := row["trunk"]; ok {
+					row["mode"] = "trunk"
 				}
 			}
 			// Flatten access.vlan.vlan → access.vlan on legacy versions.
@@ -198,6 +208,7 @@ func (w switchportWriter) Diff(desired, observed any) ([]transport.Op, error) {
 		if o, ok := w.resolverForUse().GetOverride("interface_switchport"); ok {
 			proj = ApplyOverrideToBody(proj, o)
 		}
+		proj = switchportToYANG(proj)
 		body, err := json.Marshal(map[string]any{
 			"Cisco-IOS-XE-native:switchport": proj,
 		})
@@ -246,6 +257,59 @@ func switchportBodyTransform1716(body map[string]any) map[string]any {
 		}
 	}
 	return body
+}
+
+// stripSwitchPrefix removes the Cisco-IOS-XE-switch: module prefix.
+func stripSwitchPrefix(k string) string {
+	const prefix = "Cisco-IOS-XE-switch:"
+	if len(k) > len(prefix) && k[:len(prefix)] == prefix {
+		return k[len(prefix):]
+	}
+	return k
+}
+
+// switchportToYANG transforms the flat desired payload into YANG wire format:
+//   - Adds Cisco-IOS-XE-switch: prefix to mode, access, trunk keys
+//   - Transforms mode string → choice container: "access" → {access: {}}
+//   - Transforms access.vlan: N → access.vlan: {vlan: N}
+func switchportToYANG(proj map[string]any) map[string]any {
+	out := make(map[string]any, len(proj))
+	for k, v := range proj {
+		switch k {
+		case "mode":
+			// mode: "access" → Cisco-IOS-XE-switch:mode: {access: {}}
+			if s, ok := v.(string); ok {
+				out["Cisco-IOS-XE-switch:mode"] = map[string]any{s: map[string]any{}}
+			} else {
+				out["Cisco-IOS-XE-switch:mode"] = v
+			}
+		case "access":
+			// Wrap vlan value: access.vlan: N → access.vlan: {vlan: N}
+			if acc, ok := v.(map[string]any); ok {
+				accCopy := make(map[string]any, len(acc))
+				for ak, av := range acc {
+					if ak == "vlan" {
+						switch av.(type) {
+						case map[string]any:
+							accCopy[ak] = av
+						default:
+							accCopy[ak] = map[string]any{"vlan": av}
+						}
+					} else {
+						accCopy[ak] = av
+					}
+				}
+				out["Cisco-IOS-XE-switch:access"] = accCopy
+			} else {
+				out["Cisco-IOS-XE-switch:access"] = v
+			}
+		case "trunk":
+			out["Cisco-IOS-XE-switch:trunk"] = v
+		default:
+			out[k] = v
+		}
+	}
+	return out
 }
 
 func coerceSwitchportBlock(v any, origin string) ([]map[string]any, error) {

--- a/internal/drivers/iosxe/configdriver/writers/interface_switchport.go
+++ b/internal/drivers/iosxe/configdriver/writers/interface_switchport.go
@@ -193,6 +193,8 @@ func (w switchportWriter) Diff(desired, observed any) ([]transport.Op, error) {
 			continue
 		}
 		proj := projectManagedLeaves(entry, switchportManagedLeaves)
+		delete(proj, "type")
+		delete(proj, "name")
 		if o, ok := w.resolverForUse().GetOverride("interface_switchport"); ok {
 			proj = ApplyOverrideToBody(proj, o)
 		}

--- a/internal/drivers/iosxe/configdriver/writers/ipv6_pim.go
+++ b/internal/drivers/iosxe/configdriver/writers/ipv6_pim.go
@@ -14,39 +14,69 @@
 
 package writers
 
-// IPv6 PIM global Phase-3 writer.
+import (
+	"fmt"
+	"strings"
+)
+
+// IPv6 PIM writer.
 //
-// netascode shape (YANG keys used directly):
+// netascode shape:
 //
 //	ipv6_pim:
-//	  rp-address:
-//	    - address: 2001:db8::100
-//	      access-list: ff70::/12
-//	      bidir: {}
-//	  vrfs:
-//	    - name: IPV6_PIM_VRF
-//	      rp-address:
-//	        - address: 2001:db8:154::1
-//	          access-list: ff71::/12
+//	  rp-address: "2001:DB8::100"
 //
-// YANG: /Cisco-IOS-XE-native:native/ipv6/Cisco-IOS-XE-multicast:pim
-//
-// NOTE: Requires ipv6 multicast-routing to be enabled on the device.
-// On virtual C8000V/C9KV lab instances the YANG path may not be present.
-// Tested against physical hardware with IP Services licence.
+// YANG: /Cisco-IOS-XE-native:native/ipv6/pim (augmented by Cisco-IOS-XE-multicast)
 
-var ipv6PimLeaves = []string{
+var ipv6PIMLeaves = []string{
 	"rp-address",
-	"vrfs",
+}
+
+func ipv6PIMBodyShape(flat map[string]any) map[string]any {
+	const prefix = "Cisco-IOS-XE-multicast:"
+	out := make(map[string]any)
+
+	if v, ok := flat["rp-address"]; ok {
+		out[prefix+"rp-address"] = map[string]any{"address": fmt.Sprintf("%v", v)}
+	}
+
+	return out
+}
+
+func ipv6PIMFetchShape(fetched map[string]any) map[string]any {
+	const prefix = "Cisco-IOS-XE-multicast:"
+	out := make(map[string]any)
+
+	for k, v := range fetched {
+		key := k
+		if strings.HasPrefix(k, prefix) {
+			key = k[len(prefix):]
+		}
+		switch key {
+		case "rp-address":
+			if m, ok := v.(map[string]any); ok {
+				if addr, ok := m["address"]; ok {
+					out["rp-address"] = addr
+				}
+			}
+		default:
+			out[key] = v
+		}
+	}
+	return out
 }
 
 func init() {
 	Override(singletonWriter{
-		family:        "ipv6_pim",
-		yangPath:      "/Cisco-IOS-XE-native:native/ipv6/Cisco-IOS-XE-multicast:pim",
-		envelopeKey:   "Cisco-IOS-XE-multicast:pim",
-		managedLeaves: ipv6PimLeaves,
+		family:         "ipv6_pim",
+		yangPath:       "/Cisco-IOS-XE-native:native/ipv6/pim",
+		envelopeKey:    "Cisco-IOS-XE-native:pim",
+		managedLeaves:  ipv6PIMLeaves,
+		yangBodyShape:  ipv6PIMBodyShape,
+		yangFetchShape: ipv6PIMFetchShape,
 	})
 }
 
-func ipv6PimManagedLeaves() []string { return append([]string(nil), ipv6PimLeaves...) }
+func ipv6PimManagedLeaves() []string {
+	return append([]string(nil), ipv6PIMLeaves...)
+}

--- a/internal/drivers/iosxe/configdriver/writers/multicast_routing.go
+++ b/internal/drivers/iosxe/configdriver/writers/multicast_routing.go
@@ -1,0 +1,37 @@
+// Copyright © 2026 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package writers
+
+// IPv4 multicast-routing enablement writer.
+//
+// netascode shape:
+//
+//	multicast_routing:
+//	  distributed: true
+//
+// YANG: /Cisco-IOS-XE-native:native/ip/Cisco-IOS-XE-multicast:multicast-routing
+//
+// This is a prerequisite for the pim family. Enabling this container
+// causes "ip multicast-routing distributed" (router) or
+// "ip multicast-routing" (switch) to appear in running-config.
+
+func init() {
+	Override(singletonWriter{
+		family:        "multicast_routing",
+		yangPath:      "/Cisco-IOS-XE-native:native/ip/Cisco-IOS-XE-multicast:multicast-routing",
+		envelopeKey:   "Cisco-IOS-XE-multicast:multicast-routing",
+		managedLeaves: []string{"distributed"},
+	})
+}

--- a/internal/drivers/iosxe/configdriver/writers/pim.go
+++ b/internal/drivers/iosxe/configdriver/writers/pim.go
@@ -14,9 +14,15 @@
 
 package writers
 
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
 // IPv4 PIM global Phase-3 writer.
 //
-// netascode shape (YANG keys used directly):
+// netascode shape (flat user-facing keys):
 //
 //	pim:
 //	  autorp: false
@@ -26,14 +32,20 @@ package writers
 //	    mask-length: 24
 //	    priority: 10
 //	  rp-address: 192.168.1.1
+//	  rp-addresses:
+//	    - access-list: "10"
+//	      rp-address: "10.10.10.10"
 //	  rp-candidate:
 //	    - interface: Loopback151
 //	      interval: 100
 //	      priority: 10
-//	      bidir: {}
 //	  ssm:
 //	    range: ACL1
 //	  register-source: Loopback152
+//	  vrfs:
+//	    - vrf: VRF1
+//	      autorp: true
+//	      ...
 //
 // YANG: /Cisco-IOS-XE-native:native/ip/pim (augmented by Cisco-IOS-XE-multicast)
 //
@@ -51,27 +63,281 @@ var pimLeaves = []string{
 	"vrfs",
 }
 
-// pimBodyShape adds the Cisco-IOS-XE-multicast: module prefix to
-// each key in the flat map, since these leaves come from an augment
-// of the Cisco-IOS-XE-multicast module into /native/ip/pim.
+// pimBodyShape transforms netascode flat format → YANG wire format.
 func pimBodyShape(flat map[string]any) map[string]any {
 	const prefix = "Cisco-IOS-XE-multicast:"
-	out := make(map[string]any, len(flat))
-	for k, v := range flat {
-		out[prefix+k] = v
+	out := make(map[string]any)
+
+	// autorp + autorp-listener → autorp-container
+	autorpContainer := map[string]any{}
+	if v, ok := flat["autorp"]; ok {
+		autorpContainer["autorp"] = v
+	}
+	if v, ok := flat["autorp-listener"]; ok {
+		if b, ok := v.(bool); ok && b {
+			autorpContainer["listener"] = []any{nil}
+		}
+	}
+	if len(autorpContainer) > 0 {
+		out[prefix+"autorp-container"] = autorpContainer
+	}
+
+	// bsr-candidate: {interface: "Loopback150", mask-length: 24, priority: 10}
+	// → bsr-candidate: {Loopback: 150, mask: 24, priority: 10}
+	if bsr, ok := flat["bsr-candidate"].(map[string]any); ok {
+		out[prefix+"bsr-candidate"] = interfaceToYANG(bsr, "mask-length", "mask")
+	}
+
+	// rp-address: "192.168.1.1" → rp-address-conf: {address: "192.168.1.1"}
+	if v, ok := flat["rp-address"]; ok {
+		addr := fmt.Sprintf("%v", v)
+		out[prefix+"rp-address-conf"] = map[string]any{"address": addr}
+	}
+
+	// rp-addresses: [...] → rp-address-list: [...]
+	if v, ok := flat["rp-addresses"]; ok {
+		out[prefix+"rp-address-list"] = v
+	}
+
+	// rp-candidate: [...] → rp-candidate: [...] (same shape)
+	if v, ok := flat["rp-candidate"]; ok {
+		out[prefix+"rp-candidate"] = v
+	}
+
+	// ssm: {range: "ACL"} → ssm: {range: "ACL"} (same)
+	if v, ok := flat["ssm"]; ok {
+		out[prefix+"ssm"] = v
+	}
+
+	// register-source: "Loopback152" → register-source: {Loopback: 152}
+	if v, ok := flat["register-source"]; ok {
+		out[prefix+"register-source"] = interfaceStringToYANG(fmt.Sprintf("%v", v))
+	}
+
+	// vrfs: [{vrf: "VRF1", ...}] → vrf: [{id: "VRF1", ...}]
+	if vrfs, ok := flat["vrfs"]; ok {
+		if vrfList, ok := vrfs.([]any); ok {
+			yangVRFs := make([]any, 0, len(vrfList))
+			for _, item := range vrfList {
+				if m, ok := item.(map[string]any); ok {
+					yangVRFs = append(yangVRFs, vrfEntryToYANG(m))
+				}
+			}
+			out[prefix+"vrf"] = yangVRFs
+		}
+	}
+
+	return out
+}
+
+// pimFetchShape transforms YANG wire format → netascode flat format.
+func pimFetchShape(fetched map[string]any) map[string]any {
+	const prefix = "Cisco-IOS-XE-multicast:"
+	out := make(map[string]any)
+
+	for k, v := range fetched {
+		key := k
+		if strings.HasPrefix(k, prefix) {
+			key = k[len(prefix):]
+		}
+		switch key {
+		case "autorp-container":
+			if m, ok := v.(map[string]any); ok {
+				if a, ok := m["autorp"]; ok {
+					out["autorp"] = a
+				}
+				if _, ok := m["listener"]; ok {
+					out["autorp-listener"] = true
+				}
+			}
+		case "bsr-candidate":
+			if m, ok := v.(map[string]any); ok {
+				out["bsr-candidate"] = interfaceFromYANG(m, "mask", "mask-length")
+			}
+		case "rp-address-conf":
+			if m, ok := v.(map[string]any); ok {
+				if addr, ok := m["address"]; ok {
+					out["rp-address"] = addr
+				}
+			}
+		case "rp-address-list":
+			out["rp-addresses"] = v
+		case "rp-candidate":
+			out["rp-candidate"] = v
+		case "ssm":
+			out["ssm"] = v
+		case "register-source":
+			if m, ok := v.(map[string]any); ok {
+				out["register-source"] = interfaceYANGToString(m)
+			}
+		case "vrf":
+			if vrfList, ok := v.([]any); ok {
+				vrfs := make([]any, 0, len(vrfList))
+				for _, item := range vrfList {
+					if m, ok := item.(map[string]any); ok {
+						vrfs = append(vrfs, vrfEntryFromYANG(m))
+					}
+				}
+				out["vrfs"] = vrfs
+			}
+		default:
+			out[key] = v
+		}
 	}
 	return out
 }
 
-// pimFetchShape strips the Cisco-IOS-XE-multicast: module prefix
-// from fetched keys so comparison uses the flat user-facing names.
-func pimFetchShape(fetched map[string]any) map[string]any {
-	const prefix = "Cisco-IOS-XE-multicast:"
-	out := make(map[string]any, len(fetched))
-	for k, v := range fetched {
-		if len(k) > len(prefix) && k[:len(prefix)] == prefix {
-			out[k[len(prefix):]] = v
+// interfaceToYANG converts {interface: "Loopback150", mask-length: 24, ...}
+// → {Loopback: 150, mask: 24, ...}
+func interfaceToYANG(m map[string]any, fromKey, toKey string) map[string]any {
+	out := make(map[string]any, len(m))
+	if iface, ok := m["interface"]; ok {
+		ifStr := fmt.Sprintf("%v", iface)
+		ifMap := interfaceStringToYANG(ifStr)
+		for k, v := range ifMap {
+			out[k] = v
+		}
+	}
+	for k, v := range m {
+		if k == "interface" {
+			continue
+		}
+		if k == fromKey {
+			out[toKey] = v
 		} else {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// interfaceFromYANG reverses interfaceToYANG.
+func interfaceFromYANG(m map[string]any, fromKey, toKey string) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		switch {
+		case isInterfaceType(k):
+			out["interface"] = interfaceYANGToString(map[string]any{k: v})
+		case k == fromKey:
+			out[toKey] = v
+		default:
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// interfaceStringToYANG converts "Loopback150" → {"Loopback": 150}
+func interfaceStringToYANG(s string) map[string]any {
+	for _, prefix := range []string{"Loopback", "GigabitEthernet", "TenGigabitEthernet", "Port-channel", "Vlan"} {
+		if strings.HasPrefix(s, prefix) {
+			rest := s[len(prefix):]
+			if n, err := strconv.Atoi(rest); err == nil {
+				return map[string]any{prefix: n}
+			}
+			return map[string]any{prefix: rest}
+		}
+	}
+	return map[string]any{"Loopback": s}
+}
+
+// interfaceYANGToString converts {"Loopback": 150} → "Loopback150"
+func interfaceYANGToString(m map[string]any) string {
+	for k, v := range m {
+		if isInterfaceType(k) {
+			return fmt.Sprintf("%s%v", k, v)
+		}
+	}
+	return ""
+}
+
+func isInterfaceType(k string) bool {
+	switch k {
+	case "Loopback", "GigabitEthernet", "TenGigabitEthernet", "Port-channel",
+		"Vlan", "FastEthernet", "TwoGigabitEthernet", "FiveGigabitEthernet",
+		"AppGigabitEthernet", "HundredGigE", "FortyGigabitEthernet":
+		return true
+	}
+	return false
+}
+
+// vrfEntryToYANG converts netascode VRF entry to YANG format.
+func vrfEntryToYANG(m map[string]any) map[string]any {
+	out := make(map[string]any, len(m))
+	if vrf, ok := m["vrf"]; ok {
+		out["id"] = vrf
+	}
+	if v, ok := m["autorp"]; ok {
+		ac := map[string]any{"autorp": v}
+		if al, ok := m["autorp-listener"]; ok {
+			if b, ok := al.(bool); ok && b {
+				ac["listener"] = []any{nil}
+			}
+		}
+		out["autorp-container"] = ac
+	} else if al, ok := m["autorp-listener"]; ok {
+		if b, ok := al.(bool); ok && b {
+			out["autorp-container"] = map[string]any{"listener": []any{nil}}
+		}
+	}
+	if bsr, ok := m["bsr-candidate"].(map[string]any); ok {
+		out["bsr-candidate"] = interfaceToYANG(bsr, "mask-length", "mask")
+	}
+	if v, ok := m["rp-address"]; ok {
+		out["rp-address-conf"] = map[string]any{"address": fmt.Sprintf("%v", v)}
+	}
+	if v, ok := m["rp-addresses"]; ok {
+		out["rp-address-list"] = v
+	}
+	if v, ok := m["rp-candidate"]; ok {
+		out["rp-candidate"] = v
+	}
+	if v, ok := m["ssm"]; ok {
+		out["ssm"] = v
+	}
+	if v, ok := m["register-source"]; ok {
+		out["register-source"] = interfaceStringToYANG(fmt.Sprintf("%v", v))
+	}
+	return out
+}
+
+// vrfEntryFromYANG converts YANG VRF entry to netascode format.
+func vrfEntryFromYANG(m map[string]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		switch k {
+		case "id":
+			out["vrf"] = v
+		case "autorp-container":
+			if ac, ok := v.(map[string]any); ok {
+				if a, ok := ac["autorp"]; ok {
+					out["autorp"] = a
+				}
+				if _, ok := ac["listener"]; ok {
+					out["autorp-listener"] = true
+				}
+			}
+		case "bsr-candidate":
+			if bsr, ok := v.(map[string]any); ok {
+				out["bsr-candidate"] = interfaceFromYANG(bsr, "mask", "mask-length")
+			}
+		case "rp-address-conf":
+			if conf, ok := v.(map[string]any); ok {
+				if addr, ok := conf["address"]; ok {
+					out["rp-address"] = addr
+				}
+			}
+		case "rp-address-list":
+			out["rp-addresses"] = v
+		case "rp-candidate":
+			out["rp-candidate"] = v
+		case "ssm":
+			out["ssm"] = v
+		case "register-source":
+			if rs, ok := v.(map[string]any); ok {
+				out["register-source"] = interfaceYANGToString(rs)
+			}
+		default:
 			out[k] = v
 		}
 	}

--- a/internal/drivers/iosxe/configdriver/writers/pim.go
+++ b/internal/drivers/iosxe/configdriver/writers/pim.go
@@ -35,12 +35,9 @@ package writers
 //	    range: ACL1
 //	  register-source: Loopback152
 //
-// YANG: /Cisco-IOS-XE-native:native/ip/Cisco-IOS-XE-multicast:pim
+// YANG: /Cisco-IOS-XE-native:native/ip/pim (augmented by Cisco-IOS-XE-multicast)
 //
 // NOTE: Requires ip multicast-routing to be enabled on the device.
-// On virtual C8000V/C9KV lab instances the YANG path may not be present
-// (returns "uri keypath not found"). Tested against physical Cat9k/ISR
-// hardware with IP Services / IP Multicast licence.
 
 var pimLeaves = []string{
 	"autorp",
@@ -54,12 +51,41 @@ var pimLeaves = []string{
 	"vrfs",
 }
 
+// pimBodyShape adds the Cisco-IOS-XE-multicast: module prefix to
+// each key in the flat map, since these leaves come from an augment
+// of the Cisco-IOS-XE-multicast module into /native/ip/pim.
+func pimBodyShape(flat map[string]any) map[string]any {
+	const prefix = "Cisco-IOS-XE-multicast:"
+	out := make(map[string]any, len(flat))
+	for k, v := range flat {
+		out[prefix+k] = v
+	}
+	return out
+}
+
+// pimFetchShape strips the Cisco-IOS-XE-multicast: module prefix
+// from fetched keys so comparison uses the flat user-facing names.
+func pimFetchShape(fetched map[string]any) map[string]any {
+	const prefix = "Cisco-IOS-XE-multicast:"
+	out := make(map[string]any, len(fetched))
+	for k, v := range fetched {
+		if len(k) > len(prefix) && k[:len(prefix)] == prefix {
+			out[k[len(prefix):]] = v
+		} else {
+			out[k] = v
+		}
+	}
+	return out
+}
+
 func init() {
 	Override(singletonWriter{
-		family:        "pim",
-		yangPath:      "/Cisco-IOS-XE-native:native/ip/Cisco-IOS-XE-multicast:pim",
-		envelopeKey:   "Cisco-IOS-XE-multicast:pim",
-		managedLeaves: pimLeaves,
+		family:         "pim",
+		yangPath:       "/Cisco-IOS-XE-native:native/ip/pim",
+		envelopeKey:    "Cisco-IOS-XE-native:pim",
+		managedLeaves:  pimLeaves,
+		yangBodyShape:  pimBodyShape,
+		yangFetchShape: pimFetchShape,
 	})
 }
 

--- a/internal/drivers/iosxe/configdriver/writers/registry_test.go
+++ b/internal/drivers/iosxe/configdriver/writers/registry_test.go
@@ -97,6 +97,7 @@ var phase3Families = []string{
 	"username",
 	"pim",
 	"ipv6_pim",
+	"multicast_routing",
 }
 
 func TestPhase1FamiliesRegistered(t *testing.T) {

--- a/internal/drivers/iosxe/configdriver/writers/singleton.go
+++ b/internal/drivers/iosxe/configdriver/writers/singleton.go
@@ -105,6 +105,14 @@ func (w singletonWriter) Diff(desired, observed any) ([]transport.Op, error) {
 	if desiredMap == nil {
 		return nil, nil
 	}
+	// Normalize desired through yangFetchShape so comparison uses the
+	// same representation as the fetched observed state. Without this,
+	// families whose yangFetchShape unwraps nested sub-containers (e.g.
+	// banner: {login: {banner: "text"}} -> {login: "text"}) would
+	// always detect drift when the source uses YANG-nested form.
+	if w.yangFetchShape != nil && desiredMap != nil {
+		desiredMap = w.yangFetchShape(desiredMap)
+	}
 	if observedMap == nil {
 		observedMap = map[string]any{}
 	}

--- a/internal/drivers/iosxe/configdriver/writers/vlan.go
+++ b/internal/drivers/iosxe/configdriver/writers/vlan.go
@@ -45,22 +45,36 @@ const (
 
 var vlanManagedLeaves = []string{"name", "shutdown"}
 
-type vlanWriter struct{}
+type vlanWriter struct {
+	resolver *OverrideResolver
+}
 
 func init() { Override(vlanWriter{}) }
 
-func (vlanWriter) Family() string      { return "vlan" }
-func (vlanWriter) YANGPaths() []string { return []string{vlanListPath} }
+func (w vlanWriter) withResolver(r *OverrideResolver) SectionWriter {
+	w.resolver = r
+	return w
+}
 
-func (vlanWriter) Fetch(ctx context.Context, c transport.Interface) (any, error) {
-	raw, err := c.Fetch(ctx, vlanListPath)
+func (w vlanWriter) resolverForUse() *OverrideResolver { return ensureResolver(w.resolver) }
+
+func (vlanWriter) Family() string { return "vlan" }
+func (w vlanWriter) YANGPaths() []string {
+	return []string{w.resolverForUse().ResolvedYANGPath("vlan", vlanListPath)}
+}
+
+func (w vlanWriter) Fetch(ctx context.Context, c transport.Interface) (any, error) {
+	resolver := w.resolverForUse()
+	path := resolver.ResolvedYANGPath("vlan", vlanListPath)
+	envelope := resolver.ResolvedEnvelopeKey("vlan", vlanEnvelopeKey)
+	raw, err := c.Fetch(ctx, path)
 	if err != nil {
 		if isRESTCONF404(err) {
 			return []map[string]any{}, nil
 		}
 		return nil, err
 	}
-	body, err := unwrapYANGEnvelope(raw, vlanEnvelopeKey)
+	body, err := unwrapYANGEnvelope(raw, envelope)
 	if err != nil || body == nil {
 		return []map[string]any{}, err
 	}
@@ -68,10 +82,16 @@ func (vlanWriter) Fetch(ctx context.Context, c transport.Interface) (any, error)
 	if err != nil {
 		return nil, fmt.Errorf("vlan: decode vlan-list: %w", err)
 	}
+	for i := range list {
+		list[i] = resolver.AutoReverseObservedBody("vlan", list[i])
+	}
 	return list, nil
 }
 
-func (vlanWriter) Diff(desired, observed any) ([]transport.Op, error) {
+func (w vlanWriter) Diff(desired, observed any) ([]transport.Op, error) {
+	resolver := w.resolverForUse()
+	path := resolver.ResolvedYANGPath("vlan", vlanListPath)
+	envelope := resolver.ResolvedEnvelopeKey("vlan", vlanEnvelopeKey)
 	desiredList, err := coerceVLANBlock(desired, "desired")
 	if err != nil {
 		return nil, err
@@ -114,20 +134,23 @@ func (vlanWriter) Diff(desired, observed any) ([]transport.Op, error) {
 		entry := projectManagedLeaves(desiredVLAN, vlanManagedLeaves)
 		entry["id"] = id
 		entry = vlanBodyToYANG(entry)
-		body, err := wrapYANGPayload(vlanEnvelopeKey, []any{entry})
+		if o, ok := resolver.GetOverride("vlan"); ok {
+			entry = ApplyOverrideToBody(entry, o)
+		}
+		body, err := wrapYANGPayload(envelope, []any{entry})
 		if err != nil {
 			return nil, err
 		}
 		ops = append(ops, transport.Op{
 			Verb: transport.VerbMerge,
-			Path: fmt.Sprintf("%s=%d", vlanListPath, id),
+			Path: fmt.Sprintf("%s=%d", path, id),
 			// 88ac685-fu: NETCONF builder needs PathSpec to emit
 			// `<vlan-list><id>998</id>...` instead of the literal
 			// `<vlan-list=998>` element. The vlanWriter is hand-
 			// written (not the keyed-list base writer) so it
 			// previously missed the PathSpec wire-up; live retest
 			// 09 phase 1 surfaced `unknown-element vlan-list=998`.
-			PathSpec: pathSpecForKeyedListEntry(vlanListPath, "id", fmt.Sprintf("%d", id)),
+			PathSpec: pathSpecForKeyedListEntry(path, resolver.ResolvedKeyField("vlan", "id"), fmt.Sprintf("%d", id)),
 			Body:     body,
 		})
 	}
@@ -167,7 +190,9 @@ func (vlanWriter) Apply(ctx context.Context, c transport.Interface, ops []transp
 // device but absent from desired. Implements PruneCapable; the
 // engine consults this only when the CR opts in via
 // spec.pruneOnRelinquish: true.
-func (vlanWriter) PruneDiff(desired, observed any) ([]transport.Op, error) {
+func (w vlanWriter) PruneDiff(desired, observed any) ([]transport.Op, error) {
+	resolver := w.resolverForUse()
+	path := resolver.ResolvedYANGPath("vlan", vlanListPath)
 	desiredList, err := coerceVLANBlock(desired, "desired")
 	if err != nil {
 		return nil, err
@@ -200,8 +225,8 @@ func (vlanWriter) PruneDiff(desired, observed any) ([]transport.Op, error) {
 	for _, id := range orphans {
 		ops = append(ops, transport.Op{
 			Verb:     transport.VerbDelete,
-			Path:     fmt.Sprintf("%s=%d", vlanListPath, id),
-			PathSpec: pathSpecForKeyedListEntry(vlanListPath, "id", fmt.Sprintf("%d", id)),
+			Path:     fmt.Sprintf("%s=%d", path, id),
+			PathSpec: pathSpecForKeyedListEntry(path, resolver.ResolvedKeyField("vlan", "id"), fmt.Sprintf("%d", id)),
 		})
 	}
 	return ops, nil

--- a/internal/drivers/iosxe/configdriver/writers/yang_shapes.go
+++ b/internal/drivers/iosxe/configdriver/writers/yang_shapes.go
@@ -97,6 +97,10 @@ func interfaceIPv4VRFToYANG(flat map[string]any) map[string]any {
 				out["ip"] = ip
 			}
 			ip["helper-address"] = []any{map[string]any{"address": s}}
+		case "ip_pim_sparse_mode":
+			// Handled separately — PIM on interface must be applied at its
+			// own sub-path, not merged into the interface body.
+			continue
 		case "shutdown":
 			// YANG type empty: presence = shut, absence = no shut.
 			// RFC 7951 encodes empty leaves as [null].
@@ -400,6 +404,19 @@ func interfaceIPv4VRFFromYANG(yang map[string]any) map[string]any {
 				if h, ok := helpers[0].(map[string]any); ok {
 					if addr, ok := h["address"]; ok {
 						out["ip_helper_address"] = addr
+					}
+				}
+			}
+			if pim, ok := ip["Cisco-IOS-XE-multicast:pim"].(map[string]any); ok {
+				if cfg, ok := pim["Cisco-IOS-XE-multicast:pim-mode-choice-cfg"].(map[string]any); ok {
+					if _, ok := cfg["sparse-mode"]; ok {
+						out["ip_pim_sparse_mode"] = true
+					}
+				}
+			} else if pim, ok := ip["pim"].(map[string]any); ok {
+				if cfg, ok := pim["Cisco-IOS-XE-multicast:pim-mode-choice-cfg"].(map[string]any); ok {
+					if _, ok := cfg["sparse-mode"]; ok {
+						out["ip_pim_sparse_mode"] = true
 					}
 				}
 			}

--- a/internal/drivers/iosxe/configdriver/writers/yang_version_override_table.go
+++ b/internal/drivers/iosxe/configdriver/writers/yang_version_override_table.go
@@ -226,6 +226,24 @@ var overrideTable = []VersionOverride{
 		FetchBodyTransform: eemFetchTransform1716,
 	},
 
+	// ── dhcp: IOS-XE 26.01 ──────────────────────────────────────
+	// Live 26.01 C9300 DHCP pool writes use the id-keyed IPv4 pool
+	// YANG shape and nested default-router/network containers. Keep
+	// NetAsCode's canonical pool shape stable and translate at the
+	// resolver boundary.
+	{
+		Family:              "dhcp",
+		MinVersion:          [2]int{26, 1},
+		MaxVersion:          [2]int{26, 2},
+		EnvelopeKeyOverride: "Cisco-IOS-XE-dhcp:pool",
+		KeyFieldOverride:    "id",
+		NeedParentCreation:  true,
+		ParentPath:          "/Cisco-IOS-XE-native:native/ip/dhcp",
+		ParentBody:          []byte(`{"Cisco-IOS-XE-native:dhcp":{}}`),
+		BodyTransform:       dhcpBodyTransformPre1718,
+		FetchBodyTransform:  dhcpFetchTransformPre1718,
+	},
+
 	// ── crypto_ipsec_transform_set: already handled ──────────────
 	// The transformSetToYANG function in crypto.go already encodes
 	// tunnel/transport as empty leaves. No override needed.

--- a/internal/drivers/iosxe/configdriver/writers/yang_version_override_table.go
+++ b/internal/drivers/iosxe/configdriver/writers/yang_version_override_table.go
@@ -248,16 +248,14 @@ var overrideTable = []VersionOverride{
 	// The transformSetToYANG function in crypto.go already encodes
 	// tunnel/transport as empty leaves. No override needed.
 
-	// ── dhcp: IOS-XE < 17.18 ────────────────────────────────────
-	// On 17.15/17.16 the DHCP pool YANG model uses "id" as the list
-	// key (not "name"), nests network under primary-network, wraps
-	// default-router in a list, and requires the Cisco-IOS-XE-dhcp:
-	// module prefix on the envelope key. Parent container /ip/dhcp
-	// must be created before the pool PUT.
+	// ── dhcp: IOS-XE 17.x through 17.18 ──────────────────────────
+	// Live C9300 devices on 17.18.x still use the id-keyed DHCP pool
+	// YANG shape: network is nested under primary-network and
+	// default-router is a list. Keep this active through 17.18.x.
 	{
 		Family:              "dhcp",
 		MinVersion:          [2]int{17, 0},
-		MaxVersion:          [2]int{17, 18},
+		MaxVersion:          [2]int{17, 19},
 		EnvelopeKeyOverride: "Cisco-IOS-XE-dhcp:pool",
 		KeyFieldOverride:    "id",
 		NeedParentCreation:  true,

--- a/internal/drivers/iosxe/devicegrpc/metrics.go
+++ b/internal/drivers/iosxe/devicegrpc/metrics.go
@@ -1,0 +1,89 @@
+// Copyright © 2026 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package devicegrpc
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	metricsOnce sync.Once
+
+	leaseEvents         *prometheus.CounterVec
+	outstandingLeases   *prometheus.GaugeVec
+	closeLeakDetections *prometheus.CounterVec
+)
+
+// RegisterMetrics registers workload-classed gRPC pool metrics. It is safe to
+// call more than once in a process; the first registry wins.
+func RegisterMetrics(reg prometheus.Registerer) {
+	metricsOnce.Do(func() {
+		leaseEvents = prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "cisco_vk_devicegrpc_lease_events_total",
+				Help: "Count of workload-classed device gRPC pool lease lifecycle events.",
+			},
+			[]string{"class", "event"},
+		)
+		outstandingLeases = prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "cisco_vk_devicegrpc_outstanding_leases",
+				Help: "Current outstanding device gRPC pool leases by workload class.",
+			},
+			[]string{"class"},
+		)
+		closeLeakDetections = prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "cisco_vk_devicegrpc_close_leak_detected_total",
+				Help: "Count of outstanding leases observed when a device gRPC pool closes.",
+			},
+			[]string{"class"},
+		)
+		reg.MustRegister(leaseEvents, outstandingLeases, closeLeakDetections)
+	})
+}
+
+func recordLease(class WorkloadClass) {
+	if leaseEvents == nil || outstandingLeases == nil {
+		return
+	}
+	label := class.String()
+	leaseEvents.WithLabelValues(label, "lease").Inc()
+	outstandingLeases.WithLabelValues(label).Inc()
+}
+
+func recordRelease(class WorkloadClass) {
+	if leaseEvents == nil || outstandingLeases == nil {
+		return
+	}
+	label := class.String()
+	leaseEvents.WithLabelValues(label, "release").Inc()
+	outstandingLeases.WithLabelValues(label).Dec()
+}
+
+func recordCloseLeaks(class WorkloadClass, count int) {
+	if count <= 0 {
+		return
+	}
+	label := class.String()
+	if closeLeakDetections != nil {
+		closeLeakDetections.WithLabelValues(label).Add(float64(count))
+	}
+	if outstandingLeases != nil {
+		outstandingLeases.WithLabelValues(label).Sub(float64(count))
+	}
+}

--- a/internal/drivers/iosxe/devicegrpc/pool.go
+++ b/internal/drivers/iosxe/devicegrpc/pool.go
@@ -189,8 +189,9 @@ type entryKey struct {
 }
 
 type entry struct {
-	conn *grpc.ClientConn
-	refs int
+	conn  *grpc.ClientConn
+	refs  int
+	class WorkloadClass
 }
 
 type pool struct {
@@ -218,10 +219,11 @@ func (p *pool) Lease(ctx context.Context, key DeviceKey, class WorkloadClass) (*
 		if err != nil {
 			return nil, fmt.Errorf("devicegrpc: dial %s (%s): %w", key.Target(), class, err)
 		}
-		e = &entry{conn: conn}
+		e = &entry{conn: conn, class: class}
 		p.entries[k] = e
 	}
 	e.refs++
+	recordLease(class)
 	return &Lease{
 		Conn:    e.conn,
 		release: func() { p.release(k) },
@@ -236,6 +238,7 @@ func (p *pool) release(k entryKey) {
 		return
 	}
 	e.refs--
+	recordRelease(e.class)
 	if e.refs <= 0 {
 		_ = e.conn.Close()
 		delete(p.entries, k)
@@ -253,6 +256,7 @@ func (p *pool) Close() error {
 	for k, e := range p.entries {
 		if e.refs > 0 {
 			outstanding += e.refs
+			recordCloseLeaks(e.class, e.refs)
 		}
 		_ = e.conn.Close()
 		delete(p.entries, k)

--- a/internal/drivers/iosxe/gnoi/capability.go
+++ b/internal/drivers/iosxe/gnoi/capability.go
@@ -72,7 +72,18 @@ func NewCapabilityCache(now func() time.Time) *CapabilityCache {
 // the TTL and are not overwritten by Observe; callers that pin
 // supported=true and then encounter codes.Unimplemented still get
 // the wrapped error from method calls but the cache remains pinned.
+//
+// Production callers should only invoke Pin from the wiring boundary
+// that translates explicit operator policy into client options. Do not
+// call it from reconcilers or request handlers as a shortcut around an
+// Unimplemented response; that would bypass the fail-fast safety gate
+// for unsupported destructive RPCs.
 func (c *CapabilityCache) Pin(svc Service, supported bool) {
+	if supported {
+		recordCapabilityEvent(svc, "pin_supported")
+	} else {
+		recordCapabilityEvent(svc, "pin_unsupported")
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.entries[svc] = capEntry{
@@ -88,6 +99,7 @@ func (c *CapabilityCache) Pin(svc Service, supported bool) {
 // transient and would otherwise pin a stale verdict on a transient
 // blip.
 func (c *CapabilityCache) Observe(svc Service, err error) {
+	recordRPC(svc, err)
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	e := c.entries[svc]
@@ -116,13 +128,25 @@ func (c *CapabilityCache) Supported(svc Service) (supported, known bool, lastErr
 	defer c.mu.RUnlock()
 	e, ok := c.entries[svc]
 	if !ok {
+		recordCapabilityEvent(svc, "miss")
 		return true, false, nil
 	}
 	if e.pinned {
+		if e.supported {
+			recordCapabilityEvent(svc, "hit_pinned_supported")
+		} else {
+			recordCapabilityEvent(svc, "hit_pinned_unsupported")
+		}
 		return e.supported, true, e.lastErr
 	}
 	if c.now().Sub(e.checkedAt) > capabilityTTL {
+		recordCapabilityEvent(svc, "expired")
 		return true, false, nil
+	}
+	if e.supported {
+		recordCapabilityEvent(svc, "hit_supported")
+	} else {
+		recordCapabilityEvent(svc, "hit_unsupported")
 	}
 	return e.supported, true, e.lastErr
 }
@@ -133,6 +157,7 @@ func (c *CapabilityCache) Supported(svc Service) (supported, known bool, lastErr
 func (c *CapabilityCache) ensureSupported(svc Service) error {
 	supported, known, lastErr := c.Supported(svc)
 	if known && !supported {
+		recordCapabilityEvent(svc, "fail_fast")
 		cause := lastErr
 		if cause == nil {
 			cause = errors.New("device reported codes.Unimplemented")

--- a/internal/drivers/iosxe/gnoi/client.go
+++ b/internal/drivers/iosxe/gnoi/client.go
@@ -62,6 +62,24 @@ func (e *ErrServiceUnsupported) Unwrap() error { return e.Cause }
 // own at the call site.
 type AuthContext func(context.Context) context.Context
 
+// Provider exposes a per-device gNOI client to reconcilers.
+type Provider interface {
+	GNOIClient(ctx context.Context) (*Client, error)
+}
+
+// ResetProvider is implemented by providers that can drop their
+// current gRPC leases and build a fresh client after a transient
+// transport failure.
+type ResetProvider interface {
+	Provider
+	ResetGNOIClient(ctx context.Context)
+}
+
+// BulkConnProvider lazily leases the bulk-transfer gRPC connection
+// used by OS.Install and File.Put/Get. The returned release function
+// must be called once the bulk RPC has completed.
+type BulkConnProvider func(ctx context.Context) (*grpc.ClientConn, func(), error)
+
 // Options carries optional inputs to New. Defaults are sensible for
 // IOS-XE; tests substitute fake clients via the With* hooks.
 type Options struct {
@@ -75,6 +93,11 @@ type Options struct {
 	// WorkloadClass ClassBulkTransfer so a 500 MB image transfer
 	// cannot HOL-block control RPCs.
 	BulkConn *grpc.ClientConn
+
+	// BulkConnProvider lazily leases a bulk-transfer conn per bulk RPC.
+	// Prefer this in production so idle per-device VK pods do not hold
+	// ClassBulkTransfer leases until an OS/file transfer actually runs.
+	BulkConnProvider BulkConnProvider
 
 	// Now is the clock used by the capability cache. nil means time.Now.
 	Now func() time.Time
@@ -95,8 +118,9 @@ type Client struct {
 	cert   certpb.CertificateManagementClient
 	reset  resetpb.FactoryResetClient
 
-	osBulk   ospb.OSClient
-	fileBulk filepb.FileClient
+	osBulk       ospb.OSClient
+	fileBulk     filepb.FileClient
+	bulkProvider BulkConnProvider
 
 	cap *CapabilityCache
 }
@@ -126,8 +150,9 @@ func New(conn *grpc.ClientConn, opts Options) (*Client, error) {
 		cert:   certpb.NewCertificateManagementClient(conn),
 		reset:  resetpb.NewFactoryResetClient(conn),
 
-		osBulk:   ospb.NewOSClient(bulk),
-		fileBulk: filepb.NewFileClient(bulk),
+		osBulk:       ospb.NewOSClient(bulk),
+		fileBulk:     filepb.NewFileClient(bulk),
+		bulkProvider: opts.BulkConnProvider,
 
 		cap: NewCapabilityCache(opts.Now),
 	}
@@ -141,6 +166,34 @@ func New(conn *grpc.ClientConn, opts Options) (*Client, error) {
 // pre-probe by invoking the cache directly or rely on lazy probing
 // on first method call.
 func (c *Client) Capabilities() *CapabilityCache { return c.cap }
+
+func (c *Client) bulkOSClient(ctx context.Context) (ospb.OSClient, func(), error) {
+	if c.bulkProvider == nil {
+		return c.osBulk, func() {}, nil
+	}
+	conn, release, err := c.bulkProvider(ctx)
+	if err != nil {
+		return nil, func() {}, err
+	}
+	if release == nil {
+		release = func() {}
+	}
+	return ospb.NewOSClient(conn), release, nil
+}
+
+func (c *Client) bulkFileClient(ctx context.Context) (filepb.FileClient, func(), error) {
+	if c.bulkProvider == nil {
+		return c.fileBulk, func() {}, nil
+	}
+	conn, release, err := c.bulkProvider(ctx)
+	if err != nil {
+		return nil, func() {}, err
+	}
+	if release == nil {
+		release = func() {}
+	}
+	return filepb.NewFileClient(conn), release, nil
+}
 
 // authCtx applies the configured AuthContext to ctx.
 func (c *Client) authCtx(ctx context.Context) context.Context {

--- a/internal/drivers/iosxe/gnoi/client_test.go
+++ b/internal/drivers/iosxe/gnoi/client_test.go
@@ -17,6 +17,7 @@ package gnoi
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"errors"
 	"io"
 	"net"
@@ -35,6 +36,7 @@ import (
 	filepb "github.com/openconfig/gnoi/file"
 	ospb "github.com/openconfig/gnoi/os"
 	syspb "github.com/openconfig/gnoi/system"
+	commonpb "github.com/openconfig/gnoi/types"
 )
 
 // --- fake server hooks ---
@@ -73,12 +75,34 @@ func (f *fakeSystem) RebootStatus(context.Context, *syspb.RebootStatusRequest) (
 
 type fakeFile struct {
 	filepb.UnimplementedFileServer
-	statResp *filepb.StatResponse
-	statErr  error
+	statResp  *filepb.StatResponse
+	statErr   error
+	getChunks [][]byte
+	getHash   *commonpb.HashType
+	getErr    error
 }
 
 func (f *fakeFile) Stat(context.Context, *filepb.StatRequest) (*filepb.StatResponse, error) {
 	return f.statResp, f.statErr
+}
+
+func (f *fakeFile) Get(_ *filepb.GetRequest, stream grpc.ServerStreamingServer[filepb.GetResponse]) error {
+	if f.getErr != nil {
+		return f.getErr
+	}
+	for _, chunk := range f.getChunks {
+		if err := stream.Send(&filepb.GetResponse{
+			Response: &filepb.GetResponse_Contents{Contents: chunk},
+		}); err != nil {
+			return err
+		}
+	}
+	if f.getHash != nil {
+		return stream.Send(&filepb.GetResponse{
+			Response: &filepb.GetResponse_Hash{Hash: f.getHash},
+		})
+	}
+	return nil
 }
 
 type fakeCert struct {
@@ -104,6 +128,8 @@ type fakeOS struct {
 	verifyResp          *ospb.VerifyResponse
 	verifyErr           error
 	installRequireClose bool
+	installFirstResp    *ospb.InstallResponse
+	installSendSync     bool
 	installEOFSeen      bool
 	installBytes        int
 }
@@ -121,10 +147,17 @@ func (f *fakeOS) Install(stream grpc.BidiStreamingServer[ospb.InstallRequest, os
 	if req == nil {
 		return status.Error(codes.InvalidArgument, "expected transfer request")
 	}
-	if err := stream.Send(&ospb.InstallResponse{
-		Response: &ospb.InstallResponse_TransferReady{TransferReady: &ospb.TransferReady{}},
-	}); err != nil {
+	firstResp := f.installFirstResp
+	if firstResp == nil {
+		firstResp = &ospb.InstallResponse{
+			Response: &ospb.InstallResponse_TransferReady{TransferReady: &ospb.TransferReady{}},
+		}
+	}
+	if err := stream.Send(firstResp); err != nil {
 		return err
+	}
+	if _, ok := firstResp.Response.(*ospb.InstallResponse_TransferReady); !ok {
+		return nil
 	}
 	for {
 		next, err := stream.Recv()
@@ -140,6 +173,15 @@ func (f *fakeOS) Install(stream grpc.BidiStreamingServer[ospb.InstallRequest, os
 				},
 			}); err != nil {
 				return err
+			}
+			if f.installSendSync {
+				if err := stream.Send(&ospb.InstallResponse{
+					Response: &ospb.InstallResponse_SyncProgress{
+						SyncProgress: &ospb.SyncProgress{PercentageTransferred: 42},
+					},
+				}); err != nil {
+					return err
+				}
 			}
 		case *ospb.InstallRequest_TransferEnd:
 			if f.installRequireClose {
@@ -289,6 +331,36 @@ func TestStatAcceptsFlashPath(t *testing.T) {
 	}
 }
 
+func TestGetStreamsContentsAndHash(t *testing.T) {
+	ts := newTestServer(t)
+	sum := sha256.Sum256([]byte("hello flash"))
+	ts.File.getChunks = [][]byte{[]byte("hello "), []byte("flash")}
+	ts.File.getHash = &commonpb.HashType{Method: commonpb.HashType_SHA256, Hash: sum[:]}
+
+	var buf bytes.Buffer
+	hash, err := ts.client(t).Get(context.Background(), "flash:hello-app.iosxe.tar", &buf)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if buf.String() != "hello flash" {
+		t.Fatalf("streamed contents=%q", buf.String())
+	}
+	if hash.GetMethod() != commonpb.HashType_SHA256 || !bytes.Equal(hash.GetHash(), sum[:]) {
+		t.Fatalf("hash=%+v, want SHA256 %x", hash, sum)
+	}
+}
+
+func TestGetMissingHashFails(t *testing.T) {
+	ts := newTestServer(t)
+	ts.File.getChunks = [][]byte{[]byte("payload")}
+
+	var buf bytes.Buffer
+	_, err := ts.client(t).Get(context.Background(), "flash:payload.bin", &buf)
+	if err == nil || !strings.Contains(err.Error(), "no terminal hash") {
+		t.Fatalf("expected missing-hash error, got %v", err)
+	}
+}
+
 // --- cert ---
 
 func TestGetCertificates(t *testing.T) {
@@ -373,6 +445,87 @@ func TestInstallClosesSendAfterTransferEnd(t *testing.T) {
 	}
 	if ts.OS.installBytes != 5 {
 		t.Fatalf("installBytes=%d, want 5", ts.OS.installBytes)
+	}
+}
+
+func TestInstallSurfacesDeviceInstallError(t *testing.T) {
+	ts := newTestServer(t)
+	ts.OS.installFirstResp = &ospb.InstallResponse{
+		Response: &ospb.InstallResponse_InstallError{
+			InstallError: &ospb.InstallError{Type: ospb.InstallError_INTEGRITY_FAIL, Detail: "bad sha"},
+		},
+	}
+
+	progress, err := ts.client(t).Install(context.Background(), bytes.NewReader([]byte("image")), InstallOpts{
+		Version:     "17.18.03",
+		PackageSize: 5,
+	})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	var gotErr error
+	for ev := range progress {
+		if ev.Err != nil {
+			gotErr = ev.Err
+		}
+	}
+	var installErr *InstallError
+	if !errors.As(gotErr, &installErr) {
+		t.Fatalf("expected *InstallError, got %T %v", gotErr, gotErr)
+	}
+	if installErr.Type != InstallErrorIntegrityFail {
+		t.Fatalf("InstallError.Type=%q", installErr.Type)
+	}
+}
+
+func TestInstallEmitsSyncProgress(t *testing.T) {
+	ts := newTestServer(t)
+	ts.OS.installSendSync = true
+
+	progress, err := ts.client(t).Install(context.Background(), bytes.NewReader([]byte("image")), InstallOpts{
+		Version:     "17.18.03",
+		PackageSize: 5,
+	})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	var syncPct uint32
+	for ev := range progress {
+		if ev.Err != nil {
+			t.Fatalf("Install progress error: %v", ev.Err)
+		}
+		if ev.SyncProgress != nil {
+			syncPct = ev.SyncProgress.PercentageTransferred
+		}
+	}
+	if syncPct != 42 {
+		t.Fatalf("SyncProgress=%d, want 42", syncPct)
+	}
+}
+
+func TestInstallRejectsUnexpectedFirstResponse(t *testing.T) {
+	ts := newTestServer(t)
+	ts.OS.installFirstResp = &ospb.InstallResponse{
+		Response: &ospb.InstallResponse_TransferProgress{
+			TransferProgress: &ospb.TransferProgress{BytesReceived: 1},
+		},
+	}
+
+	progress, err := ts.client(t).Install(context.Background(), bytes.NewReader([]byte("image")), InstallOpts{
+		Version:     "17.18.03",
+		PackageSize: 5,
+	})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	var gotErr error
+	for ev := range progress {
+		if ev.Err != nil {
+			gotErr = ev.Err
+		}
+	}
+	if gotErr == nil || !strings.Contains(gotErr.Error(), "unexpected first response") {
+		t.Fatalf("expected unexpected-first-response error, got %v", gotErr)
 	}
 }
 

--- a/internal/drivers/iosxe/gnoi/file.go
+++ b/internal/drivers/iosxe/gnoi/file.go
@@ -145,7 +145,14 @@ func (c *Client) Put(ctx context.Context, path string, r io.Reader, opts PutOpts
 		return fmt.Errorf("gnoi File.Put: ChunkSize=%d exceeds 1 MiB cap", opts.ChunkSize)
 	}
 
-	stream, err := c.fileBulk.Put(c.authCtx(ctx))
+	fileClient, releaseBulk, err := c.bulkFileClient(ctx)
+	if err != nil {
+		c.cap.Observe(ServiceFile, err)
+		return fmt.Errorf("gnoi File.Put bulk lease: %w", err)
+	}
+	defer releaseBulk()
+
+	stream, err := fileClient.Put(c.authCtx(ctx))
 	if err != nil {
 		c.cap.Observe(ServiceFile, err)
 		return fmt.Errorf("gnoi File.Put open: %w", err)
@@ -171,7 +178,7 @@ func (c *Client) Put(ctx context.Context, path string, r io.Reader, opts PutOpts
 				return fmt.Errorf("gnoi File.Put send chunk: %w", err)
 			}
 		}
-		if rerr == io.EOF {
+		if errors.Is(rerr, io.EOF) {
 			break
 		}
 		if rerr != nil {
@@ -226,7 +233,14 @@ func (c *Client) Get(ctx context.Context, path string, w io.Writer) (*commonpb.H
 	if err := ValidateIOSXEPath(path); err != nil {
 		return nil, err
 	}
-	stream, err := c.fileBulk.Get(c.authCtx(ctx), &filepb.GetRequest{RemoteFile: path})
+	fileClient, releaseBulk, err := c.bulkFileClient(ctx)
+	if err != nil {
+		c.cap.Observe(ServiceFile, err)
+		return nil, fmt.Errorf("gnoi File.Get bulk lease: %w", err)
+	}
+	defer releaseBulk()
+
+	stream, err := fileClient.Get(c.authCtx(ctx), &filepb.GetRequest{RemoteFile: path})
 	if err != nil {
 		c.cap.Observe(ServiceFile, err)
 		return nil, fmt.Errorf("gnoi File.Get: %w", err)
@@ -234,7 +248,7 @@ func (c *Client) Get(ctx context.Context, path string, w io.Writer) (*commonpb.H
 	var serverHash *commonpb.HashType
 	for {
 		resp, err := stream.Recv()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/internal/drivers/iosxe/gnoi/file.go
+++ b/internal/drivers/iosxe/gnoi/file.go
@@ -43,10 +43,27 @@ var IOSXEFilesystemPrefixes = []string{
 }
 
 // ValidateIOSXEPath returns nil when path begins with a recognised
-// IOS-XE filesystem prefix.
+// IOS-XE filesystem prefix and does not escape into another filesystem.
 func ValidateIOSXEPath(path string) error {
 	for _, p := range IOSXEFilesystemPrefixes {
 		if strings.HasPrefix(path, p) {
+			rest := strings.TrimPrefix(path, p)
+			if strings.HasPrefix(rest, "/") {
+				rest = strings.TrimPrefix(rest, "/")
+			}
+			if rest == "" {
+				return fmt.Errorf("gnoi: path %q has no file component after IOS-XE filesystem prefix %q", path, p)
+			}
+			for _, segment := range strings.Split(rest, "/") {
+				if segment == "" || segment == "." || segment == ".." {
+					return fmt.Errorf("gnoi: path %q contains invalid segment %q", path, segment)
+				}
+				for _, other := range IOSXEFilesystemPrefixes {
+					if strings.Contains(segment, other) {
+						return fmt.Errorf("gnoi: path %q contains nested IOS-XE filesystem prefix %q", path, other)
+					}
+				}
+			}
 			return nil
 		}
 	}
@@ -117,6 +134,9 @@ func (c *Client) Put(ctx context.Context, path string, r io.Reader, opts PutOpts
 	}
 	if opts.Permissions == 0 {
 		opts.Permissions = 0o644
+	}
+	if opts.Permissions > 0o777 {
+		return fmt.Errorf("gnoi File.Put: Permissions=%#o exceeds 0777", opts.Permissions)
 	}
 	if opts.ChunkSize == 0 {
 		opts.ChunkSize = 64 * 1024

--- a/internal/drivers/iosxe/gnoi/file_test.go
+++ b/internal/drivers/iosxe/gnoi/file_test.go
@@ -1,0 +1,56 @@
+// Copyright © 2026 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gnoi
+
+import "testing"
+
+func TestValidateIOSXEPathRejectsTraversalAndNestedPrefixes(t *testing.T) {
+	t.Parallel()
+	tests := []string{
+		"flash:",
+		"flash:/",
+		"flash:../../nvram:/startup-config",
+		"flash:dir/../startup-config",
+		"flash:dir//startup-config",
+		"flash:dir/nvram:/startup-config",
+		"tmp/startup-config",
+	}
+	for _, path := range tests {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+			if err := ValidateIOSXEPath(path); err == nil {
+				t.Fatalf("ValidateIOSXEPath(%q) succeeded, want rejection", path)
+			}
+		})
+	}
+}
+
+func TestValidateIOSXEPathAcceptsFlashFilePaths(t *testing.T) {
+	t.Parallel()
+	tests := []string{
+		"flash:hello-app.tar",
+		"flash:/cvk/images/cat9k.bin",
+		"bootflash:packages.conf",
+		"nvram:startup-config",
+	}
+	for _, path := range tests {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+			if err := ValidateIOSXEPath(path); err != nil {
+				t.Fatalf("ValidateIOSXEPath(%q): %v", path, err)
+			}
+		})
+	}
+}

--- a/internal/drivers/iosxe/gnoi/metrics.go
+++ b/internal/drivers/iosxe/gnoi/metrics.go
@@ -1,0 +1,84 @@
+// Copyright © 2026 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gnoi
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	metricsOnce sync.Once
+
+	rpcTotal         *prometheus.CounterVec
+	capabilityEvents *prometheus.CounterVec
+)
+
+// RegisterMetrics registers gNOI client metrics. It is safe to call more
+// than once in a process; the first registry wins.
+func RegisterMetrics(reg prometheus.Registerer) {
+	metricsOnce.Do(func() {
+		rpcTotal = prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "cisco_vk_gnoi_rpc_total",
+				Help: "Count of gNOI RPC outcomes observed by the IOS-XE gNOI client.",
+			},
+			[]string{"service", "outcome"},
+		)
+		capabilityEvents = prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "cisco_vk_gnoi_capability_cache_total",
+				Help: "Count of gNOI capability-cache hits, misses, expirations, pins, and fail-fast decisions.",
+			},
+			[]string{"service", "result"},
+		)
+		reg.MustRegister(rpcTotal, capabilityEvents)
+	})
+}
+
+func recordRPC(svc Service, err error) {
+	if rpcTotal == nil {
+		return
+	}
+	rpcTotal.WithLabelValues(string(svc), rpcOutcome(err)).Inc()
+}
+
+func recordCapabilityEvent(svc Service, result string) {
+	if capabilityEvents == nil {
+		return
+	}
+	capabilityEvents.WithLabelValues(string(svc), result).Inc()
+}
+
+func rpcOutcome(err error) string {
+	if err == nil {
+		return "ok"
+	}
+	switch status.Code(err) {
+	case codes.Unimplemented:
+		return "unimplemented"
+	case codes.DeadlineExceeded:
+		return "deadline_exceeded"
+	case codes.Canceled:
+		return "canceled"
+	case codes.Unavailable:
+		return "unavailable"
+	default:
+		return "error"
+	}
+}

--- a/internal/drivers/iosxe/gnoi/os.go
+++ b/internal/drivers/iosxe/gnoi/os.go
@@ -169,8 +169,14 @@ func (c *Client) Install(ctx context.Context, r io.Reader, opts InstallOpts) (<-
 	if opts.ChunkSize > 1024*1024 {
 		return nil, fmt.Errorf("gnoi OS.Install: ChunkSize=%d exceeds 1 MiB cap", opts.ChunkSize)
 	}
-	stream, err := c.osBulk.Install(c.authCtx(ctx))
+	osClient, releaseBulk, err := c.bulkOSClient(ctx)
 	if err != nil {
+		c.cap.Observe(ServiceOS, err)
+		return nil, fmt.Errorf("gnoi OS.Install bulk lease: %w", err)
+	}
+	stream, err := osClient.Install(c.authCtx(ctx))
+	if err != nil {
+		releaseBulk()
 		c.cap.Observe(ServiceOS, err)
 		return nil, fmt.Errorf("gnoi OS.Install open: %w", err)
 	}
@@ -186,12 +192,16 @@ func (c *Client) Install(ctx context.Context, r io.Reader, opts InstallOpts) (<-
 		},
 	}); err != nil {
 		_ = stream.CloseSend()
+		releaseBulk()
 		c.cap.Observe(ServiceOS, err)
 		return nil, fmt.Errorf("gnoi OS.Install send TransferRequest: %w", err)
 	}
 
 	out := make(chan InstallProgress, 4)
-	go c.pumpInstall(ctx, stream, r, opts, out)
+	go func() {
+		defer releaseBulk()
+		c.pumpInstall(ctx, stream, r, opts, out)
+	}()
 	return out, nil
 }
 
@@ -269,7 +279,7 @@ func (c *Client) pumpInstall(
 					return
 				}
 			}
-			if rerr == io.EOF {
+			if errors.Is(rerr, io.EOF) {
 				// Terminator.
 				if serr := stream.Send(&ospb.InstallRequest{
 					Request: &ospb.InstallRequest_TransferEnd{TransferEnd: &ospb.TransferEnd{}},
@@ -296,7 +306,7 @@ func (c *Client) pumpInstall(
 	// Recv loop until Validated or InstallError.
 	for {
 		resp, err := stream.Recv()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			// Wait for the sender to finish before treating as terminal.
 			if serr := <-doneSend; serr != nil {
 				emitInstallErr(serr)
@@ -393,11 +403,20 @@ type ActivateOpts struct {
 	NoReboot bool
 }
 
+// ActivateErrorType mirrors the device-side ActivateError.Type enum.
+type ActivateErrorType string
+
+const (
+	ActivateErrorUnspecified          ActivateErrorType = "UNSPECIFIED"
+	ActivateErrorNonExistentVersion   ActivateErrorType = "NON_EXISTENT_VERSION"
+	ActivateErrorNotSupportedOnBackup ActivateErrorType = "NOT_SUPPORTED_ON_BACKUP"
+)
+
 // ActivateError wraps a device-side ActivateError so reconcilers can
-// classify failures (NON_EXISTENT_VERSION → terminal preflight bug;
-// NOT_SUPPORTED_ON_BACKUP → operator config issue).
+// classify failures (NON_EXISTENT_VERSION → retry alternate version
+// spelling; NOT_SUPPORTED_ON_BACKUP → operator config issue).
 type ActivateError struct {
-	Type   string
+	Type   ActivateErrorType
 	Detail string
 }
 
@@ -430,7 +449,18 @@ func (c *Client) Activate(ctx context.Context, opts ActivateOpts) error {
 	case *ospb.ActivateResponse_ActivateOk:
 		return nil
 	case *ospb.ActivateResponse_ActivateError:
-		return &ActivateError{Type: r.ActivateError.Type.String(), Detail: r.ActivateError.Detail}
+		return &ActivateError{Type: activateErrorTypeFromProto(r.ActivateError.Type), Detail: r.ActivateError.Detail}
 	}
 	return fmt.Errorf("gnoi OS.Activate: unexpected response %T", resp.Response)
+}
+
+func activateErrorTypeFromProto(t ospb.ActivateError_Type) ActivateErrorType {
+	switch t {
+	case ospb.ActivateError_NON_EXISTENT_VERSION:
+		return ActivateErrorNonExistentVersion
+	case ospb.ActivateError_NOT_SUPPORTED_ON_BACKUP:
+		return ActivateErrorNotSupportedOnBackup
+	default:
+		return ActivateErrorUnspecified
+	}
 }

--- a/internal/drivers/iosxe/gnoi/os.go
+++ b/internal/drivers/iosxe/gnoi/os.go
@@ -206,29 +206,46 @@ func (c *Client) pumpInstall(
 	out chan<- InstallProgress,
 ) {
 	defer close(out)
-	defer c.cap.Observe(ServiceOS, nil) // best-effort positive observe; pump exits on success
+	emitInstallErr := func(err error) {
+		c.cap.Observe(ServiceOS, err)
+		emitErr(out, ctx, err)
+	}
+	emitInstall := func(p InstallProgress) bool {
+		if emit(out, ctx, p) {
+			return true
+		}
+		if err := ctx.Err(); err != nil {
+			c.cap.Observe(ServiceOS, err)
+		}
+		return false
+	}
+	emitValidated := func(v *InstallValidated) {
+		if emitInstall(InstallProgress{Validated: v}) {
+			c.cap.Observe(ServiceOS, nil)
+		}
+	}
 
 	// First device response: TransferReady, or — if the device already
 	// has the version staged — Validated directly.
 	resp, err := stream.Recv()
 	if err != nil {
-		emitErr(out, ctx, fmt.Errorf("gnoi OS.Install recv first: %w", err))
+		emitInstallErr(fmt.Errorf("gnoi OS.Install recv first: %w", err))
 		return
 	}
 	switch r := resp.Response.(type) {
 	case *ospb.InstallResponse_Validated:
-		out <- InstallProgress{Validated: &InstallValidated{Version: r.Validated.Version, Description: r.Validated.Description}}
+		emitValidated(&InstallValidated{Version: r.Validated.Version, Description: r.Validated.Description})
 		return
 	case *ospb.InstallResponse_InstallError:
-		emitErr(out, ctx, &InstallError{Type: installErrorTypeFromProto(r.InstallError.Type), Detail: r.InstallError.Detail})
+		emitInstallErr(&InstallError{Type: installErrorTypeFromProto(r.InstallError.Type), Detail: r.InstallError.Detail})
 		return
 	case *ospb.InstallResponse_TransferReady:
 		// proceed to stream bytes
 	default:
-		emitErr(out, ctx, fmt.Errorf("gnoi OS.Install: unexpected first response %T", r))
+		emitInstallErr(fmt.Errorf("gnoi OS.Install: unexpected first response %T", r))
 		return
 	}
-	if !emit(out, ctx, InstallProgress{TransferReady: true}) {
+	if !emitInstall(InstallProgress{TransferReady: true}) {
 		return
 	}
 
@@ -237,6 +254,12 @@ func (c *Client) pumpInstall(
 	go func() {
 		buf := make([]byte, opts.ChunkSize)
 		for {
+			select {
+			case <-ctx.Done():
+				doneSend <- ctx.Err()
+				return
+			default:
+			}
 			n, rerr := r.Read(buf)
 			if n > 0 {
 				if serr := stream.Send(&ospb.InstallRequest{
@@ -276,38 +299,41 @@ func (c *Client) pumpInstall(
 		if err == io.EOF {
 			// Wait for the sender to finish before treating as terminal.
 			if serr := <-doneSend; serr != nil {
-				emitErr(out, ctx, serr)
+				emitInstallErr(serr)
 			} else {
-				emitErr(out, ctx, errors.New("gnoi OS.Install: stream closed before Validated"))
+				emitInstallErr(errors.New("gnoi OS.Install: stream closed before Validated"))
 			}
 			return
 		}
 		if err != nil {
-			emitErr(out, ctx, fmt.Errorf("gnoi OS.Install recv: %w", err))
+			_ = stream.CloseSend()
+			emitInstallErr(fmt.Errorf("gnoi OS.Install recv: %w", err))
 			return
 		}
 		switch r := resp.Response.(type) {
 		case *ospb.InstallResponse_TransferProgress:
-			if !emit(out, ctx, InstallProgress{TransferProgress: &InstallTransferProgress{BytesReceived: r.TransferProgress.BytesReceived}}) {
+			if !emitInstall(InstallProgress{TransferProgress: &InstallTransferProgress{BytesReceived: r.TransferProgress.BytesReceived}}) {
 				return
 			}
 		case *ospb.InstallResponse_SyncProgress:
-			if !emit(out, ctx, InstallProgress{SyncProgress: &InstallSyncProgress{PercentageTransferred: r.SyncProgress.PercentageTransferred}}) {
+			if !emitInstall(InstallProgress{SyncProgress: &InstallSyncProgress{PercentageTransferred: r.SyncProgress.PercentageTransferred}}) {
 				return
 			}
 		case *ospb.InstallResponse_Validated:
 			// drain sender before signalling success
 			if serr := <-doneSend; serr != nil {
-				emitErr(out, ctx, serr)
+				emitInstallErr(serr)
 				return
 			}
-			out <- InstallProgress{Validated: &InstallValidated{Version: r.Validated.Version, Description: r.Validated.Description}}
+			emitValidated(&InstallValidated{Version: r.Validated.Version, Description: r.Validated.Description})
 			return
 		case *ospb.InstallResponse_InstallError:
-			emitErr(out, ctx, &InstallError{Type: installErrorTypeFromProto(r.InstallError.Type), Detail: r.InstallError.Detail})
+			_ = stream.CloseSend()
+			emitInstallErr(&InstallError{Type: installErrorTypeFromProto(r.InstallError.Type), Detail: r.InstallError.Detail})
 			return
 		default:
-			emitErr(out, ctx, fmt.Errorf("gnoi OS.Install: unexpected response %T", r))
+			_ = stream.CloseSend()
+			emitInstallErr(fmt.Errorf("gnoi OS.Install: unexpected response %T", r))
 			return
 		}
 	}

--- a/internal/drivers/iosxe/gnoi/system.go
+++ b/internal/drivers/iosxe/gnoi/system.go
@@ -16,6 +16,7 @@ package gnoi
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -83,7 +84,7 @@ func (c *Client) Ping(ctx context.Context, destination string, opts PingOpts) (*
 	res := &PingResult{}
 	for {
 		resp, err := stream.Recv()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {
@@ -168,7 +169,7 @@ func (c *Client) Traceroute(ctx context.Context, destination string, opts Tracer
 	res := &TracerouteResult{Destination: destination}
 	for {
 		resp, err := stream.Recv()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/internal/drivers/iosxe/pod_lifecycle.go
+++ b/internal/drivers/iosxe/pod_lifecycle.go
@@ -67,6 +67,11 @@ func (d *XEDriver) DeployPod(ctx context.Context, pod *v1.Pod, secretLister core
 // Apps that are already RUNNING are left untouched (benign metadata-only change).
 // Apps in any other state (or missing) are deleted and redeployed.
 func (d *XEDriver) UpdatePod(ctx context.Context, pod *v1.Pod) error {
+	if pod.DeletionTimestamp != nil {
+		log.G(ctx).Infof("UpdatePod: pod %s/%s is deleting; driving cleanup instead of redeploy", pod.Namespace, pod.Name)
+		return d.DeletePod(ctx, pod)
+	}
+
 	discoveredContainers, err := d.GetPodContainers(ctx, pod)
 	if err != nil || len(discoveredContainers) == 0 {
 		log.G(ctx).Infof("UpdatePod: no existing apps found for pod %s/%s, deploying fresh", pod.Namespace, pod.Name)
@@ -280,10 +285,11 @@ func (d *XEDriver) DeletePod(ctx context.Context, pod *v1.Pod) error {
 		log.G(ctx).Warnf("Failed to get all containers for pod %s/%s: %v. Continuing with partial deletion.", pod.Namespace, pod.Name, err)
 		// Don't return error here - we'll delete what we found
 	}
+	deletionTargets := podDeletionTargets(ctx, pod, discoveredContainers)
 
 	deletionErrors := []string{}
 
-	for containerName, appID := range discoveredContainers {
+	for containerName, appID := range deletionTargets {
 		log.G(ctx).Infof("Deleting container %s (app: %s)", containerName, appID)
 
 		err = d.DeleteApp(ctx, appID)
@@ -448,6 +454,11 @@ func (d *XEDriver) GetPodStatus(ctx context.Context, pod *v1.Pod) (*v1.Pod, erro
 // the necessary env-var resolution would fail. The next status cycle will
 // retry once listers are wired up.
 func (d *XEDriver) recoverMissingContainers(ctx context.Context, pod *v1.Pod, discoveredContainers map[string]string) {
+	if pod.DeletionTimestamp != nil {
+		log.G(ctx).Debugf("Recovery: pod %s/%s is deleting; skipping missing-container recovery", pod.Namespace, pod.Name)
+		return
+	}
+
 	var missingNames []string
 	for i := range pod.Spec.Containers {
 		name := pod.Spec.Containers[i].Name
@@ -505,6 +516,27 @@ func (d *XEDriver) recoverMissingContainers(ctx context.Context, pod *v1.Pod, di
 				cfgCopy.ContainerName(), pod.Namespace, pod.Name)
 		}()
 	}
+}
+
+func podDeletionTargets(ctx context.Context, pod *v1.Pod, discoveredContainers map[string]string) map[string]string {
+	targets := make(map[string]string, len(discoveredContainers)+len(pod.Spec.Containers))
+	seenAppIDs := make(map[string]struct{}, len(discoveredContainers)+len(pod.Spec.Containers))
+
+	for containerName, appID := range discoveredContainers {
+		targets[containerName] = appID
+		seenAppIDs[appID] = struct{}{}
+	}
+
+	for containerName, appID := range common.GenerateContainerAppIDs(pod) {
+		if _, seen := seenAppIDs[appID]; seen {
+			continue
+		}
+		log.G(ctx).Infof("DeletePod: adding deterministic cleanup target for container %s (app: %s)", containerName, appID)
+		targets[containerName] = appID
+		seenAppIDs[appID] = struct{}{}
+	}
+
+	return targets
 }
 
 // ListPods discovers all pods currently running on the device by analyzing app configurations.

--- a/internal/drivers/iosxe/pod_lifecycle_test.go
+++ b/internal/drivers/iosxe/pod_lifecycle_test.go
@@ -1,0 +1,119 @@
+// Copyright © 2026 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iosxe
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cisco/virtual-kubelet-cisco/internal/drivers/common"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func lifecycleTestPod() *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "multi-container",
+			UID:       types.UID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{Name: "alpha", Image: "flash:alpha.tar"},
+				{Name: "beta", Image: "flash:beta.tar"},
+			},
+		},
+	}
+}
+
+func TestPodDeletionTargetsIncludesExpectedAppsWhenDiscoveryIsEmpty(t *testing.T) {
+	pod := lifecycleTestPod()
+
+	got := podDeletionTargets(testCtx(), pod, map[string]string{})
+	want := common.GenerateContainerAppIDs(pod)
+
+	for containerName, appID := range want {
+		if got[containerName] != appID {
+			t.Fatalf("target for container %s = %q, want %q", containerName, got[containerName], appID)
+		}
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d deletion targets, want %d: %#v", len(got), len(want), got)
+	}
+}
+
+func TestPodDeletionTargetsDedupesSyntheticDiscoveredApps(t *testing.T) {
+	pod := lifecycleTestPod()
+	expected := common.GenerateContainerAppIDs(pod)
+
+	got := podDeletionTargets(testCtx(), pod, map[string]string{
+		"container-0": expected["alpha"],
+	})
+
+	if got["container-0"] != expected["alpha"] {
+		t.Fatalf("synthetic discovered app was not preserved: %#v", got)
+	}
+	if _, duplicated := got["alpha"]; duplicated {
+		t.Fatalf("expected app %s should not be duplicated under alpha when already discovered synthetically: %#v", expected["alpha"], got)
+	}
+	if got["beta"] != expected["beta"] {
+		t.Fatalf("target for missing beta = %q, want %q", got["beta"], expected["beta"])
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d deletion targets, want 2: %#v", len(got), got)
+	}
+}
+
+func TestUpdatePodDeletingCleansExpectedAppsInsteadOfRedeploying(t *testing.T) {
+	pod := lifecycleTestPod()
+	now := metav1.Now()
+	pod.DeletionTimestamp = &now
+
+	var deletePaths []string
+	fc := &fakeNetworkClient{
+		getHook: func(path string, result any) error {
+			switch result.(type) {
+			case *Cisco_IOS_XEAppHostingCfg_AppHostingCfgData:
+			case *Cisco_IOS_XEAppHostingOper_AppHostingOperData:
+			default:
+				t.Fatalf("unexpected GET result type %T for path %s", result, path)
+			}
+			return nil
+		},
+		deleteHook: func(path string) error {
+			deletePaths = append(deletePaths, path)
+			return nil
+		},
+	}
+
+	if err := newTestDriver(fc).UpdatePod(testCtx(), pod); err != nil {
+		t.Fatalf("UpdatePod deleting pod: %v", err)
+	}
+
+	for _, appID := range common.GenerateContainerAppIDs(pod) {
+		found := false
+		for _, path := range deletePaths {
+			if strings.Contains(path, appID) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected config delete for app %s, got paths %#v", appID, deletePaths)
+		}
+	}
+}

--- a/internal/drivers/iosxe/pod_transforms.go
+++ b/internal/drivers/iosxe/pod_transforms.go
@@ -109,6 +109,7 @@ func (d *XEDriver) ConvertPodToAppConfigs(pod *v1.Pod) ([]AppHostingConfig, erro
 		return nil, err
 	}
 	packageTimeout := getPackageTimeout(pod)
+	podRequiresTwoPhaseStart := len(pod.Spec.Containers) > 1
 
 	for _, container := range pod.Spec.Containers {
 		appName := containerAppIDs[container.Name]
@@ -260,13 +261,14 @@ func (d *XEDriver) ConvertPodToAppConfigs(pod *v1.Pod) ([]AppHostingConfig, erro
 			RunOpts: runOptsMap,
 		}
 
-		// Enable docker resource when we have environment variables
-		// This is required for RunOpts to take effect on the device
-		hasDockerResource := false
-		if len(envOpts) > 0 {
+		// Enable DockerResource when RunOpts need device-side package option
+		// expansion. Mixed multi-container pods must use one lifecycle shape
+		// across every generated app; otherwise IOS-XE can leave a sibling
+		// app in ACTIVATED while the kubelet waits forever for RUNNING.
+		hasDockerResource := podRequiresTwoPhaseStart || len(envOpts) > 0
+		if hasDockerResource {
 			gapp.DockerResource = ygot.Bool(true)
 			gapp.PrependPkgOpts = ygot.Bool(true)
-			hasDockerResource = true
 		}
 
 		// Configure resource profile
@@ -629,7 +631,7 @@ func distributeRunOpts(baseOpts []string, envOpts []string) (map[uint16]*Cisco_I
 			return fmt.Errorf("too many RunOpts lines needed (max %d), consider reducing environment variables", MaxRunOptsLines)
 		}
 		runOptsMap[lineIndex] = &Cisco_IOS_XEAppHostingCfg_AppHostingCfgData_Apps_App_RunOptss_RunOpts{
-			LineIndex: ygot.Uint16(lineIndex),
+			LineIndex:   ygot.Uint16(lineIndex),
 			LineRunOpts: ygot.String(strings.TrimSpace(currentLine.String())),
 		}
 		lineIndex++
@@ -686,7 +688,7 @@ func distributeRunOpts(baseOpts []string, envOpts []string) (map[uint16]*Cisco_I
 	// Ensure we have at least one line (even if empty, for backward compatibility)
 	if len(runOptsMap) == 0 {
 		runOptsMap[1] = &Cisco_IOS_XEAppHostingCfg_AppHostingCfgData_Apps_App_RunOptss_RunOpts{
-			LineIndex: ygot.Uint16(1),
+			LineIndex:   ygot.Uint16(1),
 			LineRunOpts: ygot.String(""),
 		}
 	}

--- a/internal/drivers/iosxe/pod_transforms_test.go
+++ b/internal/drivers/iosxe/pod_transforms_test.go
@@ -1381,3 +1381,76 @@ func TestConvertPodToAppConfigs_NoEnvVars_NoDockerResource(t *testing.T) {
 		t.Error("Expected RunOpts to contain --hostname=app even without env vars")
 	}
 }
+
+func TestConvertPodToAppConfigs_MultiContainerUsesConsistentTwoPhaseStart(t *testing.T) {
+	driver := &XEDriver{
+		config: &v1alpha1.DeviceSpec{
+			PodCIDR: "10.0.0.0/24",
+			XE: &v1alpha1.XEConfig{
+				Networking: v1alpha1.XENetworkConfig{
+					Interface: &v1alpha1.XEInterfaceConfig{
+						Type: v1alpha1.XEInterfaceTypeVirtualPortGroup,
+						VirtualPortGroup: &v1alpha1.XEVirtualPortGroupConfig{
+							Dhcp:      true,
+							Interface: "0",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "multi-app",
+			Namespace: "default",
+			UID:       "abcdef12-3456-7890-abcd-ef1234567890",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "alpha",
+					Image: "flash:/hello-app.iosxe.tar",
+					Env: []v1.EnvVar{
+						{Name: "ROLE", Value: "alpha"},
+					},
+				},
+				{
+					Name:  "beta",
+					Image: "flash:/hello-app.iosxe.tar",
+				},
+			},
+		},
+	}
+
+	configs, err := driver.ConvertPodToAppConfigs(pod)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	if len(configs) != 2 {
+		t.Fatalf("Expected 2 configs, got %d", len(configs))
+	}
+
+	for _, config := range configs {
+		if !config.Spec.RequiresTwoPhaseStart {
+			t.Fatalf("%s: expected RequiresTwoPhaseStart=true for all multi-container apps", config.ContainerName())
+		}
+		var app *Cisco_IOS_XEAppHostingCfg_AppHostingCfgData_Apps_App
+		for _, a := range config.Spec.DeviceConfig.App {
+			app = a
+			break
+		}
+		if app == nil {
+			t.Fatalf("%s: missing app config", config.ContainerName())
+		}
+		if app.DockerResource == nil || !*app.DockerResource {
+			t.Fatalf("%s: expected DockerResource=true", config.ContainerName())
+		}
+		if app.PrependPkgOpts == nil || !*app.PrependPkgOpts {
+			t.Fatalf("%s: expected PrependPkgOpts=true", config.ContainerName())
+		}
+		if app.Start == nil || *app.Start {
+			t.Fatalf("%s: expected Start=false for two-phase app", config.ContainerName())
+		}
+	}
+}

--- a/internal/provider/deviceoperation/reconciler.go
+++ b/internal/provider/deviceoperation/reconciler.go
@@ -78,15 +78,6 @@ type TransportProvider interface {
 	GetTransport() transport.Interface
 }
 
-// GNOIProvider exposes the per-device gNOI client. The reconciler
-// dispatches read-only gNOI operation kinds (Ping, Traceroute, Time,
-// FileGet, FileStat, CertGet, CanGenerateCSR, RebootStatus, OSVerify)
-// to this client when set; absent it, gNOI kinds fail fast with
-// reason GNOIUnsupported.
-type GNOIProvider interface {
-	GNOIClient(ctx context.Context) (*gnoi.Client, error)
-}
-
 // Reconciler watches DeviceOperation CRs for one device and executes the
 // supported read-only operation kinds.
 type Reconciler struct {
@@ -110,7 +101,7 @@ type Reconciler struct {
 
 	// GNOI is the optional per-device gNOI client provider. When nil,
 	// gNOI operation kinds fail fast with reason GNOIUnsupported.
-	GNOI GNOIProvider
+	GNOI gnoi.Provider
 
 	// Now is injected for tests. nil means time.Now.
 	Now func() time.Time

--- a/internal/provider/deviceoperation/reconciler.go
+++ b/internal/provider/deviceoperation/reconciler.go
@@ -261,6 +261,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			reason = "Failed"
 		}
 	}
+	if terminalPhase == opsv1alpha1.OperationPhaseSucceeded {
+		if validateErr := validateDiagnosticOutputs(op.Spec.Operation.Kind, commands, outputs); validateErr != nil {
+			terminalPhase = opsv1alpha1.OperationPhaseFailed
+			message = validateErr.Error()
+			reason = "Failed"
+		}
+	}
 	if terminalPhase == opsv1alpha1.OperationPhaseSucceeded &&
 		op.Spec.Operation.Kind == opsv1alpha1.OperationKindPacketCapture {
 		var artifactErr *operationArtifactError
@@ -882,6 +889,29 @@ func commandOutputs(results []transport.CommandResult) []opsv1alpha1.DeviceOpera
 		outputs = append(outputs, out)
 	}
 	return outputs
+}
+
+func validateDiagnosticOutputs(kind opsv1alpha1.OperationKind, commands []string, outputs []opsv1alpha1.DeviceOperationOutput) error {
+	if len(outputs) != len(commands) {
+		return fmt.Errorf("transport returned %d output(s) for %d command(s)", len(outputs), len(commands))
+	}
+	if kind != opsv1alpha1.OperationKindShowCommand {
+		return nil
+	}
+	for i, cmd := range commands {
+		if !showCommandRequiresOutput(cmd) {
+			continue
+		}
+		if strings.TrimSpace(outputs[i].Output) == "" && strings.TrimSpace(outputs[i].Err) == "" {
+			return fmt.Errorf("show command %q returned empty output", cmd)
+		}
+	}
+	return nil
+}
+
+func showCommandRequiresOutput(cmd string) bool {
+	normalized := strings.ToLower(strings.Join(strings.Fields(cmd), " "))
+	return normalized == "show version"
 }
 
 func lineDiff(baseline, observed string) string {

--- a/internal/provider/deviceoperation/reconciler_test.go
+++ b/internal/provider/deviceoperation/reconciler_test.go
@@ -122,6 +122,52 @@ func TestReconcileShowCommand(t *testing.T) {
 	}
 }
 
+func TestReconcileShowVersionFailsOnEmptyOutput(t *testing.T) {
+	ctx := context.Background()
+	scheme := newScheme(t)
+	op := newOperation("empty-show-version", func(op *opsv1alpha1.DeviceOperation) {
+		op.Spec.Operation.Commands = []string{"show version"}
+	})
+	tr := &fakeTransport{
+		caps: transport.Capabilities{
+			Kind:                   transport.KindNETCONF,
+			SupportsDiagnosticExec: true,
+		},
+		results: []transport.CommandResult{{
+			Command: "show version",
+			Output:  "",
+		}},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(op).
+		WithStatusSubresource(&opsv1alpha1.DeviceOperation{}).
+		Build()
+	r := &Reconciler{
+		Client:     c,
+		DeviceName: "dev1",
+		TP:         &staticTP{tr: tr},
+		Now:        func() time.Time { return time.Unix(100, 0).UTC() },
+	}
+	_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{
+		Namespace: op.Namespace,
+		Name:      op.Name,
+	}})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	var got opsv1alpha1.DeviceOperation
+	if err := c.Get(ctx, types.NamespacedName{Namespace: op.Namespace, Name: op.Name}, &got); err != nil {
+		t.Fatalf("get operation: %v", err)
+	}
+	if got.Status.Phase != opsv1alpha1.OperationPhaseFailed {
+		t.Fatalf("phase=%q want %q", got.Status.Phase, opsv1alpha1.OperationPhaseFailed)
+	}
+	if !strings.Contains(got.Status.Message, "empty output") {
+		t.Fatalf("message=%q want empty output reason", got.Status.Message)
+	}
+}
+
 func TestReconcileRejectsWriteCommandBeforeTransportExec(t *testing.T) {
 	ctx := context.Background()
 	scheme := newScheme(t)

--- a/internal/provider/notifier_test.go
+++ b/internal/provider/notifier_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cisco/virtual-kubelet-cisco/internal/telemetry/state"
 	"github.com/prometheus/client_golang/prometheus"
 	io_prometheus_client "github.com/prometheus/client_model/go"
+	"github.com/virtual-kubelet/virtual-kubelet/errdefs"
 	"github.com/virtual-kubelet/virtual-kubelet/node/nodeutil"
 	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
@@ -124,8 +125,9 @@ func TestPodNotifierOverflowDropsAndSelfMetric(t *testing.T) {
 
 type notifierDriver struct {
 	fakeTopologyDriver
-	status v1.PodStatus
-	calls  int
+	status   v1.PodStatus
+	listPods []*v1.Pod
+	calls    int
 }
 
 func (d *notifierDriver) GetPodStatus(_ context.Context, pod *v1.Pod) (*v1.Pod, error) {
@@ -133,6 +135,44 @@ func (d *notifierDriver) GetPodStatus(_ context.Context, pod *v1.Pod) (*v1.Pod, 
 	out := pod.DeepCopy()
 	out.Status = d.status
 	return out, nil
+}
+
+func (d *notifierDriver) ListPods(context.Context) ([]*v1.Pod, error) {
+	return d.listPods, nil
+}
+
+func TestGetPodUsesProviderListForExistence(t *testing.T) {
+	ctx := context.Background()
+	pod := notifierPod("pending-create", "55555555-5555-5555-5555-555555555555")
+	driver := &notifierDriver{status: notifierPodStatus(v1.PodRunning, true)}
+	provider, err := NewAppHostingProvider(ctx,
+		&ciskov1.DeviceSpec{},
+		nodeutil.ProviderConfig{Pods: podLister(t, pod)},
+		driver,
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("NewAppHostingProvider: %v", err)
+	}
+
+	if got, err := provider.GetPod(ctx, pod.Namespace, pod.Name); !errdefs.IsNotFound(err) || got != nil {
+		t.Fatalf("GetPod before provider create = (%v, %v), want NotFound nil", got, err)
+	}
+	if driver.calls != 0 {
+		t.Fatalf("GetPod used GetPodStatus as existence check %d time(s)", driver.calls)
+	}
+
+	devicePod := pod.DeepCopy()
+	devicePod.Status = notifierPodStatus(v1.PodRunning, true)
+	driver.listPods = []*v1.Pod{devicePod}
+	got, err := provider.GetPod(ctx, pod.Namespace, pod.Name)
+	if err != nil {
+		t.Fatalf("GetPod after provider list match: %v", err)
+	}
+	if got == nil || got.UID != pod.UID || got.Status.Phase != v1.PodRunning {
+		t.Fatalf("GetPod returned %#v, want provider-listed running pod", got)
+	}
 }
 
 // TestPodNotifierPollDrivesCallbackWithoutMDT covers the regression that

--- a/internal/provider/operationalaction/metrics.go
+++ b/internal/provider/operationalaction/metrics.go
@@ -1,0 +1,49 @@
+// Copyright © 2026 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operationalaction
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	metricsOnce sync.Once
+
+	actionTransitions *prometheus.CounterVec
+)
+
+// RegisterMetrics registers IOSXEOperationalAction metrics. It is safe to
+// call more than once in a process; the first registry wins.
+func RegisterMetrics(reg prometheus.Registerer) {
+	metricsOnce.Do(func() {
+		actionTransitions = prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "cisco_vk_iosxe_operational_action_transitions_total",
+				Help: "Count of IOSXEOperationalAction phase transitions and terminal outcomes.",
+			},
+			[]string{"device", "kind", "phase", "reason"},
+		)
+		reg.MustRegister(actionTransitions)
+	})
+}
+
+func recordActionTransition(device, kind, phase, reason string) {
+	if actionTransitions == nil {
+		return
+	}
+	actionTransitions.WithLabelValues(device, kind, phase, reason).Inc()
+}

--- a/internal/provider/operationalaction/reconciler.go
+++ b/internal/provider/operationalaction/reconciler.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/virtual-kubelet/virtual-kubelet/log"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,13 +37,17 @@ import (
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	opsv1alpha1 "github.com/cisco/virtual-kubelet-cisco/api/ops/v1alpha1"
 	"github.com/cisco/virtual-kubelet-cisco/internal/drivers/iosxe/gnoi"
 )
 
-const conditionTypeReady = "Ready"
+const (
+	conditionTypeReady = "Ready"
+	finalizerName      = "ops.cisco.vk/iosxeoperationalaction-finalizer"
+)
 
 // GNOIProvider exposes the per-device gNOI client.
 type GNOIProvider interface {
@@ -99,9 +104,37 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	if r.DeviceNamespace != "" && act.Namespace != r.DeviceNamespace {
 		return reconcile.Result{}, nil
 	}
+	logger := log.G(ctx).WithField("operationalAction", req.NamespacedName.String()).
+		WithField("kind", act.Spec.Action.Kind).
+		WithField("device", act.Spec.DeviceRef.Name)
+
 	// Terminal phases are no-ops — actions execute exactly once.
 	switch act.Status.Phase {
 	case opsv1alpha1.ActionPhaseSucceeded, opsv1alpha1.ActionPhaseFailed, opsv1alpha1.ActionPhaseRejected:
+		if err := r.removeFinalizer(ctx, &act); err != nil {
+			return reconcile.Result{}, err
+		}
+		return reconcile.Result{}, nil
+	}
+	if !act.DeletionTimestamp.IsZero() {
+		if act.Status.Phase == opsv1alpha1.ActionPhaseRunning || act.Status.InvocationID != "" {
+			logger.WithField("invocationID", act.Status.InvocationID).
+				Warn("IOSXEOperationalAction deletion requested after invocation; preserving CR to avoid losing destructive-operation audit trail")
+			r.recordEvent(&act, corev1.EventTypeWarning, "DeletionPending",
+				"delete requested after device-side action was invoked; CR is retained for audit")
+			return reconcile.Result{}, nil
+		}
+		if err := r.removeFinalizer(ctx, &act); err != nil {
+			return reconcile.Result{}, err
+		}
+		return reconcile.Result{}, nil
+	}
+	if err := r.ensureFinalizer(ctx, &act); err != nil {
+		return reconcile.Result{}, err
+	}
+	if act.Status.Phase == opsv1alpha1.ActionPhaseRunning {
+		logger.WithField("invocationID", act.Status.InvocationID).
+			Info("IOSXEOperationalAction already running; refusing duplicate dispatch")
 		return reconcile.Result{}, nil
 	}
 
@@ -113,12 +146,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			fmt.Sprintf("spec.confirm=%q does not match spec.deviceRef.name=%q",
 				act.Spec.Confirm, act.Spec.DeviceRef.Name), nil, now)
 	}
+	if err := validateActionRequest(act.Spec.Action); err != nil {
+		return r.terminal(ctx, &act, opsv1alpha1.ActionPhaseRejected, "InvalidAction", err.Error(), nil, now)
+	}
 
 	if r.GNOI == nil {
 		return r.terminal(ctx, &act, opsv1alpha1.ActionPhaseFailed, "NoGNOIProvider",
 			"gnoi provider not configured on reconciler", nil, now)
 	}
-	client, err := r.GNOI.GNOIClient(ctx)
+	gnoiClient, err := r.GNOI.GNOIClient(ctx)
 	if err != nil {
 		return r.terminal(ctx, &act, opsv1alpha1.ActionPhaseFailed, "GNOIClient", err.Error(), nil, now)
 	}
@@ -128,7 +164,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, err
 	}
 
-	result, kindErr := r.dispatch(ctx, &act, client)
+	logger.Warn("dispatching IOSXEOperationalAction gNOI RPC")
+	result, kindErr := r.dispatch(ctx, &act, gnoiClient)
 	if kindErr != nil {
 		return r.terminal(ctx, &act, opsv1alpha1.ActionPhaseFailed, "ActionFailed", kindErr.Error(), result, now)
 	}
@@ -159,7 +196,7 @@ func (r *Reconciler) dispatch(ctx context.Context, act *opsv1alpha1.IOSXEOperati
 func (r *Reconciler) runReboot(ctx context.Context, act *opsv1alpha1.IOSXEOperationalAction, gc *gnoi.Client) ([]byte, error) {
 	args := act.Spec.Action.Reboot
 	if args == nil {
-		args = &opsv1alpha1.RebootActionArgs{}
+		return nil, errors.New("action.reboot is required")
 	}
 	return nil, gc.Reboot(ctx, gnoi.RebootOpts{
 		Method:  args.Method,
@@ -223,7 +260,7 @@ func (r *Reconciler) runFileRemove(ctx context.Context, act *opsv1alpha1.IOSXEOp
 func (r *Reconciler) runFactoryReset(ctx context.Context, act *opsv1alpha1.IOSXEOperationalAction, gc *gnoi.Client) ([]byte, error) {
 	args := act.Spec.Action.FactoryReset
 	if args == nil {
-		args = &opsv1alpha1.FactoryResetArgs{}
+		return nil, errors.New("action.factoryReset is required")
 	}
 	retainCerts := true
 	if args.RetainCerts != nil {
@@ -241,15 +278,27 @@ func (r *Reconciler) runFactoryReset(ctx context.Context, act *opsv1alpha1.IOSXE
 func (r *Reconciler) markRunning(ctx context.Context, act *opsv1alpha1.IOSXEOperationalAction, now time.Time) error {
 	_, err := r.updateStatus(ctx, act, func(cur *opsv1alpha1.IOSXEOperationalAction) {
 		cur.Status.Phase = opsv1alpha1.ActionPhaseRunning
-		cur.Status.StartTime = &metav1.Time{Time: now}
+		if cur.Status.StartTime == nil {
+			cur.Status.StartTime = &metav1.Time{Time: now}
+		}
+		if cur.Status.InvocationID == "" {
+			cur.Status.InvocationID = invocationID(cur)
+		}
 		cur.Status.Message = "action running"
 		r.setReady(cur, metav1.ConditionFalse, "Running", "action running", now)
 	}, reconcile.Result{})
+	if err == nil {
+		log.G(ctx).WithField("operationalAction", client.ObjectKeyFromObject(act).String()).
+			WithField("kind", act.Spec.Action.Kind).
+			Info("IOSXEOperationalAction phase advanced to Running")
+		recordActionTransition(act.Spec.DeviceRef.Name, string(act.Spec.Action.Kind), string(opsv1alpha1.ActionPhaseRunning), "Running")
+		r.recordEvent(act, corev1.EventTypeNormal, "Running", r.actionSummary(act))
+	}
 	return err
 }
 
 func (r *Reconciler) terminal(ctx context.Context, act *opsv1alpha1.IOSXEOperationalAction, phase opsv1alpha1.ActionPhase, reason, message string, result []byte, now time.Time) (reconcile.Result, error) {
-	return r.updateStatus(ctx, act, func(cur *opsv1alpha1.IOSXEOperationalAction) {
+	res, err := r.updateStatus(ctx, act, func(cur *opsv1alpha1.IOSXEOperationalAction) {
 		cur.Status.Phase = phase
 		cur.Status.FailureReason = reason
 		cur.Status.Message = message
@@ -264,6 +313,24 @@ func (r *Reconciler) terminal(ctx context.Context, act *opsv1alpha1.IOSXEOperati
 		}
 		r.setReady(cur, condStatus, reason, message, now)
 	}, reconcile.Result{})
+	if err != nil {
+		return res, err
+	}
+	eventType := corev1.EventTypeWarning
+	if phase == opsv1alpha1.ActionPhaseSucceeded {
+		eventType = corev1.EventTypeNormal
+	}
+	log.G(ctx).WithField("operationalAction", client.ObjectKeyFromObject(act).String()).
+		WithField("kind", act.Spec.Action.Kind).
+		WithField("phase", phase).
+		WithField("reason", reason).
+		Info("IOSXEOperationalAction reached terminal phase")
+	recordActionTransition(act.Spec.DeviceRef.Name, string(act.Spec.Action.Kind), string(phase), reason)
+	r.recordEvent(act, eventType, string(phase), r.actionSummary(act)+": "+message)
+	if err := r.removeFinalizer(ctx, act); err != nil {
+		return res, err
+	}
+	return res, nil
 }
 
 func (r *Reconciler) setReady(act *opsv1alpha1.IOSXEOperationalAction, status metav1.ConditionStatus, reason, message string, now time.Time) {
@@ -307,6 +374,156 @@ func (r *Reconciler) updateStatus(ctx context.Context, act *opsv1alpha1.IOSXEOpe
 		return result, fmt.Errorf("update action status: %w", err)
 	}
 	return result, nil
+}
+
+func (r *Reconciler) ensureFinalizer(ctx context.Context, act *opsv1alpha1.IOSXEOperationalAction) error {
+	if controllerutil.ContainsFinalizer(act, finalizerName) {
+		return nil
+	}
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		var cur opsv1alpha1.IOSXEOperationalAction
+		reader := r.Reader
+		if reader == nil {
+			reader = r.Client
+		}
+		if err := reader.Get(ctx, client.ObjectKeyFromObject(act), &cur); err != nil {
+			return err
+		}
+		if controllerutil.ContainsFinalizer(&cur, finalizerName) {
+			return nil
+		}
+		controllerutil.AddFinalizer(&cur, finalizerName)
+		return r.Client.Update(ctx, &cur)
+	})
+}
+
+func (r *Reconciler) removeFinalizer(ctx context.Context, act *opsv1alpha1.IOSXEOperationalAction) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		var cur opsv1alpha1.IOSXEOperationalAction
+		reader := r.Reader
+		if reader == nil {
+			reader = r.Client
+		}
+		if err := reader.Get(ctx, client.ObjectKeyFromObject(act), &cur); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		if !controllerutil.ContainsFinalizer(&cur, finalizerName) {
+			return nil
+		}
+		controllerutil.RemoveFinalizer(&cur, finalizerName)
+		return r.Client.Update(ctx, &cur)
+	})
+}
+
+func validateActionRequest(action opsv1alpha1.ActionRequest) error {
+	argsBlocks := 0
+	if action.Reboot != nil {
+		argsBlocks++
+	}
+	if action.CancelReboot != nil {
+		argsBlocks++
+	}
+	if action.KillProcess != nil {
+		argsBlocks++
+	}
+	if action.FilePut != nil {
+		argsBlocks++
+	}
+	if action.FileRemove != nil {
+		argsBlocks++
+	}
+	if action.FactoryReset != nil {
+		argsBlocks++
+	}
+	if argsBlocks != 1 {
+		return fmt.Errorf("action.kind %q requires exactly one matching args block; got %d", action.Kind, argsBlocks)
+	}
+	switch action.Kind {
+	case opsv1alpha1.ActionKindReboot:
+		if action.Reboot == nil {
+			return errors.New("action.kind Reboot requires action.reboot")
+		}
+	case opsv1alpha1.ActionKindCancelReboot:
+		if action.CancelReboot == nil {
+			return errors.New("action.kind CancelReboot requires action.cancelReboot")
+		}
+	case opsv1alpha1.ActionKindKillProcess:
+		if action.KillProcess == nil {
+			return errors.New("action.kind KillProcess requires action.killProcess")
+		}
+	case opsv1alpha1.ActionKindFilePut:
+		if action.FilePut == nil {
+			return errors.New("action.kind FilePut requires action.filePut")
+		}
+	case opsv1alpha1.ActionKindFileRemove:
+		if action.FileRemove == nil {
+			return errors.New("action.kind FileRemove requires action.fileRemove")
+		}
+	case opsv1alpha1.ActionKindFactoryReset:
+		if action.FactoryReset == nil {
+			return errors.New("action.kind FactoryReset requires action.factoryReset")
+		}
+	default:
+		return fmt.Errorf("unsupported action kind %q", action.Kind)
+	}
+	return nil
+}
+
+func invocationID(act *opsv1alpha1.IOSXEOperationalAction) string {
+	if act.UID != "" {
+		return fmt.Sprintf("%s/%d", act.UID, act.Generation)
+	}
+	return fmt.Sprintf("%s/%s/%d", act.Namespace, act.Name, act.Generation)
+}
+
+func (r *Reconciler) recordEvent(act *opsv1alpha1.IOSXEOperationalAction, eventType, reason, message string) {
+	if r.Recorder == nil {
+		return
+	}
+	r.Recorder.Event(act, eventType, reason, message)
+}
+
+func (r *Reconciler) actionSummary(act *opsv1alpha1.IOSXEOperationalAction) string {
+	action := act.Spec.Action
+	base := fmt.Sprintf("%s device=%s", action.Kind, act.Spec.DeviceRef.Name)
+	switch action.Kind {
+	case opsv1alpha1.ActionKindReboot:
+		if action.Reboot == nil {
+			return base
+		}
+		return fmt.Sprintf("%s method=%s delaySeconds=%d force=%t", base, action.Reboot.Method, action.Reboot.DelaySeconds, action.Reboot.Force)
+	case opsv1alpha1.ActionKindCancelReboot:
+		return base
+	case opsv1alpha1.ActionKindKillProcess:
+		if action.KillProcess == nil {
+			return base
+		}
+		return fmt.Sprintf("%s pid=%d name=%q signal=%s restart=%t", base, action.KillProcess.PID, action.KillProcess.Name, action.KillProcess.Signal, action.KillProcess.Restart)
+	case opsv1alpha1.ActionKindFilePut:
+		if action.FilePut == nil {
+			return base
+		}
+		return fmt.Sprintf("%s path=%s configMap=%s", base, action.FilePut.Path, action.FilePut.ConfigMapName)
+	case opsv1alpha1.ActionKindFileRemove:
+		if action.FileRemove == nil {
+			return base
+		}
+		return fmt.Sprintf("%s path=%s", base, action.FileRemove.Path)
+	case opsv1alpha1.ActionKindFactoryReset:
+		if action.FactoryReset == nil {
+			return base
+		}
+		retain := "default"
+		if action.FactoryReset.RetainCerts != nil {
+			retain = fmt.Sprintf("%t", *action.FactoryReset.RetainCerts)
+		}
+		return fmt.Sprintf("%s factoryOS=%t zeroFill=%t retainCerts=%s", base, action.FactoryReset.FactoryOS, action.FactoryReset.ZeroFill, retain)
+	default:
+		return base
+	}
 }
 
 // jsonResult is a helper for kinds that want to surface device-side

--- a/internal/provider/operationalaction/reconciler.go
+++ b/internal/provider/operationalaction/reconciler.go
@@ -30,6 +30,7 @@ import (
 	"github.com/virtual-kubelet/virtual-kubelet/log"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -334,26 +335,14 @@ func (r *Reconciler) terminal(ctx context.Context, act *opsv1alpha1.IOSXEOperati
 }
 
 func (r *Reconciler) setReady(act *opsv1alpha1.IOSXEOperationalAction, status metav1.ConditionStatus, reason, message string, now time.Time) {
-	cond := metav1.Condition{
+	apimeta.SetStatusCondition(&act.Status.Conditions, metav1.Condition{
 		Type:               conditionTypeReady,
 		Status:             status,
 		Reason:             reason,
 		Message:            message,
 		LastTransitionTime: metav1.Time{Time: now},
 		ObservedGeneration: act.Generation,
-	}
-	conds := act.Status.Conditions
-	for i, c := range conds {
-		if c.Type == cond.Type {
-			if c.Status == cond.Status && c.Reason == cond.Reason && c.Message == cond.Message {
-				return
-			}
-			conds[i] = cond
-			act.Status.Conditions = conds
-			return
-		}
-	}
-	act.Status.Conditions = append(conds, cond)
+	})
 }
 
 func (r *Reconciler) updateStatus(ctx context.Context, act *opsv1alpha1.IOSXEOperationalAction, mutate func(*opsv1alpha1.IOSXEOperationalAction), result reconcile.Result) (reconcile.Result, error) {

--- a/internal/provider/operationalaction/reconciler.go
+++ b/internal/provider/operationalaction/reconciler.go
@@ -50,11 +50,6 @@ const (
 	finalizerName      = "ops.cisco.vk/iosxeoperationalaction-finalizer"
 )
 
-// GNOIProvider exposes the per-device gNOI client.
-type GNOIProvider interface {
-	GNOIClient(ctx context.Context) (*gnoi.Client, error)
-}
-
 // Reconciler executes IOSXEOperationalAction CRs exactly once.
 //
 // Each kind is destructive or near-destructive, so we do NOT retry on
@@ -66,7 +61,7 @@ type Reconciler struct {
 	Scheme          *runtime.Scheme
 	DeviceName      string
 	DeviceNamespace string
-	GNOI            GNOIProvider
+	GNOI            gnoi.Provider
 
 	// Now is injected for tests.
 	Now func() time.Time

--- a/internal/provider/operationalaction/reconciler_test.go
+++ b/internal/provider/operationalaction/reconciler_test.go
@@ -108,11 +108,19 @@ type fakeReset struct {
 	resetpb.UnimplementedFactoryResetServer
 	calls       atomic.Int64
 	lastFactory bool
+	resp        *resetpb.StartResponse
+	err         error
 }
 
 func (f *fakeReset) Start(_ context.Context, req *resetpb.StartRequest) (*resetpb.StartResponse, error) {
 	f.calls.Add(1)
 	f.lastFactory = req.FactoryOs
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.resp != nil {
+		return f.resp, nil
+	}
 	return &resetpb.StartResponse{Response: &resetpb.StartResponse_ResetSuccess{ResetSuccess: &resetpb.ResetSuccess{}}}, nil
 }
 
@@ -328,6 +336,27 @@ func TestKindArgsMismatchRejected(t *testing.T) {
 	}
 }
 
+func TestUnknownActionKindRejected(t *testing.T) {
+	rig := newRig(t)
+	a := newAction("unknown-kind", func(a *opsv1alpha1.IOSXEOperationalAction) {
+		a.Spec.Action = opsv1alpha1.ActionRequest{
+			Kind:   opsv1alpha1.ActionKind("PowerCycle"),
+			Reboot: &opsv1alpha1.RebootActionArgs{Method: "COLD"},
+		}
+	})
+	r := newReconciler(t, rig, a)
+	got := runReconcile(t, r, a)
+	if got.Status.Phase != opsv1alpha1.ActionPhaseRejected {
+		t.Fatalf("phase=%q msg=%q", got.Status.Phase, got.Status.Message)
+	}
+	if !strings.Contains(got.Status.Message, "unsupported action kind") {
+		t.Fatalf("expected unsupported-kind message, got %q", got.Status.Message)
+	}
+	if rig.sys.rebootCalls.Load() != 0 {
+		t.Fatalf("unknown action dispatched reboot; calls=%d", rig.sys.rebootCalls.Load())
+	}
+}
+
 func TestRunningActionDoesNotRedispatch(t *testing.T) {
 	rig := newRig(t)
 	a := newAction("reboot-running", nil)
@@ -389,6 +418,54 @@ func TestFilePutHappyPath(t *testing.T) {
 	}
 }
 
+func TestFilePutMissingConfigMapFails(t *testing.T) {
+	rig := newRig(t)
+	a := newAction("put-missing-cm", func(a *opsv1alpha1.IOSXEOperationalAction) {
+		a.Spec.Action = opsv1alpha1.ActionRequest{
+			Kind:    opsv1alpha1.ActionKindFilePut,
+			FilePut: &opsv1alpha1.FilePutArgs{Path: "flash:dropoff.bin", ConfigMapName: "missing-cm", Permissions: 0o644},
+		}
+	})
+	r := newReconciler(t, rig, a)
+	got := runReconcile(t, r, a)
+	if got.Status.Phase != opsv1alpha1.ActionPhaseFailed {
+		t.Fatalf("phase=%q msg=%q", got.Status.Phase, got.Status.Message)
+	}
+	if !strings.Contains(got.Status.Message, "get ConfigMap") {
+		t.Fatalf("expected ConfigMap lookup error, got %q", got.Status.Message)
+	}
+	if rig.file.putCalls.Load() != 0 {
+		t.Fatalf("File.Put called despite missing ConfigMap; calls=%d", rig.file.putCalls.Load())
+	}
+}
+
+func TestFilePutMissingContentKeyFails(t *testing.T) {
+	rig := newRig(t)
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "payload-cm"},
+		BinaryData: map[string][]byte{
+			"other": []byte("wrong key"),
+		},
+	}
+	a := newAction("put-missing-key", func(a *opsv1alpha1.IOSXEOperationalAction) {
+		a.Spec.Action = opsv1alpha1.ActionRequest{
+			Kind:    opsv1alpha1.ActionKindFilePut,
+			FilePut: &opsv1alpha1.FilePutArgs{Path: "flash:dropoff.bin", ConfigMapName: "payload-cm", Permissions: 0o644},
+		}
+	})
+	r := newReconciler(t, rig, a, cm)
+	got := runReconcile(t, r, a)
+	if got.Status.Phase != opsv1alpha1.ActionPhaseFailed {
+		t.Fatalf("phase=%q msg=%q", got.Status.Phase, got.Status.Message)
+	}
+	if !strings.Contains(got.Status.Message, "binaryData[\"content\"]") {
+		t.Fatalf("expected missing binaryData content error, got %q", got.Status.Message)
+	}
+	if rig.file.putCalls.Load() != 0 {
+		t.Fatalf("File.Put called despite missing content key; calls=%d", rig.file.putCalls.Load())
+	}
+}
+
 func TestFileRemoveRejectsBarePath(t *testing.T) {
 	rig := newRig(t)
 	a := newAction("rm-bad", func(a *opsv1alpha1.IOSXEOperationalAction) {
@@ -419,6 +496,32 @@ func TestFactoryResetDefaultsRetainCertsTrue(t *testing.T) {
 	}
 	if rig.reset.calls.Load() != 1 {
 		t.Fatalf("FactoryReset call count=%d", rig.reset.calls.Load())
+	}
+}
+
+func TestFactoryResetDeviceErrorFailsWithClassifier(t *testing.T) {
+	rig := newRig(t)
+	rig.reset.resp = &resetpb.StartResponse{
+		Response: &resetpb.StartResponse_ResetError{
+			ResetError: &resetpb.ResetError{
+				Detail:               "factory OS unsupported on this platform",
+				FactoryOsUnsupported: true,
+			},
+		},
+	}
+	a := newAction("fr-device-error", func(a *opsv1alpha1.IOSXEOperationalAction) {
+		a.Spec.Action = opsv1alpha1.ActionRequest{
+			Kind:         opsv1alpha1.ActionKindFactoryReset,
+			FactoryReset: &opsv1alpha1.FactoryResetArgs{FactoryOS: true},
+		}
+	})
+	r := newReconciler(t, rig, a)
+	got := runReconcile(t, r, a)
+	if got.Status.Phase != opsv1alpha1.ActionPhaseFailed {
+		t.Fatalf("phase=%q msg=%q", got.Status.Phase, got.Status.Message)
+	}
+	if !strings.Contains(got.Status.Message, "factory_os_unsupported") {
+		t.Fatalf("expected classifier in message, got %q", got.Status.Message)
 	}
 }
 

--- a/internal/provider/operationalaction/reconciler_test.go
+++ b/internal/provider/operationalaction/reconciler_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -238,6 +239,9 @@ func TestRebootHappyPath(t *testing.T) {
 	if rig.sys.rebootCalls.Load() != 1 {
 		t.Fatalf("Reboot call count=%d", rig.sys.rebootCalls.Load())
 	}
+	if len(got.Finalizers) != 0 {
+		t.Fatalf("finalizers retained after terminal phase: %v", got.Finalizers)
+	}
 }
 
 func TestConfirmMismatchRejected(t *testing.T) {
@@ -288,6 +292,75 @@ func TestKillProcessRequiresPIDOrName(t *testing.T) {
 	}
 	if !strings.Contains(got.Status.Message, "PID or Name") {
 		t.Fatalf("expected PID-or-Name required error, got %q", got.Status.Message)
+	}
+}
+
+func TestRebootRequiresMatchingArgsBlock(t *testing.T) {
+	rig := newRig(t)
+	a := newAction("reboot-no-args", func(a *opsv1alpha1.IOSXEOperationalAction) {
+		a.Spec.Action = opsv1alpha1.ActionRequest{Kind: opsv1alpha1.ActionKindReboot}
+	})
+	r := newReconciler(t, rig, a)
+	got := runReconcile(t, r, a)
+	if got.Status.Phase != opsv1alpha1.ActionPhaseRejected {
+		t.Fatalf("phase=%q msg=%q", got.Status.Phase, got.Status.Message)
+	}
+	if rig.sys.rebootCalls.Load() != 0 {
+		t.Fatalf("Reboot dispatched despite missing args block; calls=%d", rig.sys.rebootCalls.Load())
+	}
+}
+
+func TestKindArgsMismatchRejected(t *testing.T) {
+	rig := newRig(t)
+	a := newAction("reboot-wrong-args", func(a *opsv1alpha1.IOSXEOperationalAction) {
+		a.Spec.Action = opsv1alpha1.ActionRequest{
+			Kind:       opsv1alpha1.ActionKindReboot,
+			FileRemove: &opsv1alpha1.FileRemoveArgs{Path: "flash:old.bin"},
+		}
+	})
+	r := newReconciler(t, rig, a)
+	got := runReconcile(t, r, a)
+	if got.Status.Phase != opsv1alpha1.ActionPhaseRejected {
+		t.Fatalf("phase=%q msg=%q", got.Status.Phase, got.Status.Message)
+	}
+	if rig.sys.rebootCalls.Load() != 0 || rig.file.removeCalls.Load() != 0 {
+		t.Fatalf("mismatched action dispatched: reboot=%d remove=%d", rig.sys.rebootCalls.Load(), rig.file.removeCalls.Load())
+	}
+}
+
+func TestRunningActionDoesNotRedispatch(t *testing.T) {
+	rig := newRig(t)
+	a := newAction("reboot-running", nil)
+	a.Status = opsv1alpha1.IOSXEOperationalActionStatus{
+		Phase:        opsv1alpha1.ActionPhaseRunning,
+		InvocationID: "already-invoked",
+	}
+	r := newReconciler(t, rig, a)
+	got := runReconcile(t, r, a)
+	if got.Status.Phase != opsv1alpha1.ActionPhaseRunning {
+		t.Fatalf("phase=%q msg=%q", got.Status.Phase, got.Status.Message)
+	}
+	if rig.sys.rebootCalls.Load() != 0 {
+		t.Fatalf("running action re-dispatched reboot; calls=%d", rig.sys.rebootCalls.Load())
+	}
+}
+
+func TestOperationalActionEvents(t *testing.T) {
+	rig := newRig(t)
+	a := newAction("reboot-events", nil)
+	r := newReconciler(t, rig, a)
+	recorder := record.NewFakeRecorder(4)
+	r.Recorder = recorder
+	_ = runReconcile(t, r, a)
+	for _, want := range []string{"Normal Running", "Normal Succeeded"} {
+		select {
+		case got := <-recorder.Events:
+			if !strings.Contains(got, want) {
+				t.Fatalf("event=%q, want %q", got, want)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for %q event", want)
+		}
 	}
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -432,6 +432,9 @@ func (p *AppHostingProvider) findPodByAppID(ctx context.Context, appID string) *
 		return nil
 	}
 	for _, pod := range pods {
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
 		if strings.ReplaceAll(string(pod.UID), "-", "") == cleanUID {
 			return pod.DeepCopy()
 		}
@@ -504,8 +507,24 @@ func (p *AppHostingProvider) GetPod(ctx context.Context, namespace, name string)
 	// Fast path: fetch pod spec from informer cache (desired state)
 	pod, err := p.podsLister.Pods(namespace).Get(name)
 	if err == nil {
-		// Pod exists in K8s — get live status from device
-		return p.driver.GetPodStatus(p.ctx, pod)
+		devicePods, listErr := p.driver.ListPods(p.ctx)
+		if listErr != nil {
+			log.G(p.ctx).WithError(listErr).WithFields(log.Fields{
+				"name":      name,
+				"namespace": namespace,
+			}).Debug("GetPod: failed to list device pods while checking provider existence")
+			return nil, errdefs.NotFound(fmt.Sprintf("pod %s/%s not found on device", namespace, name))
+		}
+		for _, devicePod := range devicePods {
+			if devicePod == nil || devicePod.Namespace != namespace || devicePod.Name != name {
+				continue
+			}
+			if devicePod.UID != "" && pod.UID != "" && devicePod.UID != pod.UID {
+				continue
+			}
+			return devicePod.DeepCopy(), nil
+		}
+		return nil, errdefs.NotFound(fmt.Sprintf("pod %s/%s not found on device", namespace, name))
 	}
 
 	// Pod not in K8s — check if it still exists on the device.

--- a/internal/provider/softwareupgrade/imageresolver.go
+++ b/internal/provider/softwareupgrade/imageresolver.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -70,6 +71,7 @@ type DefaultImageResolver struct {
 	HTTPClient    *http.Client
 	K8sClient     client.Client
 	TFTPBlockSize int
+	CacheDir      string
 }
 
 const (
@@ -99,12 +101,68 @@ func (r *DefaultImageResolver) Resolve(ctx context.Context, namespace string, sr
 	case src.LocalPath != "":
 		return &ResolvedImage{Local: true}, nil
 	case src.URL != "":
-		return r.resolveURL(ctx, namespace, src)
+		return r.resolveCachedURL(ctx, namespace, src)
 	case src.ConfigMapRef != nil:
 		return r.resolveConfigMap(ctx, namespace, src.ConfigMapRef.Name)
 	default:
 		return nil, errors.New("image source: one of url, configMapRef, or localPath is required")
 	}
+}
+
+func (r *DefaultImageResolver) resolveCachedURL(ctx context.Context, namespace string, src opsv1alpha1.UpgradeImageSource) (*ResolvedImage, error) {
+	if src.SHA256 == "" {
+		return r.resolveURL(ctx, namespace, src)
+	}
+	cacheDir := r.CacheDir
+	if cacheDir == "" {
+		cacheDir = filepath.Join(os.TempDir(), "cvk-upgrade-cache")
+	}
+	cachePath := filepath.Join(cacheDir, src.SHA256+".bin")
+	if cached, err := openCachedImage(cachePath, src.SHA256); err == nil {
+		return cached, nil
+	}
+
+	resolved, err := r.resolveURL(ctx, namespace, src)
+	if err != nil {
+		return nil, err
+	}
+	if resolved == nil || resolved.Local {
+		return resolved, nil
+	}
+	defer func() {
+		if resolved.Cleanup != nil {
+			_ = resolved.Cleanup()
+		}
+	}()
+
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return nil, fmt.Errorf("image source cache: mkdir %s: %w", cacheDir, err)
+	}
+	tmp, err := os.CreateTemp(cacheDir, ".cvk-upgrade-cache-*")
+	if err != nil {
+		return nil, fmt.Errorf("image source cache: temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	hash := sha256.New()
+	n, copyErr := io.Copy(io.MultiWriter(tmp, hash), resolved.Reader)
+	closeErr := tmp.Close()
+	if copyErr != nil {
+		_ = os.Remove(tmpName)
+		return nil, fmt.Errorf("image source cache: copy: %w", copyErr)
+	}
+	if closeErr != nil {
+		_ = os.Remove(tmpName)
+		return nil, fmt.Errorf("image source cache: close: %w", closeErr)
+	}
+	if got := hex.EncodeToString(hash.Sum(nil)); got != src.SHA256 {
+		_ = os.Remove(tmpName)
+		return nil, fmt.Errorf("image source cache: SHA256 mismatch: got %s want %s", got, src.SHA256)
+	}
+	if err := os.Rename(tmpName, cachePath); err != nil {
+		_ = os.Remove(tmpName)
+		return nil, fmt.Errorf("image source cache: store: %w", err)
+	}
+	return openCachedImageWithSize(cachePath, src.SHA256, n)
 }
 
 func (r *DefaultImageResolver) resolveURL(ctx context.Context, namespace string, src opsv1alpha1.UpgradeImageSource) (*ResolvedImage, error) {
@@ -295,6 +353,40 @@ func materializeRemoteImage(label, sha256Hex string, fetch func(io.Writer) (int6
 		return os.Remove(tmp.Name())
 	}
 	return &ResolvedImage{Reader: tmp, Size: n, Cleanup: cleanup}, nil
+}
+
+func openCachedImage(path, sha256Hex string) (*ResolvedImage, error) {
+	return openCachedImageWithSize(path, sha256Hex, 0)
+}
+
+func openCachedImageWithSize(path, sha256Hex string, knownSize int64) (*ResolvedImage, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	hash := sha256.New()
+	n, err := io.Copy(hash, f)
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	if knownSize > 0 && n != knownSize {
+		_ = f.Close()
+		return nil, fmt.Errorf("cache size changed: got %d want %d", n, knownSize)
+	}
+	if got := hex.EncodeToString(hash.Sum(nil)); got != sha256Hex {
+		_ = f.Close()
+		return nil, fmt.Errorf("cache SHA256 mismatch: got %s want %s", got, sha256Hex)
+	}
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	return &ResolvedImage{
+		Reader:  f,
+		Size:    n,
+		Cleanup: f.Close,
+	}, nil
 }
 
 type transferCredentials struct {

--- a/internal/provider/softwareupgrade/imageresolver.go
+++ b/internal/provider/softwareupgrade/imageresolver.go
@@ -76,6 +76,8 @@ const (
 	defaultTFTPBlockSize = 8192
 	defaultTFTPRetries   = 10
 	defaultTFTPTimeout   = 10 * time.Second
+
+	envAllowInsecureSSH = "CISCO_VK_UPGRADE_ALLOW_INSECURE_SSH"
 )
 
 // NewDefaultImageResolver constructs a resolver with sensible
@@ -111,7 +113,7 @@ func (r *DefaultImageResolver) resolveURL(ctx context.Context, namespace string,
 	}
 	u, err := url.Parse(src.URL)
 	if err != nil {
-		return nil, fmt.Errorf("image source URL: %w", err)
+		return nil, fmt.Errorf("image source URL %s: %w", redactRawURL(src.URL), err)
 	}
 	switch strings.ToLower(u.Scheme) {
 	case "http", "https":
@@ -182,17 +184,18 @@ func (r *DefaultImageResolver) resolveTFTPURL(ctx context.Context, u *url.URL, s
 }
 
 func (r *DefaultImageResolver) resolveFTPURL(ctx context.Context, namespace string, u *url.URL, src opsv1alpha1.UpgradeImageSource) (*ResolvedImage, error) {
+	label := fmt.Sprintf("image source FTP %s", redactURL(u))
 	path, err := requiredRemotePath(u, "FTP")
 	if err != nil {
 		return nil, err
 	}
 	addr, err := hostPort(u, "21")
 	if err != nil {
-		return nil, fmt.Errorf("image source FTP: %w", err)
+		return nil, fmt.Errorf("%s: %w", label, err)
 	}
 	creds, err := r.urlCredentials(ctx, namespace, u, src.URLSecretRef)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%s: %w", label, err)
 	}
 	username := creds.Username
 	password := creds.Password
@@ -204,61 +207,63 @@ func (r *DefaultImageResolver) resolveFTPURL(ctx context.Context, namespace stri
 	}
 	conn, err := ftp.Dial(addr, ftp.DialWithContext(ctx), ftp.DialWithTimeout(30*time.Second))
 	if err != nil {
-		return nil, fmt.Errorf("image source FTP dial: %w", err)
+		return nil, fmt.Errorf("%s dial: %w", label, err)
 	}
 	defer func() { _ = conn.Quit() }()
 	if err := conn.Login(username, password); err != nil {
-		return nil, fmt.Errorf("image source FTP login: %w", err)
+		return nil, fmt.Errorf("%s login: %w", label, err)
 	}
 	if err := conn.Type(ftp.TransferTypeBinary); err != nil {
-		return nil, fmt.Errorf("image source FTP binary mode: %w", err)
+		return nil, fmt.Errorf("%s binary mode: %w", label, err)
 	}
 	resp, err := conn.Retr(path)
 	if err != nil {
-		return nil, fmt.Errorf("image source FTP retrieve %s: %w", path, err)
+		return nil, fmt.Errorf("%s retrieve %s: %w", label, path, err)
 	}
 	defer func() { _ = resp.Close() }()
-	return materializeRemoteImage("image source FTP", src.SHA256, func(w io.Writer) (int64, error) {
+	return materializeRemoteImage(label, src.SHA256, func(w io.Writer) (int64, error) {
 		return io.Copy(w, resp)
 	})
 }
 
 func (r *DefaultImageResolver) resolveSCPURL(ctx context.Context, namespace string, u *url.URL, src opsv1alpha1.UpgradeImageSource) (*ResolvedImage, error) {
+	label := fmt.Sprintf("image source SCP %s", redactURL(u))
 	path, err := requiredRemotePath(u, "SCP")
 	if err != nil {
 		return nil, err
 	}
 	client, err := r.sshClient(ctx, namespace, u, src.URLSecretRef)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%s: %w", label, err)
 	}
 	defer func() { _ = client.Close() }()
-	return materializeRemoteImage("image source SCP", src.SHA256, func(w io.Writer) (int64, error) {
+	return materializeRemoteImage(label, src.SHA256, func(w io.Writer) (int64, error) {
 		return scpDownload(ctx, client, path, w)
 	})
 }
 
 func (r *DefaultImageResolver) resolveSFTPURL(ctx context.Context, namespace string, u *url.URL, src opsv1alpha1.UpgradeImageSource) (*ResolvedImage, error) {
+	label := fmt.Sprintf("image source SFTP %s", redactURL(u))
 	path, err := requiredRemotePath(u, "SFTP")
 	if err != nil {
 		return nil, err
 	}
 	client, err := r.sshClient(ctx, namespace, u, src.URLSecretRef)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%s: %w", label, err)
 	}
 	defer func() { _ = client.Close() }()
 	sftpClient, err := sftp.NewClient(client)
 	if err != nil {
-		return nil, fmt.Errorf("image source SFTP client: %w", err)
+		return nil, fmt.Errorf("%s client: %w", label, err)
 	}
 	defer func() { _ = sftpClient.Close() }()
 	file, err := sftpClient.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("image source SFTP open %s: %w", path, err)
+		return nil, fmt.Errorf("%s open %s: %w", label, path, err)
 	}
 	defer func() { _ = file.Close() }()
-	return materializeRemoteImage("image source SFTP", src.SHA256, func(w io.Writer) (int64, error) {
+	return materializeRemoteImage(label, src.SHA256, func(w io.Writer) (int64, error) {
 		return io.Copy(w, file)
 	})
 }
@@ -410,6 +415,10 @@ func sshAuthMethods(creds *transferCredentials) ([]ssh.AuthMethod, error) {
 
 func sshHostKeyCallback(u *url.URL, creds *transferCredentials) (ssh.HostKeyCallback, error) {
 	if queryBool(u, "insecureSkipHostKey") || queryBool(u, "insecure") {
+		allowed, _ := strconv.ParseBool(os.Getenv(envAllowInsecureSSH))
+		if !allowed {
+			return nil, fmt.Errorf("image source SSH: insecure host key verification requires %s=true", envAllowInsecureSSH)
+		}
 		return ssh.InsecureIgnoreHostKey(), nil //nolint:gosec // explicit per-URL lab escape hatch
 	}
 	if len(creds.KnownHosts) == 0 {
@@ -584,6 +593,19 @@ func redactURL(u *url.URL) string {
 		redacted.User = url.User(redacted.User.Username())
 	}
 	return redacted.String()
+}
+
+func redactRawURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		at := strings.LastIndex(raw, "@")
+		scheme := strings.Index(raw, "://")
+		if scheme >= 0 && at > scheme {
+			return raw[:scheme+3] + "xxxxx@" + raw[at+1:]
+		}
+		return raw
+	}
+	return redactURL(u)
 }
 
 func shellQuote(s string) string {

--- a/internal/provider/softwareupgrade/imageresolver_test.go
+++ b/internal/provider/softwareupgrade/imageresolver_test.go
@@ -135,6 +135,38 @@ func TestDefaultImageResolverSCPRequiresHostKeyPolicy(t *testing.T) {
 	if !strings.Contains(err.Error(), "knownHosts") {
 		t.Fatalf("expected host-key policy error, got %v", err)
 	}
+	if strings.Contains(err.Error(), "pass") {
+		t.Fatalf("error leaked URL password: %v", err)
+	}
+}
+
+func TestDefaultImageResolverSCPInsecureRequiresOperatorEnv(t *testing.T) {
+	t.Setenv(envAllowInsecureSSH, "")
+	src := opsv1alpha1.UpgradeImageSource{
+		URL:    "scp://user:pass@127.0.0.1/tmp/cat9k.bin?insecureSkipHostKey=true",
+		SHA256: strings.Repeat("a", 64),
+	}
+	_, err := NewDefaultImageResolver(nil, nil).Resolve(context.Background(), "default", src)
+	if err == nil {
+		t.Fatal("Resolve admitted insecure SCP host-key bypass without operator env gate")
+	}
+	if !strings.Contains(err.Error(), envAllowInsecureSSH) {
+		t.Fatalf("expected env-gate error, got %v", err)
+	}
+	if strings.Contains(err.Error(), "pass") {
+		t.Fatalf("error leaked URL password: %v", err)
+	}
+}
+
+func TestRedactURLPreservesUsernameAndDropsPassword(t *testing.T) {
+	raw := "sftp://user:secret@example.com/images/cat9k.bin"
+	got := redactRawURL(raw)
+	if !strings.Contains(got, "user@example.com") {
+		t.Fatalf("redacted URL %q did not preserve username and host", got)
+	}
+	if strings.Contains(got, "secret") {
+		t.Fatalf("redacted URL leaked password: %q", got)
+	}
 }
 
 func sha256Hex(b []byte) string {

--- a/internal/provider/softwareupgrade/metrics.go
+++ b/internal/provider/softwareupgrade/metrics.go
@@ -1,0 +1,49 @@
+// Copyright © 2026 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package softwareupgrade
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	metricsOnce sync.Once
+
+	phaseTransitions *prometheus.CounterVec
+)
+
+// RegisterMetrics registers IOSXESoftwareUpgrade metrics. It is safe to call
+// more than once in a process; the first registry wins.
+func RegisterMetrics(reg prometheus.Registerer) {
+	metricsOnce.Do(func() {
+		phaseTransitions = prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "cisco_vk_iosxe_software_upgrade_phase_transitions_total",
+				Help: "Count of IOSXESoftwareUpgrade phase transitions.",
+			},
+			[]string{"device", "target_version", "from", "to", "reason"},
+		)
+		reg.MustRegister(phaseTransitions)
+	})
+}
+
+func recordPhaseTransition(device, targetVersion, from, to, reason string) {
+	if phaseTransitions == nil {
+		return
+	}
+	phaseTransitions.WithLabelValues(device, targetVersion, from, to, reason).Inc()
+}

--- a/internal/provider/softwareupgrade/reconciler.go
+++ b/internal/provider/softwareupgrade/reconciler.go
@@ -65,18 +65,13 @@ const (
 	conditionTypeActivated       = "Activated"
 	conditionTypeDeviceReachable = "DeviceReachable"
 	conditionTypeVerified        = "Verified"
+	conditionTypeRollback        = "Rollback"
 )
 
 const (
 	awaitingReachabilityPoll = 30 * time.Second
 	activationRPCTimeout     = 90 * time.Second
 )
-
-// GNOIProvider exposes the per-device gNOI client. Set on the
-// reconciler at startup.
-type GNOIProvider interface {
-	GNOIClient(ctx context.Context) (*gnoi.Client, error)
-}
 
 // TransportProvider exposes the per-device config transport for
 // install-oper reads that complement gNOI lifecycle RPCs.
@@ -93,7 +88,7 @@ type Reconciler struct {
 	Scheme          *runtime.Scheme
 	DeviceName      string
 	DeviceNamespace string
-	GNOI            GNOIProvider
+	GNOI            gnoi.Provider
 	TP              TransportProvider
 	ImageResolver   ImageResolver
 
@@ -169,8 +164,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	case opsv1alpha1.UpgradePhaseVerifying:
 		return r.runVerifying(ctx, &up, now)
 	case opsv1alpha1.UpgradePhaseRollingBack:
-		return r.terminal(ctx, &up, opsv1alpha1.UpgradePhaseFailed, "RollbackNotImplemented",
-			"rollbackOnFailure requested, but boot-variable rewrite rollback is not implemented", now)
+		return r.runRollingBack(ctx, &up, now)
 	default:
 		// Terminal phases: nothing to do.
 		return reconcile.Result{}, nil
@@ -204,8 +198,9 @@ func (r *Reconciler) runPending(ctx context.Context, up *opsv1alpha1.IOSXESoftwa
 }
 
 func (r *Reconciler) runResolving(ctx context.Context, up *opsv1alpha1.IOSXESoftwareUpgrade, now time.Time) (reconcile.Result, error) {
+	previousVersion := up.Status.PreviousVersion
 	if r.GNOI != nil {
-		client, err := r.GNOI.GNOIClient(ctx)
+		gnoiClient, err := r.GNOI.GNOIClient(ctx)
 		if err != nil {
 			return r.updateStatus(ctx, up, func(cur *opsv1alpha1.IOSXESoftwareUpgrade) {
 				if cur.Status.StartTime == nil {
@@ -217,7 +212,8 @@ func (r *Reconciler) runResolving(ctx context.Context, up *opsv1alpha1.IOSXESoft
 				r.setReady(cur, metav1.ConditionFalse, "DeviceUnreachable", cur.Status.Message, now)
 			}, reconcile.Result{RequeueAfter: awaitingReachabilityPoll})
 		}
-		if res, err := client.Verify(ctx); err != nil {
+		if res, err := gnoiClient.Verify(ctx); err != nil {
+			r.resetGNOIClientIfTransient(ctx, err)
 			return r.updateStatus(ctx, up, func(cur *opsv1alpha1.IOSXESoftwareUpgrade) {
 				if cur.Status.StartTime == nil {
 					cur.Status.StartTime = &metav1.Time{Time: now}
@@ -249,6 +245,8 @@ func (r *Reconciler) runResolving(ctx context.Context, up *opsv1alpha1.IOSXESoft
 					fmt.Sprintf("gNOI OS.Verify reports target version %s", res.Version), now)
 				r.setReady(cur, metav1.ConditionTrue, "AlreadyRunning", cur.Status.Message, now)
 			}, reconcile.Result{})
+		} else if res.Version != "" {
+			previousVersion = res.Version
 		}
 	}
 	if r.ImageResolver == nil {
@@ -261,6 +259,7 @@ func (r *Reconciler) runResolving(ctx context.Context, up *opsv1alpha1.IOSXESoft
 				cur.Status.StartTime = &metav1.Time{Time: now}
 			}
 			cur.Status.Phase = opsv1alpha1.UpgradePhaseActivating
+			rememberPreviousVersion(cur, previousVersion)
 			cur.Status.ValidatedVersion = stagedVersion
 			cur.Status.Message = fmt.Sprintf("device already has staged version %s, activating", stagedVersion)
 			cur.Status.FailureReason = ""
@@ -311,6 +310,7 @@ func (r *Reconciler) runResolving(ctx context.Context, up *opsv1alpha1.IOSXESoft
 				cur.Status.StartTime = &metav1.Time{Time: now}
 			}
 			cur.Status.Phase = opsv1alpha1.UpgradePhaseActivating
+			rememberPreviousVersion(cur, previousVersion)
 			cur.Status.Message = "using image already on device flash"
 			cur.Status.FailureReason = ""
 			r.setCondition(cur, conditionTypeImageResolved, metav1.ConditionTrue, "LocalPath",
@@ -335,6 +335,7 @@ func (r *Reconciler) runResolving(ctx context.Context, up *opsv1alpha1.IOSXESoft
 			cur.Status.StartTime = &metav1.Time{Time: now}
 		}
 		cur.Status.Phase = opsv1alpha1.UpgradePhaseTransferring
+		rememberPreviousVersion(cur, previousVersion)
 		cur.Status.Message = fmt.Sprintf("image resolved (%d bytes), transferring to device", resolved.Size)
 		cur.Status.FailureReason = ""
 		r.setCondition(cur, conditionTypeImageResolved, metav1.ConditionTrue, "ImageResolved",
@@ -352,10 +353,12 @@ func (r *Reconciler) runTransferring(ctx context.Context, up *opsv1alpha1.IOSXES
 	}
 	gnoiClient, err := r.GNOI.GNOIClient(ctx)
 	if err != nil {
+		r.resetGNOIClientIfTransient(ctx, err)
 		return r.waitForTransferPreflight(ctx, up, "DeviceUnreachable",
 			fmt.Sprintf("waiting for gNOI client before image transfer: %s", err.Error()), now)
 	}
 	if _, err := gnoiClient.Verify(ctx); err != nil {
+		r.resetGNOIClientIfTransient(ctx, err)
 		return r.waitForTransferPreflight(ctx, up, "VerifyPending",
 			fmt.Sprintf("waiting for gNOI OS.Verify before image transfer: %s", err.Error()), now)
 	}
@@ -381,12 +384,14 @@ func (r *Reconciler) runTransferring(ctx context.Context, up *opsv1alpha1.IOSXES
 		PackageSize: uint64(resolved.Size),
 	})
 	if err != nil {
+		r.resetGNOIClientIfTransient(ctx, err)
 		return r.handleInstallErr(ctx, up, err, now)
 	}
 	var validated *gnoi.InstallValidated
 	for ev := range progress {
 		switch {
 		case ev.Err != nil:
+			r.resetGNOIClientIfTransient(ctx, ev.Err)
 			return r.handleInstallErr(ctx, up, ev.Err, now)
 		case ev.TransferProgress != nil:
 			r.updateTransferProgress(ctx, up, ev.TransferProgress.BytesReceived, resolved.Size, now)
@@ -477,6 +482,7 @@ func (r *Reconciler) runTransferInterrupted(ctx context.Context, up *opsv1alpha1
 func (r *Reconciler) runActivating(ctx context.Context, up *opsv1alpha1.IOSXESoftwareUpgrade, now time.Time) (reconcile.Result, error) {
 	gnoiClient, err := r.GNOI.GNOIClient(ctx)
 	if err != nil {
+		r.resetGNOIClientIfTransient(ctx, err)
 		if activationRequestSubmitted(up) {
 			return r.activationLikelyStarted(ctx, up, up.Status.ValidatedVersion,
 				fmt.Sprintf("waiting for device after activation request: %s", err.Error()), now)
@@ -490,13 +496,15 @@ func (r *Reconciler) runActivating(ctx context.Context, up *opsv1alpha1.IOSXESof
 	}
 	if stagedVersion, err := r.resolveStagedVersion(ctx, up.Spec.TargetVersion); err == nil && stagedVersion != "" && stagedVersion != activateVersion {
 		activateVersion = stagedVersion
-		_, _ = r.updateStatus(ctx, up, func(cur *opsv1alpha1.IOSXESoftwareUpgrade) {
+		if _, err := r.updateStatus(ctx, up, func(cur *opsv1alpha1.IOSXESoftwareUpgrade) {
 			cur.Status.ValidatedVersion = stagedVersion
 			cur.Status.Message = fmt.Sprintf("device staged %s, activating", stagedVersion)
 			r.setCondition(cur, conditionTypeValidated, metav1.ConditionTrue, "StagedVersionResolved",
 				fmt.Sprintf("device staged %s for activation", stagedVersion), now)
 			r.setReady(cur, metav1.ConditionFalse, "StagedVersionResolved", cur.Status.Message, now)
-		}, reconcile.Result{})
+		}, reconcile.Result{}); err != nil {
+			return reconcile.Result{}, err
+		}
 	}
 	activateCandidates := activationVersionCandidates(activateVersion, up.Spec.TargetVersion)
 	activationMessage := fmt.Sprintf("submitting gNOI OS.Activate for version %s", activateCandidates[0])
@@ -521,11 +529,13 @@ func (r *Reconciler) runActivating(ctx context.Context, up *opsv1alpha1.IOSXESof
 		if idx > 0 {
 			fallbackMessage := fmt.Sprintf("retrying gNOI OS.Activate with version %s after IOS XE rejected %s",
 				candidate, activateCandidates[idx-1])
-			_, _ = r.updateStatus(ctx, up, func(cur *opsv1alpha1.IOSXESoftwareUpgrade) {
+			if _, err := r.updateStatus(ctx, up, func(cur *opsv1alpha1.IOSXESoftwareUpgrade) {
 				cur.Status.Message = fallbackMessage
 				r.setCondition(cur, conditionTypeActivated, metav1.ConditionFalse, "ActivationRetry", fallbackMessage, now)
 				r.setReady(cur, metav1.ConditionFalse, "ActivationRetry", fallbackMessage, now)
-			}, reconcile.Result{})
+			}, reconcile.Result{}); err != nil {
+				return reconcile.Result{}, err
+			}
 			r.emitEvent(up, corev1.EventTypeNormal, "ActivationRetry", fallbackMessage)
 		}
 		activateCtx, cancel := context.WithTimeout(ctx, activationRPCTimeout)
@@ -540,6 +550,7 @@ func (r *Reconciler) runActivating(ctx context.Context, up *opsv1alpha1.IOSXESof
 			break
 		}
 		if activationMayHaveStarted(activateErr) {
+			r.resetGNOIClientIfTransient(ctx, activateErr)
 			return r.activationLikelyStarted(ctx, up, candidate,
 				fmt.Sprintf("gNOI OS.Activate did not return cleanly after requesting version %s: %s", candidate, activateErr.Error()), now)
 		}
@@ -548,6 +559,7 @@ func (r *Reconciler) runActivating(ctx context.Context, up *opsv1alpha1.IOSXESof
 		}
 	}
 	if activateErr != nil {
+		r.resetGNOIClientIfTransient(ctx, activateErr)
 		return r.terminal(ctx, up, opsv1alpha1.UpgradePhaseFailed, "ActivateFailed", activateErr.Error(), now)
 	}
 	if noReboot {
@@ -610,18 +622,20 @@ func (r *Reconciler) activationLikelyStarted(
 }
 
 func (r *Reconciler) runAwaitingReachability(ctx context.Context, up *opsv1alpha1.IOSXESoftwareUpgrade, now time.Time) (reconcile.Result, error) {
-	client, err := r.GNOI.GNOIClient(ctx)
+	gnoiClient, err := r.GNOI.GNOIClient(ctx)
 	if err != nil {
+		r.resetGNOIClientIfTransient(ctx, err)
 		// Conn missing usually means the device is still rebooting; backoff.
 		return r.requeueAwaitingReachability(ctx, up, err, now)
 	}
-	if _, err := client.Time(ctx); err != nil {
+	if _, err := gnoiClient.Time(ctx); err != nil {
 		if isUnsupportedSystemService(err) {
-			return r.verifyReachableDevice(ctx, up, client, "device gNOI endpoint is reachable; system service unsupported", now)
+			return r.verifyReachableDevice(ctx, up, gnoiClient, "device gNOI endpoint is reachable; system service unsupported", now)
 		}
+		r.resetGNOIClientIfTransient(ctx, err)
 		return r.requeueAwaitingReachability(ctx, up, err, now)
 	}
-	return r.verifyReachableDevice(ctx, up, client, "device is reachable", now)
+	return r.verifyReachableDevice(ctx, up, gnoiClient, "device is reachable", now)
 }
 
 func (r *Reconciler) verifyReachableDevice(
@@ -633,6 +647,7 @@ func (r *Reconciler) verifyReachableDevice(
 ) (reconcile.Result, error) {
 	res, err := client.Verify(ctx)
 	if err != nil {
+		r.resetGNOIClientIfTransient(ctx, err)
 		return r.requeueAwaitingReachability(ctx, up, fmt.Errorf("%s but OS.Verify is not ready: %w", reachableMessage, err), now)
 	}
 	if versionMatches(res.Version, up.Spec.TargetVersion) {
@@ -711,12 +726,14 @@ func (r *Reconciler) requeueAwaitingReachability(ctx context.Context, up *opsv1a
 }
 
 func (r *Reconciler) runVerifying(ctx context.Context, up *opsv1alpha1.IOSXESoftwareUpgrade, now time.Time) (reconcile.Result, error) {
-	client, err := r.GNOI.GNOIClient(ctx)
+	gnoiClient, err := r.GNOI.GNOIClient(ctx)
 	if err != nil {
+		r.resetGNOIClientIfTransient(ctx, err)
 		return r.terminal(ctx, up, opsv1alpha1.UpgradePhaseFailed, "GNOIClient", err.Error(), now)
 	}
-	res, err := client.Verify(ctx)
+	res, err := gnoiClient.Verify(ctx)
 	if err != nil {
+		r.resetGNOIClientIfTransient(ctx, err)
 		return r.terminal(ctx, up, opsv1alpha1.UpgradePhaseFailed, "VerifyFailed", err.Error(), now)
 	}
 	if !versionMatches(res.Version, up.Spec.TargetVersion) {
@@ -734,9 +751,22 @@ func (r *Reconciler) runVerifying(ctx context.Context, up *opsv1alpha1.IOSXESoft
 		}
 		rollback := up.Spec.RollbackOnFailure == nil || *up.Spec.RollbackOnFailure
 		if rollback {
-			return r.terminal(ctx, up, opsv1alpha1.UpgradePhaseFailed, "RollbackNotImplemented",
-				fmt.Sprintf("device runs %s but spec targets %s; rollbackOnFailure requested, but boot-variable rewrite rollback is not implemented",
-					res.Version, up.Spec.TargetVersion), now)
+			if up.Status.PreviousVersion == "" {
+				return r.terminal(ctx, up, opsv1alpha1.UpgradePhaseFailed, "RollbackVersionMissing",
+					fmt.Sprintf("device runs %s but spec targets %s; rollbackOnFailure requested, but no previous version was captured",
+						res.Version, up.Spec.TargetVersion), now)
+			}
+			return r.updateStatus(ctx, up, func(cur *opsv1alpha1.IOSXESoftwareUpgrade) {
+				cur.Status.Phase = opsv1alpha1.UpgradePhaseRollingBack
+				cur.Status.RunningVersion = res.Version
+				cur.Status.FailureReason = ""
+				cur.Status.Message = fmt.Sprintf("device runs %s but target is %s; rolling back to previous version %s",
+					res.Version, up.Spec.TargetVersion, cur.Status.PreviousVersion)
+				r.setCondition(cur, conditionTypeVerified, metav1.ConditionFalse, "VerifyMismatch", cur.Status.Message, now)
+				r.setCondition(cur, conditionTypeRollback, metav1.ConditionFalse, "RollbackPending",
+					fmt.Sprintf("waiting to activate previous version %s", cur.Status.PreviousVersion), now)
+				r.setReady(cur, metav1.ConditionFalse, "RollbackPending", cur.Status.Message, now)
+			}, reconcile.Result{RequeueAfter: time.Second})
 		}
 		return r.updateStatus(ctx, up, func(cur *opsv1alpha1.IOSXESoftwareUpgrade) {
 			cur.Status.Phase = opsv1alpha1.UpgradePhaseFailed
@@ -762,6 +792,84 @@ func (r *Reconciler) runVerifying(ctx context.Context, up *opsv1alpha1.IOSXESoft
 	}, reconcile.Result{})
 }
 
+func (r *Reconciler) runRollingBack(ctx context.Context, up *opsv1alpha1.IOSXESoftwareUpgrade, now time.Time) (reconcile.Result, error) {
+	previous := up.Status.PreviousVersion
+	if previous == "" {
+		return r.terminal(ctx, up, opsv1alpha1.UpgradePhaseFailed, "RollbackVersionMissing",
+			"rollback requested, but no previous version was captured before activation", now)
+	}
+	gnoiClient, err := r.GNOI.GNOIClient(ctx)
+	if err != nil {
+		r.resetGNOIClientIfTransient(ctx, err)
+		return r.requeueRollback(ctx, up, fmt.Errorf("waiting for device before rollback: %w", err), now)
+	}
+
+	if rollbackRequestSubmitted(up) {
+		res, err := gnoiClient.Verify(ctx)
+		if err != nil {
+			r.resetGNOIClientIfTransient(ctx, err)
+			return r.requeueRollback(ctx, up, fmt.Errorf("waiting for device after rollback activation: %w", err), now)
+		}
+		if versionMatches(res.Version, previous) {
+			return r.updateStatus(ctx, up, func(cur *opsv1alpha1.IOSXESoftwareUpgrade) {
+				cur.Status.Phase = opsv1alpha1.UpgradePhaseRolledBack
+				cur.Status.RunningVersion = res.Version
+				cur.Status.FailureReason = "RolledBack"
+				cur.Status.CompletionTime = &metav1.Time{Time: now}
+				cur.Status.Message = fmt.Sprintf("rollback complete; device is running previous version %s", res.Version)
+				r.setCondition(cur, conditionTypeRollback, metav1.ConditionTrue, "RolledBack", cur.Status.Message, now)
+				r.setReady(cur, metav1.ConditionFalse, "RolledBack", cur.Status.Message, now)
+			}, reconcile.Result{})
+		}
+		return r.requeueRollback(ctx, up,
+			fmt.Errorf("device is reachable on %s while rollback target is %s", res.Version, previous), now)
+	}
+
+	message := fmt.Sprintf("submitting gNOI OS.Activate rollback to previous version %s", previous)
+	r.emitEvent(up, corev1.EventTypeWarning, "RollbackRequested", message)
+	activateCtx, cancel := context.WithTimeout(ctx, activationRPCTimeout)
+	log.G(ctx).WithField("softwareUpgrade", client.ObjectKeyFromObject(up).String()).
+		WithField("version", previous).
+		Warn("dispatching gNOI OS.Activate rollback")
+	activateErr := gnoiClient.Activate(activateCtx, gnoi.ActivateOpts{Version: previous})
+	cancel()
+	if activateErr != nil && !activationMayHaveStarted(activateErr) {
+		r.resetGNOIClientIfTransient(ctx, activateErr)
+		return r.terminal(ctx, up, opsv1alpha1.UpgradePhaseFailed, "RollbackActivateFailed", activateErr.Error(), now)
+	}
+	if activateErr != nil {
+		r.resetGNOIClientIfTransient(ctx, activateErr)
+		message = fmt.Sprintf("%s; device connection closed during rollback activation: %s", message, activateErr.Error())
+	}
+	return r.updateStatus(ctx, up, func(cur *opsv1alpha1.IOSXESoftwareUpgrade) {
+		cur.Status.Phase = opsv1alpha1.UpgradePhaseRollingBack
+		cur.Status.ValidatedVersion = previous
+		cur.Status.Message = message
+		cur.Status.FailureReason = ""
+		r.setCondition(cur, conditionTypeRollback, metav1.ConditionFalse, "RollbackRequested", message, now)
+		r.setReady(cur, metav1.ConditionFalse, "RollbackRequested", message, now)
+	}, reconcile.Result{RequeueAfter: awaitingReachabilityPoll})
+}
+
+func (r *Reconciler) requeueRollback(ctx context.Context, up *opsv1alpha1.IOSXESoftwareUpgrade, err error, now time.Time) (reconcile.Result, error) {
+	timeoutSec := up.Spec.RebootTimeoutSeconds
+	if timeoutSec == 0 {
+		timeoutSec = 1800
+	}
+	if rollbackTimedOut(up, now) {
+		return r.terminal(ctx, up, opsv1alpha1.UpgradePhaseFailed, "RollbackDidNotConverge",
+			fmt.Sprintf("rollback to %s did not converge within %ds: %s", up.Status.PreviousVersion, timeoutSec, err.Error()), now)
+	}
+	message := err.Error()
+	return r.updateStatus(ctx, up, func(cur *opsv1alpha1.IOSXESoftwareUpgrade) {
+		cur.Status.Phase = opsv1alpha1.UpgradePhaseRollingBack
+		cur.Status.Message = message
+		cur.Status.FailureReason = ""
+		r.setCondition(cur, conditionTypeRollback, metav1.ConditionFalse, "RollbackWaiting", message, now)
+		r.setReady(cur, metav1.ConditionFalse, "RollbackWaiting", message, now)
+	}, reconcile.Result{RequeueAfter: awaitingReachabilityPoll})
+}
+
 func upgradeTimedOut(up *opsv1alpha1.IOSXESoftwareUpgrade, now time.Time) bool {
 	timeoutSec := up.Spec.RebootTimeoutSeconds
 	if timeoutSec == 0 {
@@ -769,6 +877,53 @@ func upgradeTimedOut(up *opsv1alpha1.IOSXESoftwareUpgrade, now time.Time) bool {
 	}
 	since := upgradeWaitStart(up)
 	return since != nil && now.Sub(*since) > time.Duration(timeoutSec)*time.Second
+}
+
+func rollbackTimedOut(up *opsv1alpha1.IOSXESoftwareUpgrade, now time.Time) bool {
+	timeoutSec := up.Spec.RebootTimeoutSeconds
+	if timeoutSec == 0 {
+		timeoutSec = 1800
+	}
+	since := rollbackWaitStart(up)
+	return since != nil && now.Sub(*since) > time.Duration(timeoutSec)*time.Second
+}
+
+func rollbackWaitStart(up *opsv1alpha1.IOSXESoftwareUpgrade) *time.Time {
+	for _, cond := range up.Status.Conditions {
+		if cond.Type == conditionTypeRollback && cond.Reason == "RollbackRequested" {
+			return &cond.LastTransitionTime.Time
+		}
+	}
+	if up.Status.StartTime != nil {
+		return &up.Status.StartTime.Time
+	}
+	return nil
+}
+
+func rollbackRequestSubmitted(up *opsv1alpha1.IOSXESoftwareUpgrade) bool {
+	for _, cond := range up.Status.Conditions {
+		if cond.Type == conditionTypeRollback && cond.Reason == "RollbackRequested" {
+			return true
+		}
+	}
+	return false
+}
+
+func rememberPreviousVersion(up *opsv1alpha1.IOSXESoftwareUpgrade, previous string) {
+	if up.Status.PreviousVersion == "" && previous != "" {
+		up.Status.PreviousVersion = previous
+	}
+}
+
+func (r *Reconciler) resetGNOIClientIfTransient(ctx context.Context, err error) {
+	if err == nil || !isTransientGNOIError(err) {
+		return
+	}
+	resetter, ok := r.GNOI.(gnoi.ResetProvider)
+	if !ok {
+		return
+	}
+	resetter.ResetGNOIClient(ctx)
 }
 
 func upgradeWaitStart(up *opsv1alpha1.IOSXESoftwareUpgrade) *time.Time {
@@ -859,7 +1014,7 @@ func (r *Reconciler) updateTransferProgress(ctx context.Context, up *opsv1alpha1
 			return
 		}
 	}
-	_, _ = r.updateStatus(ctx, up, func(cur *opsv1alpha1.IOSXESoftwareUpgrade) {
+	if _, err := r.updateStatus(ctx, up, func(cur *opsv1alpha1.IOSXESoftwareUpgrade) {
 		percent := int32(0)
 		if total > 0 {
 			percent = int32(bytesReceived * 100 / uint64(total))
@@ -870,7 +1025,9 @@ func (r *Reconciler) updateTransferProgress(ctx context.Context, up *opsv1alpha1
 			Percent:          percent,
 		}
 		cur.Status.Message = fmt.Sprintf("transferring: %d/%d bytes (%d%%)", bytesReceived, total, percent)
-	}, reconcile.Result{})
+	}, reconcile.Result{}); err != nil {
+		log.G(ctx).WithError(err).Warn("IOSXESoftwareUpgrade transfer progress status update failed")
+	}
 }
 
 func (r *Reconciler) setReady(up *opsv1alpha1.IOSXESoftwareUpgrade, status metav1.ConditionStatus, reason, message string, now time.Time) {
@@ -1049,34 +1206,42 @@ func isActivateVersionNotPresent(err error) bool {
 	}
 	var activateErr *gnoi.ActivateError
 	if errors.As(err, &activateErr) {
-		detail := strings.ToLower(activateErr.Detail)
-		return strings.Contains(detail, "version not present") ||
-			strings.Contains(detail, "non-existent") ||
-			strings.Contains(detail, "non existent")
+		return activateErr.Type == gnoi.ActivateErrorNonExistentVersion
 	}
-	message := strings.ToLower(err.Error())
-	return strings.Contains(message, "version not present") ||
-		strings.Contains(message, "non-existent") ||
-		strings.Contains(message, "non existent")
+	return false
 }
 
 func activationMayHaveStarted(err error) bool {
 	if err == nil {
 		return false
 	}
-	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+	if errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, context.Canceled) ||
+		errors.Is(err, io.EOF) {
 		return true
 	}
 	switch status.Code(err) {
 	case codes.DeadlineExceeded, codes.Canceled, codes.Unavailable:
 		return true
 	}
-	message := strings.ToLower(err.Error())
-	return strings.Contains(message, "context deadline exceeded") ||
-		strings.Contains(message, "transport is closing") ||
-		strings.Contains(message, "connection reset") ||
-		strings.Contains(message, "client connection closing") ||
-		strings.Contains(message, "eof")
+	return false
+}
+
+func isTransientGNOIError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, context.Canceled) ||
+		errors.Is(err, io.EOF) {
+		return true
+	}
+	switch status.Code(err) {
+	case codes.DeadlineExceeded, codes.Canceled, codes.Unavailable, codes.ResourceExhausted, codes.Aborted:
+		return true
+	default:
+		return false
+	}
 }
 
 func activationRequestSubmitted(up *opsv1alpha1.IOSXESoftwareUpgrade) bool {

--- a/internal/provider/softwareupgrade/reconciler.go
+++ b/internal/provider/softwareupgrade/reconciler.go
@@ -352,10 +352,12 @@ func (r *Reconciler) runTransferring(ctx context.Context, up *opsv1alpha1.IOSXES
 	}
 	gnoiClient, err := r.GNOI.GNOIClient(ctx)
 	if err != nil {
-		return r.terminal(ctx, up, opsv1alpha1.UpgradePhaseFailed, "GNOIClient", err.Error(), now)
+		return r.waitForTransferPreflight(ctx, up, "DeviceUnreachable",
+			fmt.Sprintf("waiting for gNOI client before image transfer: %s", err.Error()), now)
 	}
 	if _, err := gnoiClient.Verify(ctx); err != nil {
-		return r.handleInstallErr(ctx, up, fmt.Errorf("gnoi OS.Verify preflight: %w", err), now)
+		return r.waitForTransferPreflight(ctx, up, "VerifyPending",
+			fmt.Sprintf("waiting for gNOI OS.Verify before image transfer: %s", err.Error()), now)
 	}
 	resolved, err := r.ImageResolver.Resolve(ctx, up.Namespace, up.Spec.ImageSource)
 	if err != nil {
@@ -416,6 +418,19 @@ func (r *Reconciler) runTransferring(ctx context.Context, up *opsv1alpha1.IOSXES
 			"waiting to submit gNOI OS.Activate", now)
 		r.setReady(cur, metav1.ConditionFalse, "Validated", cur.Status.Message, now)
 	}, reconcile.Result{RequeueAfter: time.Second})
+}
+
+func (r *Reconciler) waitForTransferPreflight(ctx context.Context, up *opsv1alpha1.IOSXESoftwareUpgrade, reason, message string, now time.Time) (reconcile.Result, error) {
+	return r.updateStatus(ctx, up, func(cur *opsv1alpha1.IOSXESoftwareUpgrade) {
+		if cur.Status.StartTime == nil {
+			cur.Status.StartTime = &metav1.Time{Time: now}
+		}
+		cur.Status.Phase = opsv1alpha1.UpgradePhaseTransferring
+		cur.Status.Message = message
+		cur.Status.FailureReason = ""
+		r.setCondition(cur, conditionTypeTransferred, metav1.ConditionFalse, reason, message, now)
+		r.setReady(cur, metav1.ConditionFalse, reason, message, now)
+	}, reconcile.Result{RequeueAfter: awaitingReachabilityPoll})
 }
 
 func (r *Reconciler) handleInstallErr(ctx context.Context, up *opsv1alpha1.IOSXESoftwareUpgrade, err error, now time.Time) (reconcile.Result, error) {

--- a/internal/provider/softwareupgrade/reconciler.go
+++ b/internal/provider/softwareupgrade/reconciler.go
@@ -16,12 +16,16 @@ package softwareupgrade
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
+	commonpb "github.com/openconfig/gnoi/types"
+	"github.com/virtual-kubelet/virtual-kubelet/log"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
@@ -164,12 +168,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	case opsv1alpha1.UpgradePhaseVerifying:
 		return r.runVerifying(ctx, &up, now)
 	case opsv1alpha1.UpgradePhaseRollingBack:
-		// Phase C ships RollingBack as a terminal placeholder — the
-		// reconciler records the rollback decision but does not yet
-		// trigger the boot-variable rewrite. Phase D follow-up wires
-		// the gNMI Set + System.Reboot pair.
-		return r.terminal(ctx, &up, opsv1alpha1.UpgradePhaseRolledBack, "RolledBack",
-			"rollback pending: boot-variable rewrite not yet implemented in Phase C", now)
+		return r.terminal(ctx, &up, opsv1alpha1.UpgradePhaseFailed, "RollbackNotImplemented",
+			"rollbackOnFailure requested, but boot-variable rewrite rollback is not implemented", now)
 	default:
 		// Terminal phases: nothing to do.
 		return reconcile.Result{}, nil
@@ -283,6 +283,28 @@ func (r *Reconciler) runResolving(ctx context.Context, up *opsv1alpha1.IOSXESoft
 		if resolved.Cleanup != nil {
 			_ = resolved.Cleanup()
 		}
+		if sha := up.Spec.ImageSource.LocalPathSHA256; sha != "" {
+			if r.GNOI == nil {
+				return r.terminal(ctx, up, opsv1alpha1.UpgradePhaseFailed, "NoGNOIProvider",
+					"gnoi provider is required to verify localPathSHA256", now)
+			}
+			gnoiClient, err := r.GNOI.GNOIClient(ctx)
+			if err != nil {
+				return r.terminal(ctx, up, opsv1alpha1.UpgradePhaseFailed, "GNOIClient", err.Error(), now)
+			}
+			hash, err := gnoiClient.Get(ctx, up.Spec.ImageSource.LocalPath, io.Discard)
+			if err != nil {
+				return r.terminal(ctx, up, opsv1alpha1.UpgradePhaseValidationFailed, "LocalPathHashFailed", err.Error(), now)
+			}
+			if hash.GetMethod() != commonpb.HashType_SHA256 {
+				return r.terminal(ctx, up, opsv1alpha1.UpgradePhaseValidationFailed, "LocalPathHashUnsupported",
+					fmt.Sprintf("device returned hash method %s, want SHA256", hash.GetMethod().String()), now)
+			}
+			if got := hex.EncodeToString(hash.GetHash()); got != sha {
+				return r.terminal(ctx, up, opsv1alpha1.UpgradePhaseValidationFailed, "LocalPathHashMismatch",
+					fmt.Sprintf("localPathSHA256 mismatch: got %s want %s", got, sha), now)
+			}
+		}
 		return r.updateStatus(ctx, up, func(cur *opsv1alpha1.IOSXESoftwareUpgrade) {
 			if cur.Status.StartTime == nil {
 				cur.Status.StartTime = &metav1.Time{Time: now}
@@ -327,11 +349,11 @@ func (r *Reconciler) runTransferring(ctx context.Context, up *opsv1alpha1.IOSXES
 		return r.terminal(ctx, up, opsv1alpha1.UpgradePhaseFailed, "NoGNOIProvider",
 			"gnoi provider not configured on reconciler", now)
 	}
-	client, err := r.GNOI.GNOIClient(ctx)
+	gnoiClient, err := r.GNOI.GNOIClient(ctx)
 	if err != nil {
 		return r.terminal(ctx, up, opsv1alpha1.UpgradePhaseFailed, "GNOIClient", err.Error(), now)
 	}
-	if _, err := client.Verify(ctx); err != nil {
+	if _, err := gnoiClient.Verify(ctx); err != nil {
 		return r.handleInstallErr(ctx, up, fmt.Errorf("gnoi OS.Verify preflight: %w", err), now)
 	}
 	resolved, err := r.ImageResolver.Resolve(ctx, up.Namespace, up.Spec.ImageSource)
@@ -348,7 +370,10 @@ func (r *Reconciler) runTransferring(ctx context.Context, up *opsv1alpha1.IOSXES
 		return r.advance(ctx, up, opsv1alpha1.UpgradePhaseActivating, "ImageResolved",
 			"image already on device flash")
 	}
-	progress, err := client.Install(ctx, resolved.Reader, gnoi.InstallOpts{
+	log.G(ctx).WithField("softwareUpgrade", client.ObjectKeyFromObject(up).String()).
+		WithField("targetVersion", up.Spec.TargetVersion).
+		Warn("dispatching gNOI OS.Install")
+	progress, err := gnoiClient.Install(ctx, resolved.Reader, gnoi.InstallOpts{
 		Version:     up.Spec.TargetVersion,
 		PackageSize: uint64(resolved.Size),
 	})
@@ -434,7 +459,7 @@ func (r *Reconciler) runTransferInterrupted(ctx context.Context, up *opsv1alpha1
 }
 
 func (r *Reconciler) runActivating(ctx context.Context, up *opsv1alpha1.IOSXESoftwareUpgrade, now time.Time) (reconcile.Result, error) {
-	client, err := r.GNOI.GNOIClient(ctx)
+	gnoiClient, err := r.GNOI.GNOIClient(ctx)
 	if err != nil {
 		if activationRequestSubmitted(up) {
 			return r.activationLikelyStarted(ctx, up, up.Status.ValidatedVersion,
@@ -488,7 +513,11 @@ func (r *Reconciler) runActivating(ctx context.Context, up *opsv1alpha1.IOSXESof
 			r.emitEvent(up, corev1.EventTypeNormal, "ActivationRetry", fallbackMessage)
 		}
 		activateCtx, cancel := context.WithTimeout(ctx, activationRPCTimeout)
-		activateErr = client.Activate(activateCtx, gnoi.ActivateOpts{Version: candidate, NoReboot: noReboot})
+		log.G(ctx).WithField("softwareUpgrade", client.ObjectKeyFromObject(up).String()).
+			WithField("version", candidate).
+			WithField("noReboot", noReboot).
+			Warn("dispatching gNOI OS.Activate")
+		activateErr = gnoiClient.Activate(activateCtx, gnoi.ActivateOpts{Version: candidate, NoReboot: noReboot})
 		cancel()
 		if activateErr == nil {
 			acceptedVersion = candidate
@@ -689,8 +718,9 @@ func (r *Reconciler) runVerifying(ctx context.Context, up *opsv1alpha1.IOSXESoft
 		}
 		rollback := up.Spec.RollbackOnFailure == nil || *up.Spec.RollbackOnFailure
 		if rollback {
-			return r.advance(ctx, up, opsv1alpha1.UpgradePhaseRollingBack, "VerifyMismatch",
-				fmt.Sprintf("device runs %s but spec targets %s; rolling back", res.Version, up.Spec.TargetVersion))
+			return r.terminal(ctx, up, opsv1alpha1.UpgradePhaseFailed, "RollbackNotImplemented",
+				fmt.Sprintf("device runs %s but spec targets %s; rollbackOnFailure requested, but boot-variable rewrite rollback is not implemented",
+					res.Version, up.Spec.TargetVersion), now)
 		}
 		return r.updateStatus(ctx, up, func(cur *opsv1alpha1.IOSXESoftwareUpgrade) {
 			cur.Status.Phase = opsv1alpha1.UpgradePhaseFailed
@@ -885,6 +915,12 @@ func (r *Reconciler) updateStatus(ctx context.Context, up *opsv1alpha1.IOSXESoft
 		if afterReason == "" {
 			afterReason = string(afterPhase)
 		}
+		log.G(ctx).WithField("softwareUpgrade", client.ObjectKeyFromObject(up).String()).
+			WithField("from", beforePhase).
+			WithField("to", afterPhase).
+			WithField("reason", afterReason).
+			Info("IOSXESoftwareUpgrade phase advanced")
+		recordPhaseTransition(r.DeviceName, up.Spec.TargetVersion, string(beforePhase), string(afterPhase), afterReason)
 		r.emitEvent(up, eventType, afterReason, afterMessage)
 	}
 	return result, nil

--- a/internal/provider/softwareupgrade/reconciler.go
+++ b/internal/provider/softwareupgrade/reconciler.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
@@ -862,26 +863,14 @@ func (r *Reconciler) setReady(up *opsv1alpha1.IOSXESoftwareUpgrade, status metav
 }
 
 func (r *Reconciler) setCondition(up *opsv1alpha1.IOSXESoftwareUpgrade, condType string, status metav1.ConditionStatus, reason, message string, now time.Time) {
-	cond := metav1.Condition{
+	apimeta.SetStatusCondition(&up.Status.Conditions, metav1.Condition{
 		Type:               condType,
 		Status:             status,
 		Reason:             reason,
 		Message:            message,
 		LastTransitionTime: metav1.Time{Time: now},
 		ObservedGeneration: up.Generation,
-	}
-	conds := up.Status.Conditions
-	for i, c := range conds {
-		if c.Type == cond.Type {
-			if c.Status == cond.Status && c.Reason == cond.Reason && c.Message == cond.Message {
-				return
-			}
-			conds[i] = cond
-			up.Status.Conditions = conds
-			return
-		}
-	}
-	up.Status.Conditions = append(conds, cond)
+	})
 }
 
 func (r *Reconciler) updateStatus(ctx context.Context, up *opsv1alpha1.IOSXESoftwareUpgrade, mutate func(*opsv1alpha1.IOSXESoftwareUpgrade), result reconcile.Result) (reconcile.Result, error) {

--- a/internal/provider/softwareupgrade/reconciler_test.go
+++ b/internal/provider/softwareupgrade/reconciler_test.go
@@ -535,7 +535,7 @@ func TestMarkTransferCompleteSetsTerminalProgress(t *testing.T) {
 	}
 }
 
-func TestVerifyMismatchTriggersRollback(t *testing.T) {
+func TestVerifyMismatchWithRollbackFailsClosedUntilRollbackImplemented(t *testing.T) {
 	rig := newRig(t)
 	rig.os.verifyVersion = "17.14.01a" // doesn't match target 17.15.01a
 	start := metav1.Time{Time: time.Unix(1_700_000_000, 0).UTC()}
@@ -546,10 +546,10 @@ func TestVerifyMismatchTriggersRollback(t *testing.T) {
 	})
 	r := newReconciler(t, rig, up)
 	got := runReconcile(t, r, up, 12)
-	if got.Status.Phase != opsv1alpha1.UpgradePhaseRolledBack {
+	if got.Status.Phase != opsv1alpha1.UpgradePhaseFailed {
 		t.Fatalf("phase=%q msg=%q", got.Status.Phase, got.Status.Message)
 	}
-	if got.Status.FailureReason != "RolledBack" {
+	if got.Status.FailureReason != "RollbackNotImplemented" {
 		t.Fatalf("FailureReason=%q", got.Status.FailureReason)
 	}
 }

--- a/internal/provider/softwareupgrade/reconciler_test.go
+++ b/internal/provider/softwareupgrade/reconciler_test.go
@@ -809,7 +809,7 @@ func TestResolvingDoesNotTreatCommittedInstallOperVersionAsStaged(t *testing.T) 
 	}
 }
 
-func TestTransferPreflightsGNOIBeforeResolvingImage(t *testing.T) {
+func TestTransferPreflightVerifyWaitsBeforeResolvingImage(t *testing.T) {
 	rig := newRig(t)
 	rig.os.verifyErr = status.Error(codes.Unavailable, "connect: connection refused")
 	up := newUpgrade("upgrade-gnoi-preflight", func(up *opsv1alpha1.IOSXESoftwareUpgrade) {
@@ -825,14 +825,53 @@ func TestTransferPreflightsGNOIBeforeResolvingImage(t *testing.T) {
 	if resolver.calls != 0 {
 		t.Fatalf("image resolver called %d time(s), want 0", resolver.calls)
 	}
-	if got.Status.Phase != opsv1alpha1.UpgradePhaseFailed {
+	if got.Status.Phase != opsv1alpha1.UpgradePhaseTransferring {
 		t.Fatalf("phase=%q msg=%q", got.Status.Phase, got.Status.Message)
 	}
-	if got.Status.FailureReason != "TransferMaxRetries" {
+	if got.Status.FailureReason != "" {
 		t.Fatalf("FailureReason=%q", got.Status.FailureReason)
 	}
-	if !strings.Contains(got.Status.Message, "gnoi OS.Verify preflight") {
-		t.Fatalf("expected preflight error in message, got %q", got.Status.Message)
+	if got.Status.RetryCount != 1 {
+		t.Fatalf("RetryCount=%d, want unchanged 1", got.Status.RetryCount)
+	}
+	if !strings.Contains(got.Status.Message, "waiting for gNOI OS.Verify before image transfer") {
+		t.Fatalf("expected preflight wait in message, got %q", got.Status.Message)
+	}
+	if gotReason := conditionReason(got.Status.Conditions, "Ready"); gotReason != "VerifyPending" {
+		t.Fatalf("Ready reason=%q, want VerifyPending", gotReason)
+	}
+}
+
+func TestTransferPreflightGNOIClientWaitsBeforeResolvingImage(t *testing.T) {
+	rig := newRig(t)
+	up := newUpgrade("upgrade-gnoi-client-preflight", func(up *opsv1alpha1.IOSXESoftwareUpgrade) {
+		up.Spec.MaxRetries = 1
+		up.Status.Phase = opsv1alpha1.UpgradePhaseTransferring
+		up.Status.RetryCount = 1
+	})
+	r := newReconciler(t, rig, up)
+	r.GNOI = unavailableGNOI{err: status.Error(codes.Unavailable, "connect: connection refused")}
+	resolver := &countingImageResolver{}
+	r.ImageResolver = resolver
+
+	got := runReconcile(t, r, up, 3)
+	if resolver.calls != 0 {
+		t.Fatalf("image resolver called %d time(s), want 0", resolver.calls)
+	}
+	if got.Status.Phase != opsv1alpha1.UpgradePhaseTransferring {
+		t.Fatalf("phase=%q msg=%q", got.Status.Phase, got.Status.Message)
+	}
+	if got.Status.FailureReason != "" {
+		t.Fatalf("FailureReason=%q", got.Status.FailureReason)
+	}
+	if got.Status.RetryCount != 1 {
+		t.Fatalf("RetryCount=%d, want unchanged 1", got.Status.RetryCount)
+	}
+	if !strings.Contains(got.Status.Message, "waiting for gNOI client before image transfer") {
+		t.Fatalf("expected preflight wait in message, got %q", got.Status.Message)
+	}
+	if gotReason := conditionReason(got.Status.Conditions, "Ready"); gotReason != "DeviceUnreachable" {
+		t.Fatalf("Ready reason=%q, want DeviceUnreachable", gotReason)
 	}
 }
 

--- a/internal/provider/softwareupgrade/reconciler_test.go
+++ b/internal/provider/softwareupgrade/reconciler_test.go
@@ -84,7 +84,10 @@ func (f *fakeOS) Activate(_ context.Context, req *ospb.ActivateRequest) (*ospb.A
 	}
 	if f.activateWantVersion != "" && req.Version != f.activateWantVersion {
 		return &ospb.ActivateResponse{Response: &ospb.ActivateResponse_ActivateError{
-			ActivateError: &ospb.ActivateError{Detail: "Version not present on device"},
+			ActivateError: &ospb.ActivateError{
+				Type:   ospb.ActivateError_NON_EXISTENT_VERSION,
+				Detail: "Version not present on device",
+			},
 		}}, nil
 	}
 	return &ospb.ActivateResponse{Response: &ospb.ActivateResponse_ActivateOk{ActivateOk: &ospb.ActivateOK{}}}, nil
@@ -535,22 +538,27 @@ func TestMarkTransferCompleteSetsTerminalProgress(t *testing.T) {
 	}
 }
 
-func TestVerifyMismatchWithRollbackFailsClosedUntilRollbackImplemented(t *testing.T) {
+func TestVerifyMismatchWithRollbackReactivatesPreviousVersion(t *testing.T) {
 	rig := newRig(t)
-	rig.os.verifyVersion = "17.14.01a" // doesn't match target 17.15.01a
+	rig.os.verifyVersions = []string{"17.14.01a", "17.13.01a"}
+	rig.os.activateWantVersion = "17.13.01a"
 	start := metav1.Time{Time: time.Unix(1_700_000_000, 0).UTC()}
 	up := newUpgrade("upgrade-mismatch", func(up *opsv1alpha1.IOSXESoftwareUpgrade) {
 		up.Finalizers = []string{Finalizer}
 		up.Status.Phase = opsv1alpha1.UpgradePhaseVerifying
 		up.Status.StartTime = &start
+		up.Status.PreviousVersion = "17.13.01a"
 	})
 	r := newReconciler(t, rig, up)
 	got := runReconcile(t, r, up, 12)
-	if got.Status.Phase != opsv1alpha1.UpgradePhaseFailed {
+	if got.Status.Phase != opsv1alpha1.UpgradePhaseRolledBack {
 		t.Fatalf("phase=%q msg=%q", got.Status.Phase, got.Status.Message)
 	}
-	if got.Status.FailureReason != "RollbackNotImplemented" {
+	if got.Status.FailureReason != "RolledBack" {
 		t.Fatalf("FailureReason=%q", got.Status.FailureReason)
+	}
+	if rig.os.activateVersion != "17.13.01a" {
+		t.Fatalf("activated version=%q, want previous version", rig.os.activateVersion)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add explicit opt-in gates for IOSXESoftwareUpgrade and write-class IOSXEOperationalAction via CLI flags, env propagation, and Helm values.
- Harden IOSXEOperationalAction with finalizer handling, invocation IDs, no duplicate dispatch from Running, kind-to-args validation, Kubernetes events, logging, CRD CEL, and RBAC for finalizers.
- Fix credential-safe image resolution, SSH host-key bypass gating, IOS-XE flash path validation, DHCP version override dispatch, localPath hash verification, gNOI/devicegrpc/upgrade/action metrics, and OS.Install cache/goroutine handling.
- Regenerate ops CRDs and Helm CRD copies.

## Validation
- make manifests
- go test ./cmd/cisco-vk ./internal/provider/operationalaction ./internal/provider/softwareupgrade ./internal/drivers/iosxe/gnoi ./internal/drivers/iosxe/devicegrpc ./internal/drivers/iosxe/configdriver/writers ./internal/drivers/iosxe/configdriver/engine ./internal/drivers/iosxe/configdriver/transport
- GOCACHE=/tmp/cvk-gocache go test -race ./...

## Notes
- RollbackOnFailure now fails closed with RollbackNotImplemented instead of advertising a completed rollback that is not wired yet.
- Remaining medium-priority cleanup items from the external review can follow separately so this PR stays focused on safety and operational correctness.