### PR TITLE
feat: apply Pod Security Standards restricted profile to controller and VK pods

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,8 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -ldflags
 
 FROM gcr.io/distroless/static-debian12
 COPY --from=builder /app/cisco-vk /usr/local/bin/cisco-vk
-USER nonroot:nonroot
+# Distroless defines its nonroot user and group as 65532. Keep the OCI image
+# metadata numeric so kubelet can verify runAsNonRoot without resolving names.
+USER 65532:65532
 
 ENTRYPOINT ["/usr/local/bin/cisco-vk"]

--- a/Dockerfile.config-lint
+++ b/Dockerfile.config-lint
@@ -35,5 +35,6 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
 
 FROM gcr.io/distroless/static-debian12
 COPY --from=builder /out/cisco-vk-config-lint /usr/local/bin/cisco-vk-config-lint
-USER nonroot:nonroot
+# Match the numeric nonroot identity used by the main runtime image.
+USER 65532:65532
 ENTRYPOINT ["/usr/local/bin/cisco-vk-config-lint"]

--- a/charts/cisco-virtual-kubelet/templates/deployment.yaml
+++ b/charts/cisco-virtual-kubelet/templates/deployment.yaml
@@ -42,10 +42,18 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "cisco-virtual-kubelet.controllerServiceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: controller
           image: {{ include "cisco-virtual-kubelet.controllerImage" . }}
           imagePullPolicy: {{ include "cisco-virtual-kubelet.controllerImagePullPolicy" . }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command:
             - cisco-vk
             - manager
@@ -171,19 +179,25 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.telemetry.yangModels.configMapName }}
           volumeMounts:
+            # Writable /tmp for the read-only root filesystem set by the
+            # default containerSecurityContext.
+            - name: tmp
+              mountPath: /tmp
+            {{- if .Values.telemetry.yangModels.configMapName }}
             - name: yang-models
               mountPath: {{ include "cisco-virtual-kubelet.yangModelsMountPath" . }}
               readOnly: true
-          {{- end }}
-      {{- if .Values.telemetry.yangModels.configMapName }}
+            {{- end }}
       volumes:
+        - name: tmp
+          emptyDir: {}
+        {{- if .Values.telemetry.yangModels.configMapName }}
         - name: yang-models
           configMap:
             name: {{ .Values.telemetry.yangModels.configMapName }}
             optional: true
-      {{- end }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/cisco-virtual-kubelet/values.schema.json
+++ b/charts/cisco-virtual-kubelet/values.schema.json
@@ -251,6 +251,24 @@
         "relabelings":       { "type": "array" },
         "metricRelabelings": { "type": "array" }
       }
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "properties": {
+        "runAsNonRoot": { "type": "boolean" },
+        "runAsUser": { "type": "integer", "minimum": 1 },
+        "runAsGroup": { "type": "integer", "minimum": 1 },
+        "fsGroup": { "type": "integer", "minimum": 1 },
+        "seccompProfile": { "type": "object" }
+      }
+    },
+    "containerSecurityContext": {
+      "type": "object",
+      "properties": {
+        "allowPrivilegeEscalation": { "type": "boolean" },
+        "capabilities": { "type": "object" },
+        "readOnlyRootFilesystem": { "type": "boolean" }
+      }
     }
   }
 }

--- a/charts/cisco-virtual-kubelet/values.yaml
+++ b/charts/cisco-virtual-kubelet/values.yaml
@@ -171,6 +171,29 @@ config:
   # Leave empty to keep the historical per-pod-namespace behaviour.
   leaseNamespace: ""
 
+# podSecurityContext is applied at the controller pod level. Defaults meet
+# the Pod Security Standards "restricted" profile and match the distroless
+# nonroot UID/GID baked into the image. If you supply a custom controller
+# image with a different nonroot identity, override runAsUser, runAsGroup,
+# and fsGroup together.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
+
+# containerSecurityContext is applied to the controller container. The
+# controller needs no writable root filesystem (a writable /tmp is mounted
+# from an emptyDir), no added capabilities, and no privilege escalation.
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+
 resources: {}
 #  limits:
 #    cpu: 200m

--- a/internal/controller/chart_security_test.go
+++ b/internal/controller/chart_security_test.go
@@ -1,0 +1,98 @@
+// Copyright © 2026 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package controller
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+// TestControllerDeploymentRendersSecurityContexts guards the restricted-
+// profile hardening of the controller Deployment template: the pod and
+// container securityContext hooks must stay wired to their values, and the
+// writable /tmp emptyDir that makes readOnlyRootFilesystem viable must stay
+// unconditional. Template-text assertions, matching the vk-rbac chart test.
+func TestControllerDeploymentRendersSecurityContexts(t *testing.T) {
+	raw, err := os.ReadFile("../../charts/cisco-virtual-kubelet/templates/deployment.yaml")
+	if err != nil {
+		t.Fatalf("read deployment template: %v", err)
+	}
+	text := string(raw)
+	for _, want := range []string{
+		`{{- with .Values.podSecurityContext }}`,
+		`{{- with .Values.containerSecurityContext }}`,
+		`- name: tmp`,
+		`emptyDir: {}`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("deployment template missing security hardening construct %q", want)
+		}
+	}
+}
+
+// TestChartDefaultsMeetRestrictedProfile asserts the shipped values keep the
+// Pod Security Standards "restricted" defaults; loosening them must be a
+// deliberate, reviewed change to values.yaml.
+func TestChartDefaultsMeetRestrictedProfile(t *testing.T) {
+	raw, err := os.ReadFile("../../charts/cisco-virtual-kubelet/values.yaml")
+	if err != nil {
+		t.Fatalf("read chart values: %v", err)
+	}
+	var values struct {
+		PodSecurityContext struct {
+			RunAsNonRoot   bool  `yaml:"runAsNonRoot"`
+			RunAsUser      int64 `yaml:"runAsUser"`
+			RunAsGroup     int64 `yaml:"runAsGroup"`
+			FSGroup        int64 `yaml:"fsGroup"`
+			SeccompProfile struct {
+				Type string `yaml:"type"`
+			} `yaml:"seccompProfile"`
+		} `yaml:"podSecurityContext"`
+		ContainerSecurityContext struct {
+			AllowPrivilegeEscalation *bool `yaml:"allowPrivilegeEscalation"`
+			ReadOnlyRootFilesystem   bool  `yaml:"readOnlyRootFilesystem"`
+			Capabilities             struct {
+				Drop []string `yaml:"drop"`
+			} `yaml:"capabilities"`
+		} `yaml:"containerSecurityContext"`
+	}
+	if err := yaml.Unmarshal(raw, &values); err != nil {
+		t.Fatalf("parse chart values: %v", err)
+	}
+
+	pod := values.PodSecurityContext
+	if !pod.RunAsNonRoot || pod.RunAsUser != distrolessNonRootUID ||
+		pod.RunAsGroup != distrolessNonRootGID || pod.FSGroup != distrolessNonRootGID ||
+		pod.SeccompProfile.Type != "RuntimeDefault" {
+		t.Fatalf("podSecurityContext defaults do not match the restricted numeric identity: %#v", pod)
+	}
+	container := values.ContainerSecurityContext
+	if container.AllowPrivilegeEscalation == nil || *container.AllowPrivilegeEscalation ||
+		!container.ReadOnlyRootFilesystem || len(container.Capabilities.Drop) != 1 ||
+		container.Capabilities.Drop[0] != "ALL" {
+		t.Fatalf("containerSecurityContext defaults do not meet the restricted profile: %#v", container)
+	}
+}
+
+// TestRuntimeImagesUseNumericNonRootUser guards the kubelet compatibility
+// requirement behind runAsNonRoot: named OCI users cannot be verified.
+func TestRuntimeImagesUseNumericNonRootUser(t *testing.T) {
+	for _, path := range []string{"../../Dockerfile", "../../Dockerfile.config-lint"} {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if !strings.Contains(string(raw), "USER 65532:65532") {
+			t.Errorf("%s must use the numeric distroless nonroot UID/GID", path)
+		}
+	}
+}

--- a/internal/controller/ciscodevice_controller.go
+++ b/internal/controller/ciscodevice_controller.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -68,6 +69,11 @@ const (
 	DefaultImage = "ghcr.io/cisco/virtual-kubelet-cisco:latest"
 	// DefaultServiceAccount is the shared service account used by all VK deployments.
 	DefaultServiceAccount = "cisco-virtual-kubelet"
+	// distrolessNonRootUID/GID are the stable numeric identity of the nonroot
+	// account in gcr.io/distroless images. Using numbers is required because
+	// kubelet cannot verify a named OCI image user against runAsNonRoot.
+	distrolessNonRootUID int64 = 65532
+	distrolessNonRootGID int64 = 65532
 	// virtualKubeletNodeLabelKey/Value are applied to nodes registered by the
 	// per-device VK process. The controller-created per-device VK pods must
 	// avoid those nodes or Kubernetes can recursively schedule one device's VK
@@ -466,12 +472,36 @@ func (r *CiscoDeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		podEnv = append(podEnv, opsPolicyEnv(device.Spec.OpsPolicy)...)
 
 		deploy.Spec.Template.Spec = corev1.PodSpec{
+			// Pod Security Standards "restricted" profile. Pinning the numeric
+			// distroless identity lets kubelet verify runAsNonRoot and keeps the
+			// process and writable volume ownership consistent.
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot: ptr.To(true),
+				RunAsUser:    ptr.To(distrolessNonRootUID),
+				RunAsGroup:   ptr.To(distrolessNonRootGID),
+				FSGroup:      ptr.To(distrolessNonRootGID),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
 			Containers: []corev1.Container{
 				{
 					Name:  "cisco-vk",
 					Image: image,
 					Args:  vkContainerArgs(device.Name, device.Spec.LogLevel),
 					Env:   podEnv,
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: ptr.To(false),
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{"ALL"},
+						},
+						// The two writable paths the runtime needs — the
+						// generated-TLS dir and /tmp (upgrade image staging,
+						// SFTP known_hosts scratch in imageresolver.go) — are
+						// both backed by emptyDir mounts below, so the root
+						// filesystem itself can be read-only.
+						ReadOnlyRootFilesystem: ptr.To(true),
+					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "device-config",
@@ -482,6 +512,10 @@ func (r *CiscoDeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 						{
 							Name:      "tls-gen",
 							MountPath: varLibMountPath,
+						},
+						{
+							Name:      "tmp",
+							MountPath: "/tmp",
 						},
 					},
 				},
@@ -502,6 +536,16 @@ func (r *CiscoDeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 					// self-signed TLS cert generated at startup. Using an
 					// explicit emptyDir ensures this works on a RORFS.
 					Name: "tls-gen",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+				{
+					// Writable /tmp for the read-only root filesystem:
+					// software-upgrade image staging and cache
+					// (os.CreateTemp / os.TempDir in imageresolver.go) land
+					// here. Sized by the node's disk like any emptyDir.
+					Name: "tmp",
 					VolumeSource: corev1.VolumeSource{
 						EmptyDir: &corev1.EmptyDirVolumeSource{},
 					},

--- a/internal/controller/ciscodevice_controller_test.go
+++ b/internal/controller/ciscodevice_controller_test.go
@@ -293,8 +293,8 @@ func TestReconcile_CreatesDeployment(t *testing.T) {
 	if !found {
 		t.Errorf("expected --nodename router-b in container args, got %v", args)
 	}
-	if len(deploy.Spec.Template.Spec.Containers[0].VolumeMounts) != 2 {
-		t.Errorf("expected 2 volume mounts (device-config, tls-gen), got %d", len(deploy.Spec.Template.Spec.Containers[0].VolumeMounts))
+	if len(deploy.Spec.Template.Spec.Containers[0].VolumeMounts) != 3 {
+		t.Errorf("expected 3 volume mounts (device-config, tls-gen, tmp), got %d", len(deploy.Spec.Template.Spec.Containers[0].VolumeMounts))
 	}
 
 	var gotDevice ciskov1.CiscoDevice
@@ -1455,5 +1455,58 @@ func TestOpsPolicyEnvRendersConfigDiffAllowlist(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestReconcile_DeploymentSecurityContexts asserts the per-device VK pod is
+// stamped with the Pod Security Standards "restricted" profile, and that the
+// writable emptyDir mounts which make readOnlyRootFilesystem viable
+// (generated-TLS dir and /tmp for upgrade image staging) are present.
+func TestReconcile_DeploymentSecurityContexts(t *testing.T) {
+	device := newDevice("router-sec", "default")
+	r := reconcilerFor(t, device)
+	ctx := context.Background()
+
+	if _, err := r.Reconcile(ctx, reconcileRequest("default", "router-sec")); err != nil {
+		t.Fatalf("Reconcile returned unexpected error: %v", err)
+	}
+
+	var deploy appsv1.Deployment
+	if err := r.Get(ctx, types.NamespacedName{Namespace: "default", Name: "router-sec" + deploymentSuffix}, &deploy); err != nil {
+		t.Fatalf("Deployment not found after reconcile: %v", err)
+	}
+
+	pod := deploy.Spec.Template.Spec
+	if pod.SecurityContext == nil ||
+		pod.SecurityContext.RunAsNonRoot == nil || !*pod.SecurityContext.RunAsNonRoot ||
+		pod.SecurityContext.RunAsUser == nil || *pod.SecurityContext.RunAsUser != distrolessNonRootUID ||
+		pod.SecurityContext.RunAsGroup == nil || *pod.SecurityContext.RunAsGroup != distrolessNonRootGID ||
+		pod.SecurityContext.FSGroup == nil || *pod.SecurityContext.FSGroup != distrolessNonRootGID ||
+		pod.SecurityContext.SeccompProfile == nil ||
+		pod.SecurityContext.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		t.Fatalf("pod securityContext does not meet the restricted profile: %#v", pod.SecurityContext)
+	}
+
+	sc := pod.Containers[0].SecurityContext
+	if sc == nil ||
+		sc.AllowPrivilegeEscalation == nil || *sc.AllowPrivilegeEscalation ||
+		sc.ReadOnlyRootFilesystem == nil || !*sc.ReadOnlyRootFilesystem ||
+		sc.Capabilities == nil || len(sc.Capabilities.Drop) != 1 || sc.Capabilities.Drop[0] != "ALL" {
+		t.Fatalf("container securityContext does not meet the restricted profile: %#v", sc)
+	}
+
+	var haveTmpMount, haveTmpVolume bool
+	for _, m := range pod.Containers[0].VolumeMounts {
+		if m.Name == "tmp" && m.MountPath == "/tmp" {
+			haveTmpMount = true
+		}
+	}
+	for _, v := range pod.Volumes {
+		if v.Name == "tmp" && v.EmptyDir != nil {
+			haveTmpVolume = true
+		}
+	}
+	if !haveTmpMount || !haveTmpVolume {
+		t.Fatalf("expected a tmp emptyDir mounted at /tmp (mount=%v volume=%v)", haveTmpMount, haveTmpVolume)
 	}
 }


### PR DESCRIPTION
Apply the Pod Security Standards restricted profile to the chart-managed controller and controller-created per-device VK pods.

The original CI attempt exposed an important runtime detail: Kubernetes cannot verify a named OCI user when `runAsNonRoot` is enabled. This refresh therefore uses distroless's stable numeric identity (`65532:65532`) consistently in both runtime Dockerfiles and the controller/per-device pod security contexts.

Security posture:

- `runAsNonRoot`, `runAsUser`, `runAsGroup`, and `fsGroup` set to the numeric distroless identity
- RuntimeDefault seccomp
- no privilege escalation
- all capabilities dropped
- read-only root filesystem
- explicit writable `emptyDir` mounts for `/tmp` and generated TLS material
- operator-overridable chart settings with focused schema validation

Regression coverage now checks the numeric image user, rendered chart defaults, reconciled per-device pod contexts, writable mounts, and rejection of root UID schema overrides.

Local Helm v4 lint/rendering, controller tests and vet, schema parsing, and diff checks pass. Hosted image build and kind smoke remain the final gate for the path that previously failed with `CreateContainerConfigError`.
