### PR TITLE
chore(release): bump version references to v2026.07.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,16 +80,16 @@ The chart and its container image are published to GitHub Container Registry wit
 
 ```bash
 helm install cvk oci://ghcr.io/cisco-open/charts/cisco-virtual-kubelet \
-  --version 2026.6.1 \
+  --version 2026.7.0 \
   --namespace cvk-system --create-namespace
 ```
 
-This deploys the signed `ghcr.io/cisco-open/cisco-virtual-kubelet` image by default — no `--set image.*` needed. The chart `--version` is the release normalised to SemVer (e.g. `v2026.06.1` → `2026.6.1`); see [Releases](https://github.com/cisco-open/cisco-virtual-kubelet/releases) for the current version.
+This deploys the signed `ghcr.io/cisco-open/cisco-virtual-kubelet` image by default — no `--set image.*` needed. The chart `--version` is the release normalised to SemVer (e.g. `v2026.07.0` → `2026.7.0`); see [Releases](https://github.com/cisco-open/cisco-virtual-kubelet/releases) for the current version.
 
 Optionally verify the chart signature before installing:
 
 ```bash
-cosign verify ghcr.io/cisco-open/charts/cisco-virtual-kubelet:2026.6.1 \
+cosign verify ghcr.io/cisco-open/charts/cisco-virtual-kubelet:2026.7.0 \
   --certificate-identity-regexp "https://github.com/cisco-open/cisco-virtual-kubelet/.github/workflows/release.yml@refs/tags/v.*" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```

--- a/charts/cisco-virtual-kubelet/Chart.yaml
+++ b/charts/cisco-virtual-kubelet/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # from the git tag by the release workflow; the values below are the
 # source-tree defaults used for local installs.
 version: 0.1.0
-appVersion: "v2026.06.1"
+appVersion: "v2026.07.0"
 keywords:
   - cisco
   - virtual-kubelet

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -71,11 +71,11 @@ The controller watches `CiscoDevice` custom resources and creates a Virtual Kube
 
 ```bash
 helm install cvk oci://ghcr.io/cisco-open/charts/cisco-virtual-kubelet \
-  --version 2026.6.1 \
+  --version 2026.7.0 \
   --namespace cvk-system --create-namespace
 ```
 
-This pulls the signed `ghcr.io/cisco-open/cisco-virtual-kubelet` image by default. The chart `--version` is the release normalised to SemVer (e.g. `v2026.06.1` → `2026.6.1`); see [Releases](https://github.com/cisco-open/cisco-virtual-kubelet/releases) for the current one.
+This pulls the signed `ghcr.io/cisco-open/cisco-virtual-kubelet` image by default. The chart `--version` is the release normalised to SemVer (e.g. `v2026.07.0` → `2026.7.0`); see [Releases](https://github.com/cisco-open/cisco-virtual-kubelet/releases) for the current one.
 
 **From source with a custom image** — to run the build from step 1 instead:
 


### PR DESCRIPTION
## Summary

Release prep for the **July 2026** tag (`v2026.07.0`). Bumps the committed source-of-truth version strings ahead of tagging. The release workflow derives the published image and chart versions from the pushed tag, so this only updates the values used by from-source installs and the docs.

## Changes

- `charts/cisco-virtual-kubelet/Chart.yaml`: `appVersion` `v2026.06.1` → `v2026.07.0` (the chart's default image tag for `helm install ./charts/...`).
- `README.md` and `docs/getting-started.md`: published-chart `--version` `2026.6.1` → `2026.7.0`, the `cosign verify` chart tag, and the SemVer-normalisation examples (`v2026.07.0` → `2026.7.0`).

## Testing

`helm lint` passes. Version-string only; no behavioural change. Once merged, `v2026.07.0` will be tagged on the merge commit to trigger the release pipeline (multi-arch image, SBOM, cosign signing, chart publish) and the docs deploy.