### PR TITLE
fix(release): authenticate cosign for the chart signing step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,6 +199,17 @@ jobs:
           echo "${{ secrets.GITHUB_TOKEN }}" \
             | helm registry login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
 
+      # cosign reads ~/.docker/config.json, which `helm registry login` does not
+      # write — so the chart signature push needs a docker-style login too.
+      # Without this the Keyless sign chart step fails with UNAUTHORIZED even
+      # though the chart push above succeeds.
+      - name: Log in to ghcr.io (Docker config for cosign)
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Derive chart and app versions from the tag
         id: ver
         run: |


### PR DESCRIPTION
## Problem

On the `v2026.06.1` release run, the `publish-chart` job **pushed the OCI chart successfully** but then **failed at `Keyless sign chart`**:

```
Pushing signature to: ghcr.io/cisco-open/charts/cisco-virtual-kubelet
Error: signing […]: POST https://ghcr.io/v2/cisco-open/charts/cisco-virtual-kubelet/blobs/uploads/:
  UNAUTHORIZED: unauthenticated: User cannot be authenticated with the token provided.
```

Net effect: the chart is published and installable (and Public), but **unsigned** — so the cosign-verify example in the README doesn't work for it.

## Cause

The job authenticates to GHCR with `helm registry login`, which writes Helm's own credential store. `cosign` authenticates from `~/.docker/config.json`, which that login never populates — so pushing the signature is unauthenticated. The image-signing job (`build-and-sign`) doesn't hit this because it logs in via `docker/login-action`.

## Fix

Add a `docker/login-action@v3` step to `publish-chart` (kept alongside the existing `helm registry login`, which the `helm push` relies on). cosign then has the docker-config credentials it needs to push the signature.

After this lands, the chart is signed on the next release. To sign the current `2026.6.1` chart, re-tag `v2026.06.1` once this is in `main`.