### PR TITLE
chore: gofmt first-party sources and add a formatting gate to CI

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -65,6 +65,21 @@ jobs:
         # diagnosed without waiting for the test suite.
         run: go vet ./...
 
+      - name: gofmt check
+        # Formatting gate for first-party sources. Generated trees are
+        # excluded: the ygot per-family schemas under configdriver/generated/
+        # and internal/drivers/iosxe/models.go (ygot output — reformatting it
+        # by hand would drift it from the generator; see the drift check
+        # below, which asserts generated artefacts match their sources).
+        run: |
+          fmt_out="$(gofmt -l . | grep -v '/configdriver/generated/' | grep -v 'internal/drivers/iosxe/models.go' || true)"
+          if [ -n "$fmt_out" ]; then
+            echo "gofmt violations in first-party files:"
+            echo "$fmt_out"
+            exit 1
+          fi
+          echo "gofmt clean."
+
       - name: Unit tests
         run: go test -race -count=1 ./...
 

--- a/internal/aggregator/aggregator.go
+++ b/internal/aggregator/aggregator.go
@@ -279,8 +279,8 @@ func (r *AggregatedReconciler) startWorker(dev *ciskov1.CiscoDevice, password, h
 
 	devCtx, cancel := context.WithCancel(r.rootCtx)
 	rec := &provider.ConfigReconciler{
-		Client:                r.Client,
-		DeviceName:            dev.Name,
+		Client:     r.Client,
+		DeviceName: dev.Name,
 		// DeviceNamespace scopes reconciliation to this device's namespace;
 		// deviceRef is same-namespace by contract, so without it the worker
 		// would reconcile IOSXEConfig objects from other namespaces whose

--- a/internal/aggregator/nxos_worker.go
+++ b/internal/aggregator/nxos_worker.go
@@ -40,8 +40,8 @@ func (r *AggregatedReconciler) startNXOSWorker(dev *ciskov1.CiscoDevice, passwor
 	notify := startSubscribeWatcher(r.rootCtx, dctx)
 	devCtx, cancel := context.WithCancel(r.rootCtx)
 	rec := &provider.NXOSConfigReconciler{
-		Client:             r.Client,
-		DeviceName:         dev.Name,
+		Client:     r.Client,
+		DeviceName: dev.Name,
 		// DeviceNamespace scopes reconciliation to this device's namespace.
 		// deviceRef is same-namespace by contract; without this the worker
 		// would reconcile NXOSConfig objects from any namespace whose

--- a/internal/drivers/common/naming_test.go
+++ b/internal/drivers/common/naming_test.go
@@ -297,12 +297,12 @@ func TestPodIdentityFromRunOpts(t *testing.T) {
 	)
 
 	tests := []struct {
-		name      string
-		lines     []string
-		wantNS    string
-		wantName  string
-		wantUID   string
-		wantCtr   string
+		name     string
+		lines    []string
+		wantNS   string
+		wantName string
+		wantUID  string
+		wantCtr  string
 	}{
 		{
 			name: "all labels on a single line",
@@ -338,12 +338,12 @@ func TestPodIdentityFromRunOpts(t *testing.T) {
 			wantNS: ns, wantName: name, wantUID: uid, wantCtr: ctr,
 		},
 		{
-			name:    "no labels at all",
-			lines:   []string{"-e FOO=1", "-e BAR=2"},
-			wantNS:  "",
+			name:     "no labels at all",
+			lines:    []string{"-e FOO=1", "-e BAR=2"},
+			wantNS:   "",
 			wantName: "",
-			wantUID: "",
-			wantCtr: "",
+			wantUID:  "",
+			wantCtr:  "",
 		},
 		{
 			name: "first occurrence wins (later duplicate ignored)",

--- a/internal/drivers/iosxe/env_vars_test.go
+++ b/internal/drivers/iosxe/env_vars_test.go
@@ -43,7 +43,7 @@ func TestBuildEnvironmentOptions_DirectVars(t *testing.T) {
 	container := &v1.Container{
 		Env: []v1.EnvVar{
 			{Name: "SIMPLE_VAR", Value: "simple_value"},
-			{Name: "EMPTY_VAR", Value: ""},           // Should be skipped
+			{Name: "EMPTY_VAR", Value: ""}, // Should be skipped
 			{Name: "QUOTED_VAR", Value: `value with "quotes"`},
 			{Name: "SPECIAL_VAR", Value: "value$with`special\\chars"},
 		},
@@ -316,7 +316,7 @@ func TestBuildEnvironmentOptions_ConfigMapRef(t *testing.T) {
 			Namespace: "default",
 		},
 		Data: map[string]string{
-			"api-url":  "https://api.example.com",
+			"api-url":   "https://api.example.com",
 			"log-level": "debug",
 		},
 	}

--- a/internal/drivers/iosxe/pod_transforms_test.go
+++ b/internal/drivers/iosxe/pod_transforms_test.go
@@ -1150,10 +1150,10 @@ func TestAllocateIPForContainer_NonPrimary_NoIP(t *testing.T) {
 
 func TestGetPackageDest(t *testing.T) {
 	cases := []struct {
-		name        string
-		annotation  string
-		wantDest    string
-		wantErr     bool
+		name       string
+		annotation string
+		wantDest   string
+		wantErr    bool
 	}{
 		{name: "not set", annotation: "", wantDest: ""},
 		{name: "flash with path", annotation: "flash:/virtual-kubelet/app.tar", wantDest: "flash:/virtual-kubelet/app.tar"},

--- a/internal/drivers/iosxe/telemetry/smoke_live_test.go
+++ b/internal/drivers/iosxe/telemetry/smoke_live_test.go
@@ -18,8 +18,9 @@
 // interface counters, and asserts MessagesReceived ticks within 30s.
 //
 // Invoke:
-//   RUN_LIVE_GNMI_SMOKE=1 CAT9K_PASSWORD=... \
-//     go test ./internal/drivers/iosxe/telemetry/ -run TestLiveSubscribeSmoke -v -count=1
+//
+//	RUN_LIVE_GNMI_SMOKE=1 CAT9K_PASSWORD=... \
+//	  go test ./internal/drivers/iosxe/telemetry/ -run TestLiveSubscribeSmoke -v -count=1
 package telemetry
 
 import (

--- a/tools/cisco-vk-yang-sync/main.go
+++ b/tools/cisco-vk-yang-sync/main.go
@@ -335,6 +335,7 @@ type ygotInvocation struct {
 	bin  string
 	args []string
 }
+
 func buildYgotArgs(f flags, _ []string) (ygotInvocation, error) {
 	bin := f.ygotBin
 	realArgs := []string{}

--- a/tools/cisco-vk-yang-sync/main_test.go
+++ b/tools/cisco-vk-yang-sync/main_test.go
@@ -582,9 +582,13 @@ func TestComputeModuleClosureBasic(t *testing.T) {
 	// AllFiles must include root, submod1 (submodule), dep1, dep2, dep3.
 	// TopLevelFiles must include root, dep1, dep2, dep3 but NOT submod1.
 	gotAll := map[string]bool{}
-	for _, f := range got.AllFiles { gotAll[f] = true }
+	for _, f := range got.AllFiles {
+		gotAll[f] = true
+	}
 	gotTop := map[string]bool{}
-	for _, f := range got.TopLevelFiles { gotTop[f] = true }
+	for _, f := range got.TopLevelFiles {
+		gotTop[f] = true
+	}
 
 	for _, want := range []string{
 		"Cisco-IOS-XE-root.yang",


### PR DESCRIPTION
Eight hand-written files had drifted from gofmt output (struct-field
alignment and trailing-newline nits in the aggregator, driver tests,
and the yang-sync tool). Reformat them and add a 'gofmt check' step to
the smoke workflow, between go vet and the unit tests, so drift cannot
recur.

The gate excludes generated trees:
- internal/drivers/iosxe/configdriver/generated/ (per-family ygot schemas)
- internal/drivers/iosxe/models.go (ygot output; reformatting it by hand
  would diverge it from generator output, which the existing generated-
  artefact drift check asserts against)

Formatting-only change to Go sources; no behavioural change. Verified:
gofmt -l is clean under the gate's filter, gofmt -e parses every edited
file, and the workflow edit parses as YAML.

