### PR TITLE
docs: fix broken anchor link in configuration-ir1101.md

### DIFF
--- a/docs/configuration-ir1101.md
+++ b/docs/configuration-ir1101.md
@@ -23,7 +23,7 @@ Other IOS-XE versions with App Hosting may work but are not validated.
     App-hosting pod lifecycle (create, update, delete) works normally — only the declarative
     config CRDs (`IOSXEConfig`, bundles, templates, etc.) are affected.
     The [VirtualPortGroup and DHCP pool](#device-prerequisites) must be created manually
-    before deploying pods. See [Manual RESTCONF setup](#manual-restconf-setup-17-12) below.
+    before deploying pods. See [Manual RESTCONF setup](#manual-restconf-setup-1712) below.
 
 ## Platform notes
 


### PR DESCRIPTION
The admonition on line 26 linked to `#manual-restconf-setup-17-12` but MkDocs generates the slug as `#manual-restconf-setup-1712` (no hyphen between version digits). This caused an MkDocs build warning. One-char fix.