### PR TITLE
feat(helm): publish chart to GHCR as OCI, default to the official image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,3 +170,65 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: trivy.sarif
+
+  # Package the Helm chart and push it to GHCR as an OCI artifact, so users can
+  #   helm install cvk oci://ghcr.io/<owner>/charts/cisco-virtual-kubelet --version <ver>
+  # Runs after the image is built and signed so the chart never ships ahead of
+  # the image it deploys. Chart version is the tag normalised to SemVer
+  # (2026.06.1 -> 2026.6.1, since leading zeros are invalid SemVer); appVersion
+  # keeps the released image tag, which the chart uses as the default image tag.
+  publish-chart:
+    needs: build-and-sign
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: write
+      id-token: write   # cosign keyless signing of the chart artifact
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.2
+
+      - name: Log in to ghcr.io (Helm OCI registry)
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | helm registry login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
+
+      - name: Derive chart and app versions from the tag
+        id: ver
+        run: |
+          raw="${GITHUB_REF_NAME#v}"
+          chart="$(echo "$raw" | awk -F. '{printf "%d.%d.%d", $1, $2, $3}')"
+          echo "chart=$chart" >> "$GITHUB_OUTPUT"
+          echo "app=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Package chart
+        run: |
+          helm package charts/cisco-virtual-kubelet \
+            --version "${{ steps.ver.outputs.chart }}" \
+            --app-version "${{ steps.ver.outputs.app }}" \
+            --destination dist
+
+      - name: Push chart to GHCR (OCI)
+        id: push
+        run: |
+          helm push "dist/cisco-virtual-kubelet-${{ steps.ver.outputs.chart }}.tgz" \
+            "oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts" 2>&1 | tee push.log
+          echo "digest=$(awk '/Digest:/ {print $2}' push.log)" >> "$GITHUB_OUTPUT"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: v2.4.1
+
+      - name: Keyless sign chart
+        env:
+          COSIGN_EXPERIMENTAL: 'true'
+        run: |
+          cosign sign --yes \
+            "${{ env.REGISTRY }}/${{ github.repository_owner }}/charts/cisco-virtual-kubelet@${{ steps.push.outputs.digest }}"

--- a/README.md
+++ b/README.md
@@ -70,6 +70,28 @@ This provider allows Kubernetes pods to be deployed as containers directly on Ci
 
 The controller watches `CiscoDevice` CRs and automatically creates a VK pod per device. Deploy it via the included Helm chart.
 
+### Install the published chart (recommended)
+
+The chart and its container image are published to GitHub Container Registry with every release — no clone or custom build required:
+
+```bash
+helm install cvk oci://ghcr.io/cisco-open/charts/cisco-virtual-kubelet \
+  --version 2026.6.1 \
+  --namespace cvk-system --create-namespace
+```
+
+This deploys the signed `ghcr.io/cisco-open/cisco-virtual-kubelet` image by default — no `--set image.*` needed. The chart `--version` is the release normalised to SemVer (e.g. `v2026.06.1` → `2026.6.1`); see [Releases](https://github.com/cisco-open/cisco-virtual-kubelet/releases) for the current version.
+
+Optionally verify the chart signature before installing:
+
+```bash
+cosign verify ghcr.io/cisco-open/charts/cisco-virtual-kubelet:2026.6.1 \
+  --certificate-identity-regexp "https://github.com/cisco-open/cisco-virtual-kubelet/.github/workflows/release.yml@refs/tags/v.*" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+> **Upgrades:** Helm installs CRDs only on first install. When upgrading across releases that change CRD schemas, apply the CRDs once after `helm upgrade` — see the post-install notes (`helm get notes cvk -n cvk-system`).
+
 ### Build and push a custom image
 
 ```bash
@@ -80,7 +102,9 @@ docker build -t <your-registry>/cisco-vk:latest .
 docker push <your-registry>/cisco-vk:latest
 ```
 
-### Install the Helm chart
+### Install from source with a custom image
+
+For development, or to run your own build instead of the published image, install the chart from the source tree and point it at your registry:
 
 ```bash
 # Install CRDs and the controller into the cvk-system namespace

--- a/charts/cisco-virtual-kubelet/Chart.yaml
+++ b/charts/cisco-virtual-kubelet/Chart.yaml
@@ -2,15 +2,18 @@ apiVersion: v2
 name: cisco-virtual-kubelet
 description: Helm chart for the Cisco Virtual Kubelet controller manager
 type: application
+# version (chart SemVer) and appVersion (released app/image tag) are stamped
+# from the git tag by the release workflow; the values below are the
+# source-tree defaults used for local installs.
 version: 0.1.0
-appVersion: "1.0.0"
+appVersion: "v2026.06.1"
 keywords:
   - cisco
   - virtual-kubelet
   - operator
-home: https://github.com/cisco/virtual-kubelet-cisco
+home: https://github.com/cisco-open/cisco-virtual-kubelet
 sources:
-  - https://github.com/cisco/virtual-kubelet-cisco
+  - https://github.com/cisco-open/cisco-virtual-kubelet
 maintainers:
   - name: Cisco Systems
 dependencies:

--- a/charts/cisco-virtual-kubelet/templates/NOTES.txt
+++ b/charts/cisco-virtual-kubelet/templates/NOTES.txt
@@ -62,8 +62,8 @@
 
 The {{ if .Values.aggregator.enabled }}aggregator-mode{{ else }}per-pod kubelet{{ end }} topology is configured.
 
-  controller image: {{ .Values.controllerImage.repository | default .Values.image.repository }}:{{ .Values.controllerImage.tag | default .Values.image.tag }}
-  vk image:         {{ .Values.vkImage.repository | default .Values.image.repository }}:{{ .Values.vkImage.tag | default .Values.image.tag }}
+  controller image: {{ include "cisco-virtual-kubelet.controllerImage" . }}
+  vk image:         {{ include "cisco-virtual-kubelet.vkImage" . }}
   metrics:          {{ .Values.controller.metricsBindAddress }}
   gNOI:             {{ if .Values.gnoi.disabled }}disabled{{ else if .Values.gnoi.insecure }}insecure{{ else }}auto{{ end }}{{ if .Values.gnoi.port }} on port {{ .Values.gnoi.port }}{{ end }}
   diag admin:       {{ if .Values.aggregator.enabled }}(disabled in aggregator-mode){{ else }}127.0.0.1:8082 inside each per-device pod{{ end }}

--- a/charts/cisco-virtual-kubelet/templates/_helpers.tpl
+++ b/charts/cisco-virtual-kubelet/templates/_helpers.tpl
@@ -54,7 +54,7 @@ Falls back to .Values.image when controllerImage.repository is empty.
 */}}
 {{- define "cisco-virtual-kubelet.controllerImage" -}}
 {{- $repo := .Values.controllerImage.repository | default .Values.image.repository }}
-{{- $tag  := .Values.controllerImage.tag        | default .Values.image.tag }}
+{{- $tag  := .Values.controllerImage.tag        | default .Values.image.tag | default .Chart.AppVersion }}
 {{- printf "%s:%s" $repo $tag }}
 {{- end }}
 
@@ -72,7 +72,7 @@ Falls back to .Values.image when vkImage.repository is empty.
 */}}
 {{- define "cisco-virtual-kubelet.vkImage" -}}
 {{- $repo := .Values.vkImage.repository | default .Values.image.repository }}
-{{- $tag  := .Values.vkImage.tag        | default .Values.image.tag }}
+{{- $tag  := .Values.vkImage.tag        | default .Values.image.tag | default .Chart.AppVersion }}
 {{- printf "%s:%s" $repo $tag }}
 {{- end }}
 

--- a/charts/cisco-virtual-kubelet/values.yaml
+++ b/charts/cisco-virtual-kubelet/values.yaml
@@ -2,10 +2,11 @@
 
 # image is the shared default image for both the controller and VK pods.
 # Individual overrides (controllerImage / vkImage) take precedence when set.
+# tag defaults to the chart appVersion (the released image tag) when left empty.
 image:
-  repository: cunningr/cisco-vk
-  tag: latest
-  pullPolicy: Always
+  repository: ghcr.io/cisco-open/cisco-virtual-kubelet
+  tag: ""
+  pullPolicy: IfNotPresent
 
 # controllerImage overrides the image used for the controller Deployment.
 # When not set (repository: ""), the shared `image` above is used.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -58,7 +58,19 @@ minikube image load <your-registry>/cisco-vk:"$LATEST"
 
 ## 2. Install the controller
 
-The controller watches `CiscoDevice` custom resources and creates a Virtual Kubelet deployment for each one. The chart lives in-repo — point it at the image you just built.
+The controller watches `CiscoDevice` custom resources and creates a Virtual Kubelet deployment for each one.
+
+**Published chart (recommended)** — the chart and image are released to GHCR, so steps 1's build/push are optional and you can install directly:
+
+```bash
+helm install cvk oci://ghcr.io/cisco-open/charts/cisco-virtual-kubelet \
+  --version 2026.6.1 \
+  --namespace cvk-system --create-namespace
+```
+
+This pulls the signed `ghcr.io/cisco-open/cisco-virtual-kubelet` image by default. The chart `--version` is the release normalised to SemVer (e.g. `v2026.06.1` → `2026.6.1`); see [Releases](https://github.com/cisco-open/cisco-virtual-kubelet/releases) for the current one.
+
+**From source with a custom image** — to run the build from step 1 instead:
 
 ```bash
 helm install cvk ./charts/cisco-virtual-kubelet \


### PR DESCRIPTION
## What & why

The Helm chart at `charts/cisco-virtual-kubelet/` is mature (CRDs, RBAC, NetworkPolicy, PDB, ServiceMonitor, values schema, collector subchart) and already smoke-installs in CI — but it wasn't usable as a real `helm install` capability:

- **Default image was wrong** — `values.yaml` pointed at `cunningr/cisco-vk:latest` (a personal Docker Hub repo), not the released `ghcr.io/cisco-open/cisco-virtual-kubelet`.
- **The chart was published nowhere** — no OCI artifact, no `gh-pages`, nothing in CI packaged it. Docs told users to clone and `--set image.repository=<your-registry>/cisco-vk`.

## Changes

- **`values.yaml`** — default image → `ghcr.io/cisco-open/cisco-virtual-kubelet`, empty `tag` (falls back to chart `appVersion`), `pullPolicy: IfNotPresent`.
- **`_helpers.tpl`** — controller/vk image tag now falls back to `.Chart.AppVersion`, so the chart tracks the release with no hardcoded tag. Overrides (`image.tag`, `controllerImage.*`, `vkImage.*`) still win — smoke.yml's `--set image.tag=smoke` is unaffected.
- **`release.yml`** — new `publish-chart` job (`needs: build-and-sign`) packages the chart, pushes it to `oci://ghcr.io/cisco-open/charts`, and cosign-signs the artifact.
- **`Chart.yaml`** — `appVersion: v2026.06.1`; `home`/`sources` corrected to the `cisco-open` repo.
- **Docs** — README + getting-started lead with the published OCI install; source/custom-image install kept as the alternative.

Result, once a tag is published:
```bash
helm install cvk oci://ghcr.io/cisco-open/charts/cisco-virtual-kubelet --version 2026.6.1 \
  --namespace cvk-system --create-namespace
```

## Notes for reviewers

- **Version mapping:** Helm chart `version` must be valid SemVer2, but `2026.06.1` has a leading-zero component (invalid). The job normalises the tag → chart `version` `2026.6.1`, while `appVersion` keeps `v2026.06.1` (the image tag). Verified locally: `helm package --version 2026.6.1 --app-version v2026.06.1` succeeds and bundles the `file://` collector subchart + CRDs.
- **Validated locally:** `helm lint` clean; `helm template` renders the controller image as `ghcr.io/cisco-open/cisco-virtual-kubelet:v2026.06.1` by default and respects `--set` overrides.
- **Sequencing:** the chart publishes on the *next* `v*` tag after this merges. To ship the chart for the current release, re-tag `v2026.06.1` (or cut the next tag) once this is in `main`.
- **First publish is Private:** the new `charts/cisco-virtual-kubelet` GHCR package defaults to Private (org default), same as the image package did — it'll need to be flipped to Public for anonymous `helm install`.
- **CRD upgrades:** unchanged — `NOTES.txt` already documents the one-time `kubectl apply -f crds/` on cross-release upgrades (Helm doesn't upgrade CRDs in `crds/`).