### PR TITLE
fix(release): cross-compile multi-arch image to fix GHCR publish timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,9 @@ on:
 permissions:
   contents: write
   packages: write
-  id-token: write   # required for cosign keyless signing
+  id-token: write          # required for cosign keyless signing
   attestations: write
+  security-events: write   # required to upload the Trivy SARIF to code-scanning
 
 env:
   REGISTRY: ghcr.io
@@ -55,7 +56,9 @@ env:
 jobs:
   build-and-sign:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Native cross-compilation (see Dockerfile) keeps this well under 30m, but
+    # leave headroom for the Trivy scan, SBOM generation, and cosign round-trips.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
 
@@ -93,6 +96,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           provenance: true
           sbom: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Install Trivy
         uses: aquasecurity/setup-trivy@v0.2.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 # Build stage
-FROM golang:1.25-alpine AS builder
+# Pin the builder to the runner's native architecture ($BUILDPLATFORM) and
+# cross-compile to the requested target arch via Go's GOOS/GOARCH below. This
+# keeps the Go toolchain off QEMU emulation for the non-native leg of a
+# multi-arch build (e.g. linux/arm64 on an amd64 runner) — emulated Go builds
+# are what pushed the release pipeline past its timeout. CGO is disabled, so the
+# cross-compile is pure-Go and needs no target-arch toolchain.
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
 
 WORKDIR /app
 
@@ -13,8 +19,10 @@ RUN go mod download
 # Copy source code
 COPY . .
 
-# Build the unified binary (supports 'run' and 'manager' subcommands)
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o cisco-vk ./cmd/cisco-vk
+# Build the unified binary (supports 'run' and 'manager' subcommands).
+# TARGETOS/TARGETARCH are provided automatically by buildx per target platform.
+ARG TARGETOS TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -ldflags="-w -s" -o cisco-vk ./cmd/cisco-vk
 
 FROM gcr.io/distroless/static-debian12
 COPY --from=builder /app/cisco-vk /usr/local/bin/cisco-vk


### PR DESCRIPTION
## Problem

The `v2026.06.0` release was tagged and a GitHub Release was published, but **no image reached GHCR** — `ghcr.io/cisco-open/cisco-virtual-kubelet` does not exist (404). The single `release` workflow run for the tag ([26714020702](https://github.com/cisco-open/cisco-virtual-kubelet/actions/runs/26714020702)) was **cancelled by the 30-minute job timeout**.

Per-step timing shows the cause: every step before the build took 24s combined, then **Build and push image ran 29m35s and was cancelled** before the push completed. The Trivy scan, SBOM, cosign sign/attest, and SBOM-to-release steps never ran.

Root cause: the `Dockerfile` compiled Go *inside the target-arch container*, so the `linux/arm64` leg of the `linux/amd64,linux/arm64` matrix ran the entire Go toolchain under QEMU emulation — pathologically slow, and unnecessary since `CGO_ENABLED=0`.

## Fix

- **Dockerfile:** pin the builder to the runner's native arch (`--platform=$BUILDPLATFORM`) and cross-compile per target via `GOOS=$TARGETOS GOARCH=$TARGETARCH`. Pure-Go cross-compile, no emulation. Validated locally: each arch builds in ~1m and produces a correct per-arch static ELF (verified `aarch64` + `x86-64`).
- **release.yml:** add `security-events: write` (the Trivy SARIF upload was failing with "Resource not accessible by integration"); raise `timeout-minutes` 30 → 60 as headroom; add buildx GHA layer cache.

## Publish plan

This unblocks cutting **`v2026.06.1`** from `main` after merge, which fires the fixed `release` workflow on the tag event and publishes the multi-arch signed image to GHCR. (`main` is 4 commits ahead of `v2026.06.0` incl. functional fix #131, so `.1` is the honest version for the published artifact rather than re-tagging `v2026.06.0`.)