### PR TITLE
docs: NX-OS (Beta) doc currency and license-header compliance for the July release

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1,4 +1,4 @@
-# Copyright 2026 Cisco Systems, Inc.
+# Copyright 2026 Cisco Systems Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# Copyright 2026 Cisco Systems, Inc.
+# Copyright 2026 Cisco Systems Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,4 +1,4 @@
-# Copyright 2026 Cisco Systems, Inc.
+# Copyright 2026 Cisco Systems Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/tiers.yml
+++ b/.github/workflows/tiers.yml
@@ -1,4 +1,4 @@
-# Copyright 2026 Cisco Systems, Inc.
+# Copyright 2026 Cisco Systems Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/yang-drift.yml
+++ b/.github/workflows/yang-drift.yml
@@ -1,4 +1,4 @@
-# Copyright 2026 Cisco Systems, Inc.
+# Copyright 2026 Cisco Systems Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,17 @@
+# Copyright 2026 Cisco Systems Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Build stage
 # Pin the builder to the runner's native architecture ($BUILDPLATFORM) and
 # cross-compile to the requested target arch via Go's GOOS/GOARCH below. This

--- a/Dockerfile.config-lint
+++ b/Dockerfile.config-lint
@@ -1,3 +1,17 @@
+# Copyright 2026 Cisco Systems Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Distroless image carrying just the cisco-vk-config-lint tool.
 # Built separately from the main Dockerfile so a pre-commit
 # integration via `language: docker_image` doesn't have to pull the

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,17 @@
+# Copyright 2026 Cisco Systems Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Cisco Virtual Kubelet Provider Makefile
 
 # Build variables

--- a/charts/cisco-virtual-kubelet/templates/controller-rbac.yaml
+++ b/charts/cisco-virtual-kubelet/templates/controller-rbac.yaml
@@ -1,3 +1,18 @@
+{{/*
+Copyright 2026 Cisco Systems Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/cisco-virtual-kubelet/templates/deployment.yaml
+++ b/charts/cisco-virtual-kubelet/templates/deployment.yaml
@@ -1,3 +1,18 @@
+{{/*
+Copyright 2026 Cisco Systems Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
 {{- include "cisco-virtual-kubelet.validateLeaderElection" . -}}
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/cisco-virtual-kubelet/templates/networkpolicy.yaml
+++ b/charts/cisco-virtual-kubelet/templates/networkpolicy.yaml
@@ -1,3 +1,18 @@
+{{/*
+Copyright 2026 Cisco Systems Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
 {{- if .Values.networkPolicy.enabled }}
 # NetworkPolicy for the controller manager. Default-deny ingress +
 # explicit-allow egress to:

--- a/charts/cisco-virtual-kubelet/templates/poddisruptionbudget.yaml
+++ b/charts/cisco-virtual-kubelet/templates/poddisruptionbudget.yaml
@@ -1,3 +1,18 @@
+{{/*
+Copyright 2026 Cisco Systems Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
 {{- if .Values.podDisruptionBudget.enabled }}
 # PodDisruptionBudget for the controller manager. With replicaCount: 1
 # (the default), this prevents voluntary disruptions (node drain,

--- a/charts/cisco-virtual-kubelet/templates/servicemonitor.yaml
+++ b/charts/cisco-virtual-kubelet/templates/servicemonitor.yaml
@@ -1,3 +1,18 @@
+{{/*
+Copyright 2026 Cisco Systems Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
 {{- if .Values.serviceMonitor.enabled }}
 # Prometheus Operator ServiceMonitor for the controller manager's
 # /metrics endpoint at :8080. Scraped on the interval listed in

--- a/charts/cisco-virtual-kubelet/templates/vk-rbac.yaml
+++ b/charts/cisco-virtual-kubelet/templates/vk-rbac.yaml
@@ -1,3 +1,18 @@
+{{/*
+Copyright 2026 Cisco Systems Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
 {{- $strictRBAC := eq .Values.rbac.profile "strict" }}
 ---
 # Service account used by all Virtual Kubelet Deployments spawned by the controller.

--- a/cmd/cisco-vk/config_reconciler.go
+++ b/cmd/cisco-vk/config_reconciler.go
@@ -1,4 +1,4 @@
-// Copyright © 2026 Cisco Systems, Inc.
+// Copyright © 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/cisco-vk/controller_logger.go
+++ b/cmd/cisco-vk/controller_logger.go
@@ -1,4 +1,4 @@
-// Copyright © 2026 Cisco Systems, Inc.
+// Copyright © 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/cisco-vk/controller_logger_test.go
+++ b/cmd/cisco-vk/controller_logger_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2026 Cisco Systems, Inc.
+// Copyright © 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/cisco-vk/drivers_register.go
+++ b/cmd/cisco-vk/drivers_register.go
@@ -1,4 +1,4 @@
-// Copyright © 2026 Cisco Systems, Inc.
+// Copyright © 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/cisco-vk/gnoi_wiring.go
+++ b/cmd/cisco-vk/gnoi_wiring.go
@@ -1,4 +1,4 @@
-// Copyright © 2026 Cisco Systems, Inc.
+// Copyright © 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/cisco-vk/main.go
+++ b/cmd/cisco-vk/main.go
@@ -1,4 +1,4 @@
-// Copyright © 2026 Cisco Systems, Inc.
+// Copyright © 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/cisco-vk/manager.go
+++ b/cmd/cisco-vk/manager.go
@@ -1,4 +1,4 @@
-// Copyright © 2026 Cisco Systems, Inc.
+// Copyright © 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/cisco-vk/run.go
+++ b/cmd/cisco-vk/run.go
@@ -1,4 +1,4 @@
-// Copyright © 2026 Cisco Systems, Inc.
+// Copyright © 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/cisco-vk/run_test.go
+++ b/cmd/cisco-vk/run_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2026 Cisco Systems, Inc.
+// Copyright © 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,6 +4,13 @@ This guide walks you through deploying Cisco Virtual Kubelet against a Kubernete
 
 You'll install the Helm chart, which deploys a Kubernetes controller. The controller watches `CiscoDevice` custom resources and stands up a Virtual Kubelet pod for each one — this is the supported way to run Cisco Virtual Kubelet.
 
+!!! info "NX-OS (Beta)"
+    This walkthrough uses an IOS-XE device, the production-focused path. Cisco
+    Nexus (NX-OS) switches are also supported in Beta — the install and pod
+    steps are identical; only the `CiscoDevice` spec differs (`driver: NXOS`
+    with an `nxos:` block). See [Deploying to NX-OS](#deploying-to-nx-os-beta)
+    below and the [NX-OS Family Reference](reference/families-nxos.md).
+
 ## Prerequisites
 
 | Requirement | Notes |
@@ -167,6 +174,44 @@ cat9000-1    Ready    agent   15s
 ```
 
 If `PHASE` stays on `Provisioning` or shows `Error`, see [Troubleshooting](troubleshooting.md#ciscodevice-stuck-in-provisioning).
+
+### Deploying to NX-OS (Beta)
+
+For a Cisco Nexus (NX-OS) switch, the controller install (step 2), credential
+Secret (step 3), and pod scheduling (step 5) are unchanged. Only the
+`CiscoDevice` spec differs: set `driver: NXOS` and use an `nxos:` block instead
+of `xe:`. App-hosting is driven over NX-API CLI; the only supported host-side
+attachment today is the `Management` interface.
+
+```yaml
+apiVersion: cisco.vk/v1alpha1
+kind: CiscoDevice
+metadata:
+  name: nexus9300v-01
+  namespace: default
+spec:
+  driver: NXOS
+  address: "192.168.1.120"
+  port: 443
+  username: admin
+  credentialSecretRef:
+    name: nexus9300v-01-creds
+  tls:
+    enabled: true
+    insecureSkipVerify: true    # acceptable for lab; use caFile in production
+  nxos:
+    networking:
+      interface:
+        type: Management
+        management:
+          guestInterface: 0
+```
+
+Declarative NX-OS device configuration (VLANs, interfaces, features, and so on)
+is managed separately through the `NXOSConfig` CRD over NX-API REST/DME — see
+the [NX-OS Family Reference](reference/families-nxos.md) for the supported
+families and an example. NX-OS is a Beta runtime slice; the
+[Production Readiness](production-readiness.md) page tracks its current scope.
 
 ## 5. Deploy a pod
 

--- a/docs/reference/families-nxos.md
+++ b/docs/reference/families-nxos.md
@@ -1,0 +1,75 @@
+# NX-OS Family Reference (Beta)
+
+!!! warning "Beta"
+    NX-OS `NXOSConfig` support is a Beta runtime slice. The schema is
+    `v1alpha1`, family coverage is still expanding, and wire-format behaviour
+    may change between releases. See
+    [Production Readiness](../production-readiness.md) for the current scope and
+    hardening roadmap.
+
+Declarative NX-OS device configuration is driven by the `NXOSConfig` CRD over
+NX-API REST/DME, using the shared Network as Code config engine. Unlike the
+IOS-XE [Family Reference](families/README.md) — which is generated from vendored
+YANG across many families — the NX-OS slice currently ships a focused set of
+hand-written family writers.
+
+## Supported families
+
+| Family | Key | Covers |
+|---|---|---|
+| System | `system` | Device-level settings such as `hostname` |
+| Feature | `feature` | Individual NX-OS feature enablement (e.g. `interface-vlan`, `lacp`) |
+| Feature set | `feature_set` | Installable feature sets (e.g. `fex`) |
+| VLAN | `vlan` | VLAN definitions (id, name) |
+| Interface (Ethernet) | `interface_ethernet` | Ethernet interface config: description, MTU, admin state |
+
+Each family is opt-in per `NXOSConfig` via `spec.managedFamilies`; the engine
+only reconciles families you list, and applies drift detection and revision
+tracking the same way it does for IOS-XE.
+
+## Example
+
+```yaml
+apiVersion: config.cisco.vk/v1alpha1
+kind: NXOSConfig
+metadata:
+  name: nexus9300v-vlans
+  namespace: default
+spec:
+  deviceRef:
+    name: nexus9300v-01
+  managedFamilies:
+    - system
+    - vlan
+    - interface_ethernet
+  driftPolicy: revert
+  driftDetectInterval: 5m
+  writeStartup: true
+  modelSource:
+    format: netascode-nxos
+    resolved: true
+  source:
+    inline:
+      nxos:
+        devices:
+          - name: nexus9300v-01
+            configuration:
+              system:
+                hostname: nexus9300v-01
+              vlan:
+                vlans:
+                  - id: 3903
+                    name: CVK_LAB
+              interfaces:
+                ethernets:
+                  - id: 1/1
+                    description: CVK lab uplink
+                    shutdown: false
+                    mtu: 9216
+```
+
+## See also
+
+- [Network as Code](../netascode-config.md) — intent shape, drift detection, and revisions shared across IOS-XE and NX-OS
+- [CRD Reference](../crds.md#nxosconfig) — full `NXOSConfig` schema
+- [Production Readiness](../production-readiness.md) — NX-OS runtime-parity scope

--- a/docs/website/src/app/globals.css
+++ b/docs/website/src/app/globals.css
@@ -1,4 +1,4 @@
-/* Copyright 2026 Cisco Systems, Inc.
+/* Copyright 2026 Cisco Systems Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docs/website/src/app/layout.tsx
+++ b/docs/website/src/app/layout.tsx
@@ -29,15 +29,18 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "Cisco Virtual Kubelet — Deploy Containers to Cisco Network Devices",
   description:
-    "A Virtual Kubelet provider that enables Kubernetes to schedule container workloads on Cisco Catalyst series switches and IOS-XE devices with App-Hosting capabilities.",
+    "A Virtual Kubelet provider that enables Kubernetes to schedule container workloads on Cisco Catalyst series switches and IOS-XE devices, with Beta support for Cisco Nexus (NX-OS) switches, that offer App-Hosting capabilities.",
   keywords: [
     "Cisco",
     "Virtual Kubelet",
     "Kubernetes",
     "Edge Computing",
     "IOS-XE",
+    "NX-OS",
+    "Nexus",
     "Catalyst",
     "RESTCONF",
+    "NX-API",
     "Containers",
   ],
   openGraph: {

--- a/docs/website/src/app/layout.tsx
+++ b/docs/website/src/app/layout.tsx
@@ -1,4 +1,4 @@
-// Copyright 2026 Cisco Systems, Inc.
+// Copyright 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/docs/website/src/app/page.tsx
+++ b/docs/website/src/app/page.tsx
@@ -1,4 +1,4 @@
-// Copyright 2026 Cisco Systems, Inc.
+// Copyright 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/docs/website/src/components/Architecture.tsx
+++ b/docs/website/src/components/Architecture.tsx
@@ -141,7 +141,7 @@ export default function Architecture() {
               {[
                 { name: "Catalyst 8000V", ip: "192.0.2.24" },
                 { name: "Catalyst 9000", ip: "192.0.2.25" },
-                { name: "IOS-XE Device", ip: "192.0.2.x" },
+                { name: "Nexus NX-OS · Beta", ip: "192.0.2.x" },
               ].map((device, i) => (
                 <motion.div
                   key={device.name}
@@ -201,12 +201,12 @@ export default function Architecture() {
             </div>
             <div className="relative pt-12">
               <h3 className="text-xl font-semibold mb-3 text-foreground">
-                RESTCONF Reconciliation
+                Driver Reconciliation
               </h3>
               <p className="text-text-muted leading-relaxed">
-                The driver translates pod specs into IOS-XE app-hosting config
-                and reconciles state via RESTCONF. A recovery loop reprocesses
-                stuck pods automatically.
+                The driver translates pod specs into device app-hosting config
+                and reconciles state — via RESTCONF on IOS-XE, or NX-API CLI on
+                NX-OS. A recovery loop reprocesses stuck pods automatically.
               </p>
             </div>
           </div>

--- a/docs/website/src/components/Architecture.tsx
+++ b/docs/website/src/components/Architecture.tsx
@@ -1,4 +1,4 @@
-// Copyright 2026 Cisco Systems, Inc.
+// Copyright 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/docs/website/src/components/Community.tsx
+++ b/docs/website/src/components/Community.tsx
@@ -1,4 +1,4 @@
-// Copyright 2026 Cisco Systems, Inc.
+// Copyright 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/docs/website/src/components/Features.tsx
+++ b/docs/website/src/components/Features.tsx
@@ -22,6 +22,9 @@ import {
   Activity,
   Layers,
   LineChart,
+  FileCode,
+  ArrowUpCircle,
+  Terminal,
 } from "lucide-react";
 
 const features = [
@@ -37,17 +40,45 @@ const features = [
     icon: Layers,
     title: "Driver-Based Architecture",
     description:
-      "Extensible driver pattern with IOS-XE (Catalyst 8000V, Catalyst 9000) available today. Add new device types through a clean driver interface.",
+      "Extensible driver pattern with IOS-XE (Catalyst 8000V, Catalyst 9000) available today and Beta support for Cisco Nexus (NX-OS). Add new device types through a clean driver interface.",
     color: "from-accent to-accent-light",
     glowColor: "accent",
+    beta: true,
   },
   {
     icon: Activity,
-    title: "Lifecycle & Recovery",
+    title: "Full App-Hosting Lifecycle",
     description:
-      "Full pod lifecycle via RESTCONF with an automatic recovery loop that reprocesses stuck pods using exponential backoff.",
+      "Create, monitor, and delete containers via RESTCONF on IOS-XE or NX-API CLI on NX-OS, with an automatic recovery loop that reprocesses stuck pods using exponential backoff.",
     color: "from-success to-emerald-400",
     glowColor: "success",
+  },
+  {
+    icon: FileCode,
+    title: "Network as Code",
+    description:
+      "Declare device configuration in Kubernetes with the IOSXEConfig and NXOSConfig CRDs — continuous drift detection, revisions, and transactional apply.",
+    color: "from-primary to-accent",
+    glowColor: "primary",
+    beta: true,
+  },
+  {
+    icon: ArrowUpCircle,
+    title: "Software Lifecycle",
+    description:
+      "Drive IOS-XE software upgrades from Kubernetes via the IOSXESoftwareUpgrade CRD, using gNOI OS install, activate, and verify.",
+    color: "from-accent to-accent-light",
+    glowColor: "accent",
+    beta: true,
+  },
+  {
+    icon: Terminal,
+    title: "Device Operations",
+    description:
+      "Run auditable show commands and read-only gNOI probes from Kubernetes via the DeviceOperation CRD — no SSH sessions required.",
+    color: "from-primary-light to-primary",
+    glowColor: "primary",
+    beta: true,
   },
   {
     icon: Network,
@@ -67,9 +98,9 @@ const features = [
   },
   {
     icon: LineChart,
-    title: "Observability & Topology",
+    title: "Telemetry & Observability",
     description:
-      "Prometheus metrics for device and interface health, plus OpenTelemetry topology traces with CDP/OSPF neighbors and hosted apps.",
+      "MDT-over-gNMI subscriptions emit OpenTelemetry metrics, logs, and traces, plus Prometheus device/interface health and CDP/OSPF topology with hosted apps.",
     color: "from-primary-light to-primary",
     glowColor: "primary",
     beta: true,

--- a/docs/website/src/components/Features.tsx
+++ b/docs/website/src/components/Features.tsx
@@ -1,4 +1,4 @@
-// Copyright 2026 Cisco Systems, Inc.
+// Copyright 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/docs/website/src/components/Footer.tsx
+++ b/docs/website/src/components/Footer.tsx
@@ -91,7 +91,8 @@ export default function Footer() {
             </a>
             <p className="text-sm text-text-muted leading-relaxed mb-6">
               Deploy container workloads on Cisco Catalyst series switches and
-              IOS-XE devices using standard Kubernetes workflows.
+              IOS-XE devices, with Beta support for Cisco Nexus (NX-OS)
+              switches, using standard Kubernetes workflows.
             </p>
             <a
               href="https://github.com/cisco-open/cisco-virtual-kubelet"

--- a/docs/website/src/components/Footer.tsx
+++ b/docs/website/src/components/Footer.tsx
@@ -1,4 +1,4 @@
-// Copyright 2026 Cisco Systems, Inc.
+// Copyright 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -133,7 +133,7 @@ export default function Footer() {
         {/* Bottom bar */}
         <div className="mt-12 pt-8 border-t border-border flex flex-col sm:flex-row items-center justify-between gap-4">
           <p className="text-sm text-text-muted">
-            © {new Date().getFullYear()} Cisco Systems, Inc. Licensed under{" "}
+            © {new Date().getFullYear()} Cisco Systems Inc. Licensed under{" "}
             <a
               href="https://github.com/cisco-open/cisco-virtual-kubelet/blob/main/LICENSE"
               target="_blank"

--- a/docs/website/src/components/GetStarted.tsx
+++ b/docs/website/src/components/GetStarted.tsx
@@ -165,7 +165,7 @@ export default function GetStarted() {
               { label: "Kubernetes 1.28+", desc: "Any distribution" },
               { label: "Helm v3 + Docker", desc: "To install the chart and build the image" },
               { label: "Container Registry", desc: "Reachable from the cluster" },
-              { label: "Cisco IOS-XE Device", desc: "Cat 8000V or Cat 9000" },
+              { label: "Cisco Device", desc: "IOS-XE (Cat 8000V/9000) or Nexus NX-OS (Beta)" },
             ].map((req) => (
               <div
                 key={req.label}

--- a/docs/website/src/components/GetStarted.tsx
+++ b/docs/website/src/components/GetStarted.tsx
@@ -1,4 +1,4 @@
-// Copyright 2026 Cisco Systems, Inc.
+// Copyright 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/docs/website/src/components/Hero.tsx
+++ b/docs/website/src/components/Hero.tsx
@@ -68,8 +68,8 @@ export default function Hero() {
               Virtual Kubelet provider
             </span>{" "}
             that enables Kubernetes to schedule container workloads on Cisco
-            Catalyst series switches and IOS-XE devices with App-Hosting
-            capabilities.
+            Catalyst series switches and IOS-XE devices — with Beta support for
+            Cisco Nexus (NX-OS) switches — that offer App-Hosting capabilities.
           </motion.p>
 
           {/* CTA Buttons */}

--- a/docs/website/src/components/Hero.tsx
+++ b/docs/website/src/components/Hero.tsx
@@ -1,4 +1,4 @@
-// Copyright 2026 Cisco Systems, Inc.
+// Copyright 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/docs/website/src/components/Navbar.tsx
+++ b/docs/website/src/components/Navbar.tsx
@@ -1,4 +1,4 @@
-// Copyright 2026 Cisco Systems, Inc.
+// Copyright 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/docs/website/src/components/NetworkAnimation.tsx
+++ b/docs/website/src/components/NetworkAnimation.tsx
@@ -1,4 +1,4 @@
-// Copyright 2026 Cisco Systems, Inc.
+// Copyright 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/drivers/iosxe/telemetry/smoke_live_test.go
+++ b/internal/drivers/iosxe/telemetry/smoke_live_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2026 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Live-device smoke test — gated behind RUN_LIVE_GNMI_SMOKE=1 so it
 // never runs in normal `make test`. Reads CAT9K_PASSWORD env var, dials
 // 10.1.1.1:50052 plaintext as user "cisco", subscribes to OpenConfig

--- a/internal/otelproviders/uxagx_smoke_test.go
+++ b/internal/otelproviders/uxagx_smoke_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2026 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Live OTLP smoke test — gated behind RUN_LIVE_OTLP_SMOKE=1.
 // Pushes one metric, one log, and one span to OTEL_EXPORTER_OTLP_ENDPOINT
 // and asserts no errors. Use to confirm collector reachability.

--- a/internal/provider/node_status_test.go
+++ b/internal/provider/node_status_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2026 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package provider
 
 import (

--- a/internal/tlsutil/tls.go
+++ b/internal/tlsutil/tls.go
@@ -1,4 +1,4 @@
-// Copyright © 2026 Cisco Systems, Inc.
+// Copyright © 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/tlsutil/tls_test.go
+++ b/internal/tlsutil/tls_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2026 Cisco Systems, Inc.
+// Copyright © 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
   - Network as Code: 'netascode-config.md'
   - CRD Reference: 'crds.md'
   - Family Reference: 'reference/families/README.md'
+  - NX-OS Family Reference: 'reference/families-nxos.md'
   - Catalyst 8000V: 'configuration-cat8000v.md'
   - Catalyst 9000: 'configuration-cat9000.md'
   - IR1100 Series: 'configuration-ir1101.md'

--- a/scripts/check-device.sh
+++ b/scripts/check-device.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2026 Cisco Systems Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Check Cisco device readiness for Virtual Kubelet
 # Usage: ./check-device.sh <device-ip> <username>
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2026 Cisco Systems Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Cisco Virtual Kubelet Provider Installation Script
 set -e
 

--- a/scripts/lint-ctx.sh
+++ b/scripts/lint-ctx.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# Copyright 2026 Cisco Systems Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -euo pipefail
 
 # Lightweight guard for the OTel context-propagation audit. New reconciler,

--- a/scripts/nxos-lab-smoke.sh
+++ b/scripts/nxos-lab-smoke.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# Copyright 2026 Cisco Systems Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/scripts/upload-image.sh
+++ b/scripts/upload-image.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2026 Cisco Systems Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Upload container image to Cisco device
 # Usage: ./upload-image.sh <device-ip> <username> <image.tar>
 

--- a/tools/cisco-vk-config-docs/main.go
+++ b/tools/cisco-vk-config-docs/main.go
@@ -1,4 +1,4 @@
-// Copyright © 2026 Cisco Systems, Inc.
+// Copyright © 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/cisco-vk-config-docs/main_test.go
+++ b/tools/cisco-vk-config-docs/main_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2026 Cisco Systems, Inc.
+// Copyright © 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/cisco-vk-config-lint/cluster.go
+++ b/tools/cisco-vk-config-lint/cluster.go
@@ -1,4 +1,4 @@
-// Copyright © 2026 Cisco Systems, Inc.
+// Copyright © 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/cisco-vk-config-lint/cluster_test.go
+++ b/tools/cisco-vk-config-lint/cluster_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2026 Cisco Systems, Inc.
+// Copyright © 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/cisco-vk-config-lint/crs.go
+++ b/tools/cisco-vk-config-lint/crs.go
@@ -1,4 +1,4 @@
-// Copyright © 2026 Cisco Systems, Inc.
+// Copyright © 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/cisco-vk-config-lint/drift.go
+++ b/tools/cisco-vk-config-lint/drift.go
@@ -1,4 +1,4 @@
-// Copyright © 2026 Cisco Systems, Inc.
+// Copyright © 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/cisco-vk-config-lint/main.go
+++ b/tools/cisco-vk-config-lint/main.go
@@ -1,4 +1,4 @@
-// Copyright © 2026 Cisco Systems, Inc.
+// Copyright © 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/cisco-vk-config-lint/main_test.go
+++ b/tools/cisco-vk-config-lint/main_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2026 Cisco Systems, Inc.
+// Copyright © 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/cisco-vk-config-lint/report.go
+++ b/tools/cisco-vk-config-lint/report.go
@@ -1,4 +1,4 @@
-// Copyright © 2026 Cisco Systems, Inc.
+// Copyright © 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/cisco-vk-yang-sync/main.go
+++ b/tools/cisco-vk-yang-sync/main.go
@@ -1,4 +1,4 @@
-// Copyright © 2026 Cisco Systems, Inc.
+// Copyright © 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/cisco-vk-yang-sync/main_test.go
+++ b/tools/cisco-vk-yang-sync/main_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2026 Cisco Systems, Inc.
+// Copyright © 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/cisco-vk-yang-sync/patch.go
+++ b/tools/cisco-vk-yang-sync/patch.go
@@ -1,4 +1,4 @@
-// Copyright © 2026 Cisco Systems, Inc.
+// Copyright © 2026 Cisco Systems Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

Release-prep cleanup ahead of the July 2026 tag. A pre-release review found the code in good shape (build, `go vet`, and `make test` with `-race` all green; CI passing), but three non-code gaps that should land before cutting the tag:

1. **The dynamic landing site was stale** — `docs/website` (published to gh-pages by `develop.yml` on every `v*` tag) still described an IOS-XE-only provider, predating the NX-OS runtime that shipped in #141, and omitted several shipped capabilities.
2. **Onboarding docs lacked NX-OS** — the headline NX-OS (Beta) feature was documented in `index.md`/`crds.md` but missing from `getting-started.md` and had no family reference page.
3. **License-header gaps** — ~17 first-party files shipped without the Apache-2.0 header (no CI gate enforces them), and the copyright entity name was split across two forms.

No code or behavioural change. Docs, chart templates (comment-only), and license headers only.

## Changes

### Dynamic website (`docs/website`)
- Hero, footer, and SEO metadata now cover Beta NX-OS (Nexus) support; added NX-OS / NX-API keywords.
- Feature grid updated to the current capability set — added NX-OS support, Network as Code (`IOSXEConfig` + `NXOSConfig`), Software Lifecycle, and Device Operations; generalised the lifecycle/telemetry cards across IOS-XE and NX-OS.
- Architecture diagram device row and reconciliation step are no longer IOS-XE/RESTCONF-exclusive (RESTCONF on IOS-XE, NX-API CLI on NX-OS).

### MkDocs
- `getting-started.md`: NX-OS (Beta) note up front plus a "Deploying to NX-OS" section showing the `driver: NXOS` / `nxos:` `CiscoDevice` spec; install and pod steps are shared with the IOS-XE walkthrough.
- New `reference/families-nxos.md`: supported NX-OS config families (`system`, `feature`, `feature_set`, `vlan`, `interface_ethernet`) over NX-API REST/DME with a worked `NXOSConfig` example; added to the Configuration nav. Placed outside the generated `families/` tree (the config-docs generator is IOS-XE-only).

### License headers / copyright
- Added the Apache-2.0 header to first-party files that lacked it: 5 shell scripts (after the shebang), both Dockerfiles, the `Makefile`, 3 Go test files, and the 6 hand-written Helm templates (`{{/* */}}` block, matching the collector subchart convention).
- Normalised the copyright entity to `Cisco Systems Inc.` (the dominant form, 377 files) across the 39 first-party files that used the comma variant.
- Left untouched by design: `charts/.../templates/role.yaml` (generated by `make rbac-gen`, carries an AUTO-GENERATED notice), CRDs under `config/crd`, `LICENSE` and `docs/website/NOTICE` (legal notices), and the vendored `tests/yang/*.yang` third-party models.

## Testing

- `make test` (`go test -race ./...`): **1026 pass / 0 fail / 0 races**.
- Generated-artefact drift gate (`make crd-gen deepcopy-gen rbac-gen helm-sync-crds` + `git diff`): **no drift** — the Helm header additions and `role.yaml` regeneration stay in sync.
- `helm lint` + `helm template`: pass. `mkdocs build --strict`: pass, 0 warnings. `npm run build` (website) + eslint: pass.
