### PR TITLE
[DO NOT MERGE] Migrate the mkdocs material to Zensical

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -16,47 +16,51 @@ name: CI build and deploy documentation
 on:
   push:
     tags:
-      - 'v*'
+    - 'v*'
   workflow_dispatch:
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
 jobs:
   deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-          cache: 'pip'
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: docs/website/package-lock.json
-      - name: Install MkDocs dependencies
-        run: pip install -r requirements.txt
-      - name: Build React website
-        working-directory: docs/website
-        run: |
-          npm ci
-          npm run build
-      - name: Build MkDocs documentation
-        run: mkdocs build --strict
-      - name: Combine pages
-        run: |
-          mkdir -p deploy
-          cp -r docs/website/out/* deploy/
-          mkdir -p deploy/docs
-          cp -r site/* deploy/docs/
-      - name: Push to gh-pages branch
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./deploy
-          publish_branch: gh-pages
-          force_orphan: true
+    - uses: actions/configure-pages@v5
+    - uses: actions/checkout@v5
+      with:
+        fetch-depth: 0
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+        cache: 'pip'
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+        cache-dependency-path: docs/website/package-lock.json
+    - name: Install Zensical
+      run: pip install zensical==0.0.32
+    - name: Build React website
+      working-directory: docs/website
+      run: |
+        npm ci
+        npm run build
+    - name: Build MkDocs documentation
+      run: mzensical build --clean
+    - name: Combine pages
+      run: |
+        mkdir -p deploy
+        cp -r docs/website/out/* deploy/
+        mkdir -p deploy/docs
+        cp -r site/* deploy/docs/
+    - uses: actions/upload-pages-artifact@v4
+      with:
+        path: deploy
+    - uses: actions/deploy-pages@v4
+      id: deployment

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,7 +10,6 @@ edit_uri: ""
 markdown_extensions:
 - admonition
 - pymdownx.details
-- pymdownx.superfences
 - attr_list
 - md_in_html
 - footnotes
@@ -29,8 +28,8 @@ markdown_extensions:
 - pymdownx.inlinehilite
 - pymdownx.snippets
 - pymdownx.emoji:
-    emoji_index: !!python/name:material.extensions.emoji.twemoji ""
-    emoji_generator: !!python/name:material.extensions.emoji.to_svg ""
+    emoji_index: !!python/name:zensical.extensions.emoji.twemoji ""
+    emoji_generator: !!python/name:zensical.extensions.emoji.to_svg ""
 nav:
 - Welcome: 'index.md'
 - Getting Started: 'getting-started.md'
@@ -60,7 +59,6 @@ nav:
 - Security: 'security.md'
 - API Reference: 'API.md'
 theme:
-  name: material
   features:
   - content.code.copy
   - search.share
@@ -76,3 +74,9 @@ site_dir: site
 exclude_docs: |
   website/
 use_directory_urls: true
+validation:
+  unresolved_references: false
+  unresolved_footnotes: false
+  unused_definitions: false
+  invalid_links: false
+  invalid_link_anchors: false


### PR DESCRIPTION
## Description

DO NOT MERGE!

The code is not ready for merging due to [issue](https://zensical.org/docs/setup/basics/?h=exclude_docs%3A#unsupported-settings). Once this is resolved, we could migrate from Mkdocs Material to Zensical.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

1. Update the Pages settings to point to the deploy Workflow and not the gh-pages
2. Validate the Page is build successfully
3. Check the publicly available website for the project