### PR TITLE
fix(release): sign before scanning, replace broken Trivy installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,34 +99,17 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Install Trivy
-        uses: aquasecurity/setup-trivy@v0.2.6
-        with:
-          version: v0.55.2
-
-      - name: Scan image for HIGH/CRITICAL CVEs
-        # Fails the build on HIGH/CRITICAL only — MEDIUM and below are
-        # surfaced in the report but don't block. Adjust the severity
-        # threshold here as the project's appetite changes.
-        run: |
-          trivy image \
-            --severity HIGH,CRITICAL \
-            --exit-code 1 \
-            --ignore-unfixed \
-            --format sarif \
-            --output trivy.sarif \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
-
-      - name: Upload Trivy SARIF to code-scanning
-        if: always()
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: trivy.sarif
-
+      # Sign and attest BEFORE scanning. The image is already pushed by the
+      # build step above, so the vulnerability scan is advisory, not a gate.
+      # Running it ahead of signing only means a scanner outage can leave a
+      # published image unsigned — which is exactly what happened on the first
+      # v2026.06.1 build (setup-trivy failed on the binary download and skipped
+      # the cosign steps). Signing first guarantees every published image
+      # carries a signature + SBOM attestation regardless of the scanner.
       - name: Generate CycloneDX SBOM
         uses: anchore/sbom-action@v0
         with:
-          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           format: cyclonedx-json
           output-file: sbom.cdx.json
 
@@ -162,3 +145,28 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: sbom.cdx.json
+
+      # Advisory vulnerability scan, runs last and never blocks the signed
+      # release (continue-on-error). trivy-action bundles install + scan +
+      # SARIF output, replacing the setup-trivy@v0.2.6 binary download that
+      # broke the release build. HIGH/CRITICAL findings still surface in the
+      # code-scanning tab; hard gating belongs in pre-merge CI, not after the
+      # image has already been pushed and signed.
+      - name: Scan image for HIGH/CRITICAL CVEs
+        id: trivy
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+          format: sarif
+          output: trivy.sarif
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          limit-severities-for-sarif: true
+
+      - name: Upload Trivy SARIF to code-scanning
+        if: always() && hashFiles('trivy.sarif') != ''
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy.sarif


### PR DESCRIPTION
## Problem

After #133 fixed the build timeout, the `v2026.06.1` tag build **successfully pushed the multi-arch image to GHCR** (`:v2026.06.1` + `:latest`) — but the run still failed and the image shipped **unsigned, with no SBOM attestation**.

Cause: the `Install Trivy` step (`aquasecurity/setup-trivy@v0.2.6`, pinned to Trivy `v0.55.2`) fails deterministically on the binary download:

```
installing Trivy binary
aquasecurity/trivy info checking GitHub for tag 'v0.55.2'
aquasecurity/trivy info found version: 0.55.2 for v0.55.2/Linux/64bit
##[error]Process completed with exit code 1.
```

Because that step sat **before** the cosign signing / SBOM / attestation steps (with no `if: always()`), its failure cascade-skipped all of them. Two runs of the `v2026.06.1` tag failed identically, confirming it's systemic, not transient.

## Fix

- **Sign first.** Move SBOM generation + cosign sign + attestation to run immediately after build+push, before any scan. The image is already pushed by the build step, so a scanner failure can never again leave a published image unsigned.
- **Replace the broken installer.** Swap `setup-trivy@v0.2.6` + manual `trivy image` for the maintained `aquasecurity/trivy-action`, run **last** as an advisory step (`continue-on-error: true`); SARIF is only uploaded when a report was actually produced (`hashFiles('trivy.sarif') != ''`).
- **Digest-pin** the SBOM/scan image references instead of using the floating tag.

### Note on the scan becoming advisory

Release-time scanning was already advisory in practice — `docker/build-push-action` pushes the image *before* the scan runs, so a HIGH/CRITICAL finding never actually prevented publication; it only failed the run after the fact. Hard CVE gating belongs in pre-merge CI (smoke), not post-push. Findings still surface in the code-scanning tab.

## After merge

Re-point the `v2026.06.1` tag to the merged commit and let the release workflow run end-to-end: build → SBOM → **sign + attest** → SBOM-to-release → advisory scan. There is no GitHub Release object for `v2026.06.1` yet (only the tag), so re-pointing is non-disruptive. Result: a signed, attested `ghcr.io/cisco-open/cisco-virtual-kubelet:v2026.06.1` whose cosign identity matches the verification command in the release notes.