### PR TITLE
fix(configdriver): correct CDP writer leaf names and legacy encoding

### DIFF
--- a/internal/drivers/iosxe/configdriver/writers/cdp.go
+++ b/internal/drivers/iosxe/configdriver/writers/cdp.go
@@ -21,15 +21,95 @@ package writers
 //     run: true
 //     advertise_v2: true
 //
-// YANG: /Cisco-IOS-XE-native:native/cdp. Managed leaves: run,
-// advertise_v2. Anything outside the set is left untouched on the
-// device per the additive-merge semantics.
+// YANG: /Cisco-IOS-XE-native:native/cdp.
+//
+// Leaf-name translation (netascode -> Cisco-IOS-XE-native YANG):
+//
+//   - run          -> run-enable   (the YANG `run` leaf is `status
+//                                   obsolete` in Cisco-IOS-XE-cdp.yang
+//                                   and rejected by RESTCONF on
+//                                   17.15/17.16; `run-enable` is the
+//                                   non-obsolete boolean enable leaf)
+//   - advertise_v2 -> advertise-v2 (underscore -> hyphen)
+//
+// Both YANG leaves are `type boolean`, so they are emitted as plain
+// JSON booleans — not [null] empty-leaf encoding. Anything outside the
+// managed set is left untouched on the device per the additive-merge
+// semantics.
+//
+// On IOS-XE < 17.18 these augmented leaves additionally require a
+// "Cisco-IOS-XE-cdp:" module prefix in the RESTCONF body. That
+// release-conditional rename is applied by the version override table
+// (yang_version_override_table.go), which stacks after cdpToYANG on the
+// Diff path and is reversed before cdpFromYANG on the Fetch path.
 
 func init() {
 	Override(singletonWriter{
-		family:        "cdp",
-		yangPath:      "/Cisco-IOS-XE-native:native/cdp",
-		envelopeKey:   "Cisco-IOS-XE-native:cdp",
-		managedLeaves: []string{"run", "advertise_v2"},
+		family:         "cdp",
+		yangPath:       "/Cisco-IOS-XE-native:native/cdp",
+		envelopeKey:    "Cisco-IOS-XE-native:cdp",
+		managedLeaves:  []string{"run", "advertise_v2"},
+		yangBodyShape:  cdpToYANG,
+		yangFetchShape: cdpFromYANG,
 	})
+}
+
+// cdpToYANG maps the netascode canonical CDP leaves to their
+// Cisco-IOS-XE-native YANG names for the Diff/Apply path. It runs on
+// the projected managed-leaf body before the RESTCONF envelope is
+// applied.
+func cdpToYANG(flat map[string]any) map[string]any {
+	out := make(map[string]any, len(flat))
+	for k, v := range flat {
+		switch k {
+		case "run":
+			out["run-enable"] = v
+		case "advertise_v2":
+			out["advertise-v2"] = v
+		default:
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// cdpFromYANG is the Fetch/Diff-side inverse of cdpToYANG. It maps the
+// device's YANG leaf names back to the netascode canonical shape so
+// leavesEqual compares like with like.
+//
+// It runs against two different inputs: the observed body fetched from
+// the device (YANG-shaped: run-enable / advertise-v2) and the desired
+// body (already netascode-shaped: run / advertise_v2). It must be a
+// no-op on canonical input, so `run` is honoured as a fallback when no
+// `run-enable` is present.
+//
+// `run-enable` is authoritative for the device's CDP enable state; the
+// bare `run` empty leaf is obsolete. When a device reports both,
+// `run-enable` wins deterministically (the result does not depend on
+// map iteration order). A `run`-only observed body is decoded from the
+// YANG empty-leaf encoding ([null] → true) so drift comparison sees a
+// boolean, not a slice.
+func cdpFromYANG(yang map[string]any) map[string]any {
+	out := make(map[string]any, len(yang))
+	for k, v := range yang {
+		switch k {
+		case "run", "run-enable":
+			// Resolved after the loop so run-enable wins deterministically.
+		case "advertise-v2":
+			out["advertise_v2"] = v
+		default:
+			out[k] = v
+		}
+	}
+	if v, ok := yang["run-enable"]; ok {
+		out["run"] = v
+	} else if v, ok := yang["run"]; ok {
+		// The obsolete `run` leaf is YANG type empty: a [null] presence
+		// value means enabled. Decode to a canonical boolean so
+		// leavesEqual compares bool against bool — a raw []any{nil}
+		// would read as perpetual drift. isTrue is a no-op on the
+		// boolean `run` of canonical desired intent.
+		out["run"] = isTrue(v)
+	}
+	return out
 }

--- a/internal/drivers/iosxe/configdriver/writers/phase2_test.go
+++ b/internal/drivers/iosxe/configdriver/writers/phase2_test.go
@@ -16,6 +16,7 @@ package writers
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
@@ -25,6 +26,21 @@ import (
 )
 
 // --- Singleton writers (cdp, lldp, banner, logging, snmp, aaa, bgp) --------
+
+// cdpBody decodes a cdp writer op body and returns the inner
+// Cisco-IOS-XE-native:cdp container.
+func cdpBody(t *testing.T, raw []byte) map[string]any {
+	t.Helper()
+	var env map[string]any
+	if err := json.Unmarshal(raw, &env); err != nil {
+		t.Fatalf("decode body %s: %v", raw, err)
+	}
+	cdp, ok := env["Cisco-IOS-XE-native:cdp"].(map[string]any)
+	if !ok {
+		t.Fatalf("body %s: missing Cisco-IOS-XE-native:cdp envelope", raw)
+	}
+	return cdp
+}
 
 func TestCDPDiffOnTransition(t *testing.T) {
 	t.Parallel()
@@ -40,6 +56,174 @@ func TestCDPDiffOnTransition(t *testing.T) {
 	}
 	if ops[0].Verb != transport.VerbMerge {
 		t.Errorf("verb=%v, want MERGE", ops[0].Verb)
+	}
+	// The netascode `run` leaf must be emitted as the YANG `run-enable`
+	// boolean leaf — the bare `run` leaf is `status obsolete` and is
+	// rejected by RESTCONF on 17.15/17.16. Regression guard for #124.
+	cdp := cdpBody(t, ops[0].Body)
+	if cdp["run-enable"] != true {
+		t.Errorf("body=%s, want run-enable:true (boolean)", ops[0].Body)
+	}
+	if _, has := cdp["run"]; has {
+		t.Errorf("body=%s, must not emit the obsolete bare `run` leaf", ops[0].Body)
+	}
+}
+
+// TestCDPDiffInSyncWhenEnabled confirms the writer reports InSync only
+// when CDP is genuinely enabled — the inverse of the #124 false-InSync
+// symptom.
+func TestCDPDiffInSyncWhenEnabled(t *testing.T) {
+	t.Parallel()
+	w := Get("cdp")
+	same := map[string]any{"run": true}
+	ops, err := w.Diff(same, same)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if len(ops) != 0 {
+		t.Fatalf("got %d ops, want 0 (InSync)", len(ops))
+	}
+}
+
+// TestCDPDiffAdvertiseV2Hyphenated confirms the netascode advertise_v2
+// leaf is emitted under its hyphenated YANG name advertise-v2.
+func TestCDPDiffAdvertiseV2Hyphenated(t *testing.T) {
+	t.Parallel()
+	w := Get("cdp")
+	desired := map[string]any{"advertise_v2": true}
+	ops, err := w.Diff(desired, map[string]any{})
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if len(ops) != 1 {
+		t.Fatalf("got %d ops, want 1", len(ops))
+	}
+	cdp := cdpBody(t, ops[0].Body)
+	if cdp["advertise-v2"] != true {
+		t.Errorf("body=%s, want hyphenated advertise-v2:true", ops[0].Body)
+	}
+	if _, has := cdp["advertise_v2"]; has {
+		t.Errorf("body=%s, must not emit the underscore netascode key", ops[0].Body)
+	}
+}
+
+// TestCDPFetchMapsRunEnableToCanonical confirms the Fetch path lifts
+// the device's YANG leaf names back to the netascode canonical shape so
+// drift comparison compares like with like.
+func TestCDPFetchMapsRunEnableToCanonical(t *testing.T) {
+	t.Parallel()
+	w := Get("cdp")
+	cli, _ := newTestTransport(t, func(wt http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(wt, `{"Cisco-IOS-XE-native:cdp":{"run-enable":true,"advertise-v2":false}}`)
+	})
+	got, err := w.Fetch(context.Background(), cli)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	m := got.(map[string]any)
+	if m["run"] != true {
+		t.Errorf("got %#v, want canonical run:true from device run-enable", m)
+	}
+	if m["advertise_v2"] != false {
+		t.Errorf("got %#v, want canonical advertise_v2:false", m)
+	}
+	if _, has := m["run-enable"]; has {
+		t.Errorf("got %#v, YANG run-enable leaked into canonical shape", m)
+	}
+}
+
+// TestCDPFetchPrefersRunEnableOverObsoleteRun confirms that when a
+// device reports both the obsolete `run` empty leaf and the current
+// `run-enable` boolean leaf, run-enable is authoritative.
+func TestCDPFetchPrefersRunEnableOverObsoleteRun(t *testing.T) {
+	t.Parallel()
+	w := Get("cdp")
+	cli, _ := newTestTransport(t, func(wt http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(wt, `{"Cisco-IOS-XE-native:cdp":{"run":[null],"run-enable":false}}`)
+	})
+	got, err := w.Fetch(context.Background(), cli)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	m := got.(map[string]any)
+	if m["run"] != false {
+		t.Errorf("got %#v, want run:false (run-enable wins over obsolete run)", m)
+	}
+}
+
+// TestCDPDiffLegacyPrefixesAugmentedLeaves confirms that on IOS-XE
+// < 17.18 the augmented cdp leaves carry the Cisco-IOS-XE-cdp: module
+// prefix in the RESTCONF body — without it the device rejects the
+// PATCH. Codex adversarial-review finding on the #124 fix.
+func TestCDPDiffLegacyPrefixesAugmentedLeaves(t *testing.T) {
+	t.Parallel()
+	w := GetForRelease("cdp", "17.16.01a")
+	if w == nil {
+		t.Fatal("GetForRelease(cdp, 17.16.01a) returned nil")
+	}
+	desired := map[string]any{"run": true, "advertise_v2": true}
+	ops, err := w.Diff(desired, map[string]any{})
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if len(ops) != 1 {
+		t.Fatalf("got %d ops, want 1", len(ops))
+	}
+	cdp := cdpBody(t, ops[0].Body)
+	if cdp["Cisco-IOS-XE-cdp:run-enable"] != true {
+		t.Errorf("body=%s, want module-prefixed Cisco-IOS-XE-cdp:run-enable", ops[0].Body)
+	}
+	if cdp["Cisco-IOS-XE-cdp:advertise-v2"] != true {
+		t.Errorf("body=%s, want module-prefixed Cisco-IOS-XE-cdp:advertise-v2", ops[0].Body)
+	}
+	if _, has := cdp["run-enable"]; has {
+		t.Errorf("body=%s, unprefixed run-enable leaks on a < 17.18 device", ops[0].Body)
+	}
+}
+
+// TestCDPFetchLegacyStripsModulePrefix confirms the Fetch path on a
+// < 17.18 device reverses the Cisco-IOS-XE-cdp: prefix back to the
+// netascode canonical shape so drift comparison compares like with like.
+func TestCDPFetchLegacyStripsModulePrefix(t *testing.T) {
+	t.Parallel()
+	w := GetForRelease("cdp", "17.16.01a")
+	if w == nil {
+		t.Fatal("GetForRelease(cdp, 17.16.01a) returned nil")
+	}
+	cli, _ := newTestTransport(t, func(wt http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(wt, `{"Cisco-IOS-XE-native:cdp":{"Cisco-IOS-XE-cdp:run-enable":true,"Cisco-IOS-XE-cdp:advertise-v2":false}}`)
+	})
+	got, err := w.Fetch(context.Background(), cli)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	m := got.(map[string]any)
+	if m["run"] != true {
+		t.Errorf("got %#v, want canonical run:true", m)
+	}
+	if m["advertise_v2"] != false {
+		t.Errorf("got %#v, want canonical advertise_v2:false", m)
+	}
+}
+
+// TestCDPFetchDecodesObsoleteRunEmptyLeaf confirms a device that
+// reports only the obsolete `run` empty leaf ([null]) is decoded to a
+// canonical boolean — otherwise leavesEqual compares a bool against a
+// slice and reconcile loops on false drift. Codex adversarial-review
+// finding on the #124 fix.
+func TestCDPFetchDecodesObsoleteRunEmptyLeaf(t *testing.T) {
+	t.Parallel()
+	w := Get("cdp")
+	cli, _ := newTestTransport(t, func(wt http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(wt, `{"Cisco-IOS-XE-native:cdp":{"run":[null]}}`)
+	})
+	got, err := w.Fetch(context.Background(), cli)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	m := got.(map[string]any)
+	if m["run"] != true {
+		t.Errorf("got %#v (%T for run), want canonical run:true", m, m["run"])
 	}
 }
 

--- a/internal/drivers/iosxe/configdriver/writers/yang_version_override_table.go
+++ b/internal/drivers/iosxe/configdriver/writers/yang_version_override_table.go
@@ -163,6 +163,25 @@ var overrideTable = []VersionOverride{
 		MaxVersion: [2]int{17, 18},
 	},
 
+	// ── cdp: IOS-XE < 17.18 ──────────────────────────────────────
+	// The cdp container lives in Cisco-IOS-XE-native, but its config
+	// leaves are augmented in from Cisco-IOS-XE-cdp. On < 17.18 those
+	// augmented leaves need the "Cisco-IOS-XE-cdp:" module prefix in
+	// the RESTCONF body; without it the device rejects the PATCH. The
+	// envelope key stays Cisco-IOS-XE-native:cdp (the container itself
+	// is native), so only the leaves are prefixed. The netascode →
+	// run-enable / advertise-v2 rename happens first in cdpToYANG;
+	// this ElementMap stacks the release-conditional prefix on top.
+	{
+		Family:     "cdp",
+		MinVersion: [2]int{17, 0},
+		MaxVersion: [2]int{17, 18},
+		ElementMap: map[string]string{
+			"run-enable":   "Cisco-IOS-XE-cdp:run-enable",
+			"advertise-v2": "Cisco-IOS-XE-cdp:advertise-v2",
+		},
+	},
+
 	// ── spanning_tree: IOS-XE < 17.18 ────────────────────────────
 	// On < 17.18 the envelope key is "Cisco-IOS-XE-native:spanning-tree"
 	// (not "Cisco-IOS-XE-spanning-tree:spanning-tree"), and


### PR DESCRIPTION
## Description

`IOSXEConfig` CRs that manage the `cdp` family reached `InSync` while CDP was
never actually enabled on the device — `show cdp` still reported
`% CDP is not enabled`. See #124.

Root cause: the `cdp` family writer targeted the wrong YANG leaves.

- It managed the bare `run` leaf, which `Cisco-IOS-XE-cdp.yang` marks
  `status obsolete` (replaced by `run-enable`). RESTCONF rejects `run` outright
  on IOS-XE 17.15/17.16 (`400 unknown element: run`); on 17.18 it is ineffective.
- `advertise_v2` was emitted with its netascode underscore name rather than the
  YANG `advertise-v2`.
- The non-obsolete enable leaf `run-enable` is `type boolean`, so the correct
  payload is `"run-enable": true` — not `[null]` empty-leaf encoding.

### Changes

- The `cdp` writer now translates the netascode canonical leaves (`run`,
  `advertise_v2`) to their YANG names (`run-enable`, `advertise-v2`) via
  `yangBodyShape`/`yangFetchShape`. The public netascode contract
  (`cdp: { run: true }`) is unchanged.
- A `< 17.18` version-override entry prefixes the augmented leaves with the
  `Cisco-IOS-XE-cdp:` module prefix that legacy IOS-XE requires for augmented
  JSON body keys — the same pattern as the existing `spanning_tree` override.
- The Fetch path decodes an observed obsolete `run` empty leaf (`[null]`) to a
  canonical boolean, so drift comparison compares bool against bool instead of
  looping on false drift.
- Adds CDP `Diff`/`Fetch` test coverage, including module-prefixed bodies for
  legacy releases and the obsolete-`run` decode path.

### References

- Issue #124
- `Cisco-IOS-XE-cdp.yang` — `config-cdp-grouping`, `augment "/native/cdp"`

Closes #124

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
