### PR TITLE
fix: honor spec.tls.caFile on every device-facing TLS path

### DIFF
--- a/cmd/cisco-vk/config_reconciler.go
+++ b/cmd/cisco-vk/config_reconciler.go
@@ -438,7 +438,10 @@ func startIOSXEConfigReconciler(ctx context.Context, cfg *rest.Config, deviceNam
 	// If the gNOI server is not reachable at startup the dial is lazy
 	// — the conn materialises on first RPC, so a device that comes up
 	// after the VK pod is fine.
-	gnoiProv, gnoiCleanup := setupGNOI(ctx, opts)
+	gnoiProv, gnoiCleanup, err := setupGNOI(ctx, opts)
+	if err != nil {
+		return err
+	}
 	if gnoiCleanup != nil {
 		go func() {
 			<-ctx.Done()

--- a/cmd/cisco-vk/gnoi_wiring.go
+++ b/cmd/cisco-vk/gnoi_wiring.go
@@ -53,7 +53,7 @@ const gNOIInsecureEnv = "CISCO_VK_GNOI_INSECURE"
 // OS.Install streams. The returned cleanup function releases leases
 // and closes the pool when the surrounding ctx is done.
 //
-// Returns (nil, nil) when:
+// Returns (nil, nil, nil) when:
 //   - The device spec is missing the address (defensive — usually
 //     caught earlier in startup).
 //   - Operators have set CISCO_VK_GNOI_DISABLED=1 to opt out.
@@ -61,13 +61,13 @@ const gNOIInsecureEnv = "CISCO_VK_GNOI_INSECURE"
 // A nil gnoi.Provider signals to the reconcilers that the gNOI
 // dispatch path is unavailable; they fail fast with reason
 // GNOIUnsupported on any CR they receive.
-func setupGNOI(ctx context.Context, opts configReconcilerOptions) (gnoi.Provider, func()) {
+func setupGNOI(ctx context.Context, opts configReconcilerOptions) (gnoi.Provider, func(), error) {
 	if v := os.Getenv(gNOIDisabledEnv); v == "1" || strings.EqualFold(v, "true") {
 		log.G(ctx).Info("gNOI pillar disabled by CISCO_VK_GNOI_DISABLED")
-		return nil, nil
+		return nil, nil, nil
 	}
 	if opts.Spec == nil || opts.Spec.Address == "" {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	forceInsecure := false
@@ -87,7 +87,7 @@ func setupGNOI(ctx context.Context, opts configReconcilerOptions) (gnoi.Provider
 		// InsecureSkipVerify, matching the apphosting driver.
 		tlsCfg, err := tlsutil.ClientTLSFromDeviceTLS(opts.Spec.TLS)
 		if err != nil {
-			return nil, fmt.Errorf("gNOI: TLS from spec: %w", err)
+			return nil, nil, fmt.Errorf("gNOI: TLS from spec: %w", err)
 		}
 		dialCfg.TLSConfig = tlsCfg
 	}
@@ -105,7 +105,7 @@ func setupGNOI(ctx context.Context, opts configReconcilerOptions) (gnoi.Provider
 	}
 
 	log.G(ctx).Infof("gNOI: pillar enabled (%s:%d, tls=%v, lazy_bulk=true)", opts.Spec.Address, port, dialCfg.TLSConfig != nil)
-	return provider, provider.Close
+	return provider, provider.Close, nil
 }
 
 type pooledGNOIProvider struct {

--- a/cmd/cisco-vk/gnoi_wiring.go
+++ b/cmd/cisco-vk/gnoi_wiring.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"os"
 	"strconv"
@@ -29,6 +28,7 @@ import (
 	ciskov1 "github.com/cisco/virtual-kubelet-cisco/api/v1alpha1"
 	"github.com/cisco/virtual-kubelet-cisco/internal/drivers/iosxe/devicegrpc"
 	"github.com/cisco/virtual-kubelet-cisco/internal/drivers/iosxe/gnoi"
+	"github.com/cisco/virtual-kubelet-cisco/internal/tlsutil"
 )
 
 // gNOIDisabledEnv lets operators force-disable the gNOI pillar even
@@ -82,10 +82,14 @@ func setupGNOI(ctx context.Context, opts configReconcilerOptions) (gnoi.Provider
 		Password: opts.Password,
 	}
 	if !forceInsecure && opts.Spec.TLS != nil && opts.Spec.TLS.Enabled {
-		dialCfg.TLSConfig = &tls.Config{
-			MinVersion:         tls.VersionTLS12,
-			InsecureSkipVerify: opts.Spec.TLS.InsecureSkipVerify,
+		// Shared device-client helper: honours spec.tls.caFile (RootCAs)
+		// and the certFile/keyFile client pair in addition to
+		// InsecureSkipVerify, matching the apphosting driver.
+		tlsCfg, err := tlsutil.ClientTLSFromDeviceTLS(opts.Spec.TLS)
+		if err != nil {
+			return nil, fmt.Errorf("gNOI: TLS from spec: %w", err)
 		}
+		dialCfg.TLSConfig = tlsCfg
 	}
 
 	pool := devicegrpc.New(dialCfg, nil)

--- a/cmd/cisco-vk/gnoi_wiring_test.go
+++ b/cmd/cisco-vk/gnoi_wiring_test.go
@@ -1,0 +1,48 @@
+// Copyright © 2026 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	ciskov1 "github.com/cisco/virtual-kubelet-cisco/api/v1alpha1"
+)
+
+func TestSetupGNOIPropagatesTLSConfigError(t *testing.T) {
+	t.Setenv(gNOIDisabledEnv, "")
+	t.Setenv(gNOIInsecureEnv, "")
+	t.Setenv(gNOIPortEnv, "")
+
+	provider, cleanup, err := setupGNOI(context.Background(), configReconcilerOptions{
+		Spec: &ciskov1.DeviceSpec{
+			Address: "192.0.2.1",
+			TLS: &ciskov1.TLSConfig{
+				Enabled: true,
+				CAFile:  filepath.Join(t.TempDir(), "missing-ca.pem"),
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("setupGNOI returned nil error for an unreadable CA file")
+	}
+	if provider != nil {
+		t.Fatalf("setupGNOI provider = %#v, want nil after TLS error", provider)
+	}
+	if cleanup != nil {
+		t.Fatal("setupGNOI returned cleanup after TLS error, want nil")
+	}
+}

--- a/cmd/cisco-vk/netconf_probe.go
+++ b/cmd/cisco-vk/netconf_probe.go
@@ -30,12 +30,14 @@ package main
 import (
 	"context"
 	"net"
+	"os"
 	"time"
 
 	"github.com/virtual-kubelet/virtual-kubelet/log"
 	"golang.org/x/crypto/ssh"
 
 	ciskov1 "github.com/cisco/virtual-kubelet-cisco/api/v1alpha1"
+	"github.com/cisco/virtual-kubelet-cisco/internal/drivers/iosxe/configdriver/transport"
 )
 
 // runNETCONFProbe periodically attempts a NETCONF SSH dial against
@@ -93,10 +95,28 @@ func probeOnce(ctx context.Context, addr, user, password string) {
 	}
 
 	// Phase 2: full ssh.Dial — same code path the configdriver uses.
+	//
+	// Host-key policy: the probe authenticates with the real device
+	// credentials, so when the operator ships a known_hosts file
+	// (CONFIG_SSH_KNOWN_HOSTS, see docs/environment-variables.md) the
+	// dial pins against it. Load failures skip the SSH phase entirely —
+	// per known_hosts.go, fail fast rather than silently fall back to
+	// accepting any presented key. Without the env var the historical
+	// lab default (accept-any) is kept.
+	hostKey := ssh.InsecureIgnoreHostKey() // #nosec G106 - lab default, overridden by CONFIG_SSH_KNOWN_HOSTS below.
+	if khPath := os.Getenv("CONFIG_SSH_KNOWN_HOSTS"); khPath != "" {
+		cb, err := transport.LoadKnownHostsCallback(khPath)
+		if err != nil {
+			log.G(ctx).WithError(err).Error("netconf-probe: known_hosts load failed; skipping SSH phase rather than dialling unpinned")
+			log.G(ctx).Infof("netconf-probe: tick raw=%q ssh=SKIPPED(known_hosts)", rawSummary)
+			return
+		}
+		hostKey = cb
+	}
 	conf := &ssh.ClientConfig{
 		User:            user,
 		Auth:            []ssh.AuthMethod{ssh.Password(password)},
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		HostKeyCallback: hostKey,
 		Timeout:         10 * time.Second,
 	}
 	sshSummary := ""

--- a/docs/security.md
+++ b/docs/security.md
@@ -246,6 +246,23 @@ spec:
 
 The `certFile` / `keyFile` / `caFile` paths refer to files **inside the VK pod**. Mount them with a Secret-backed volume or a configMap-backed volume on the VK Deployment. The controller does not currently auto-mount them — you'll need a post-install patch or a forked chart.
 
+All device-facing clients honour the full `spec.tls` block through one shared
+builder: apphosting RESTCONF, the configdriver RESTCONF fallback, MDT-over-gNMI
+telemetry, gNOI, and the NX-API client on NX-OS. A `caFile` therefore gives you
+verified TLS on every path — `insecureSkipVerify: true` is never required just
+because a device uses a private CA.
+
+### SSH host keys
+
+NETCONF and the CLI side-channel ride SSH, not TLS. Pinning uses a standard
+OpenSSH `known_hosts` file (multi-host files cover a fleet). Ship it into the
+VK pod with a Secret- or ConfigMap-backed volume and point
+`CONFIG_SSH_KNOWN_HOSTS` at the mounted path; the NETCONF diagnostic probe
+(`CONFIG_NETCONF_PROBE`) then pins its dials against it and refuses to dial
+unpinned if the file fails to load. Without the variable the probe keeps the
+historical lab default of accepting any presented key — as with
+`insecureSkipVerify`, do not rely on that in production.
+
 ### Kubelet-side TLS
 
 The VK runs its own HTTPS listener on `:10250` (serving the kubelet API surface). By default it auto-generates a self-signed cert on every start into `/var/lib/virtual-kubelet/`. Override with:

--- a/internal/drivers/iosxe/configdriver/transport/factory.go
+++ b/internal/drivers/iosxe/configdriver/transport/factory.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/grpc"
 
 	ciskov1 "github.com/cisco/virtual-kubelet-cisco/api/v1alpha1"
+	"github.com/cisco/virtual-kubelet-cisco/internal/tlsutil"
 )
 
 // FactoryOptions carries construction-time parameters that are not part
@@ -126,7 +127,11 @@ func buildGNMI(spec *ciskov1.DeviceSpec, pass string, opts FactoryOptions) (Inte
 	// (2026-04-28) where the gNMI client got
 	// `transport: authentication handshake failed` against gnxi:50052.
 	if spec.TLS != nil && spec.TLS.Enabled && port != 50052 {
-		cfg.TLSConfig = buildTLSFromSpec(spec)
+		tlsCfg, err := buildTLSFromSpec(spec)
+		if err != nil {
+			return nil, fmt.Errorf("transport.For: gNMI TLS from spec: %w", err)
+		}
+		cfg.TLSConfig = tlsCfg
 	}
 	return NewGNMI(cfg)
 }
@@ -191,9 +196,13 @@ func buildRESTCONF(spec *ciskov1.DeviceSpec, pass string, opts FactoryOptions) (
 		if timeout == 0 {
 			timeout = 30 * time.Second
 		}
+		tlsCfg, err := buildTLSFromSpec(spec)
+		if err != nil {
+			return nil, fmt.Errorf("transport.For: RESTCONF TLS from spec: %w", err)
+		}
 		httpClient = &http.Client{
 			Timeout:   timeout,
-			Transport: &http.Transport{TLSClientConfig: buildTLSFromSpec(spec)},
+			Transport: &http.Transport{TLSClientConfig: tlsCfg},
 		}
 	}
 
@@ -213,17 +222,11 @@ func buildRESTCONF(spec *ciskov1.DeviceSpec, pass string, opts FactoryOptions) (
 	})
 }
 
-// buildTLSFromSpec mirrors the existing apphosting driver's behaviour:
-// honours InsecureSkipVerify but does not load client certs here (the
-// apphosting driver does, and the intent is for its HTTP client to be
-// passed in via FactoryOptions). This fallback keeps tests and
-// local-dev configurations simple.
-func buildTLSFromSpec(spec *ciskov1.DeviceSpec) *tls.Config {
-	if spec.TLS == nil {
-		return &tls.Config{MinVersion: tls.VersionTLS12}
-	}
-	return &tls.Config{
-		MinVersion:         tls.VersionTLS12,
-		InsecureSkipVerify: spec.TLS.InsecureSkipVerify,
-	}
+// buildTLSFromSpec matches the apphosting driver's behaviour: the shared
+// helper honours InsecureSkipVerify, loads spec.tls.caFile into RootCAs
+// (so private-CA devices get verified TLS on this path too, instead of
+// being forced to skip-verify), and loads the certFile/keyFile client
+// pair when both are set.
+func buildTLSFromSpec(spec *ciskov1.DeviceSpec) (*tls.Config, error) {
+	return tlsutil.ClientTLSFromDeviceTLS(spec.TLS)
 }

--- a/internal/drivers/iosxe/configdriver/transport/factory_tls_test.go
+++ b/internal/drivers/iosxe/configdriver/transport/factory_tls_test.go
@@ -1,0 +1,39 @@
+// Copyright © 2026 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package transport
+
+import (
+	"crypto/tls"
+	"testing"
+
+	ciskov1 "github.com/cisco/virtual-kubelet-cisco/api/v1alpha1"
+)
+
+// TestBuildTLSFromSpec covers the wiring into the shared device-client TLS
+// builder: skip-verify passthrough, the TLS 1.2 floor, and — the reason the
+// signature carries an error — fail-fast on an unreadable caFile instead of
+// silently building an unverified config. Positive CA/RootCAs coverage lives
+// with the shared helper in internal/tlsutil.
+func TestBuildTLSFromSpec(t *testing.T) {
+	cfg, err := buildTLSFromSpec(&ciskov1.DeviceSpec{
+		TLS: &ciskov1.TLSConfig{Enabled: true, InsecureSkipVerify: true},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.InsecureSkipVerify || cfg.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("unexpected config: skip=%v min=%d", cfg.InsecureSkipVerify, cfg.MinVersion)
+	}
+
+	if _, err := buildTLSFromSpec(&ciskov1.DeviceSpec{
+		TLS: &ciskov1.TLSConfig{Enabled: true, CAFile: "/nonexistent/cvk-ca.pem"},
+	}); err == nil {
+		t.Fatal("expected error for unreadable caFile, got nil")
+	}
+}

--- a/internal/drivers/iosxe/telemetry/factory.go
+++ b/internal/drivers/iosxe/telemetry/factory.go
@@ -33,6 +33,7 @@ import (
 	ciskov1 "github.com/cisco/virtual-kubelet-cisco/api/v1alpha1"
 	"github.com/cisco/virtual-kubelet-cisco/internal/drivers/iosxe/configdriver/transport"
 	"github.com/cisco/virtual-kubelet-cisco/internal/drivers/iosxe/devicegrpc"
+	"github.com/cisco/virtual-kubelet-cisco/internal/tlsutil"
 )
 
 // SubscribeClientFactory creates the dedicated gRPC client used by the
@@ -115,7 +116,11 @@ func GNMIConfigFromDeviceSpec(spec *ciskov1.DeviceSpec, password string) (transp
 		Password: password,
 	}
 	if tlsEnabled {
-		cfg.TLSConfig = tlsConfigFromDeviceSpec(spec)
+		tlsCfg, err := tlsConfigFromDeviceSpec(spec)
+		if err != nil {
+			return transport.GNMIConfig{}, fmt.Errorf("telemetry: gNMI TLS from spec: %w", err)
+		}
+		cfg.TLSConfig = tlsCfg
 	}
 	return cfg, nil
 }
@@ -206,12 +211,10 @@ func authContextFunc(username, password string) func(context.Context) context.Co
 	}
 }
 
-func tlsConfigFromDeviceSpec(spec *ciskov1.DeviceSpec) *tls.Config {
-	if spec.TLS == nil {
-		return &tls.Config{MinVersion: tls.VersionTLS12}
-	}
-	return &tls.Config{
-		MinVersion:         tls.VersionTLS12,
-		InsecureSkipVerify: spec.TLS.InsecureSkipVerify,
-	}
+// tlsConfigFromDeviceSpec delegates to the shared device-client helper so
+// the MDT-over-gNMI path honours spec.tls.caFile (RootCAs) and the
+// certFile/keyFile client pair, matching the apphosting driver, instead of
+// only supporting skip-verify.
+func tlsConfigFromDeviceSpec(spec *ciskov1.DeviceSpec) (*tls.Config, error) {
+	return tlsutil.ClientTLSFromDeviceTLS(spec.TLS)
 }

--- a/internal/drivers/iosxe/telemetry/factory_tls_test.go
+++ b/internal/drivers/iosxe/telemetry/factory_tls_test.go
@@ -1,0 +1,38 @@
+// Copyright © 2026 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package telemetry
+
+import (
+	"crypto/tls"
+	"testing"
+
+	ciskov1 "github.com/cisco/virtual-kubelet-cisco/api/v1alpha1"
+)
+
+// TestTLSConfigFromDeviceSpec mirrors the transport-package coverage for the
+// MDT-over-gNMI path: skip-verify passthrough with the TLS 1.2 floor, and
+// fail-fast on an unreadable caFile. Positive CA/RootCAs coverage lives with
+// the shared helper in internal/tlsutil.
+func TestTLSConfigFromDeviceSpec(t *testing.T) {
+	cfg, err := tlsConfigFromDeviceSpec(&ciskov1.DeviceSpec{
+		TLS: &ciskov1.TLSConfig{Enabled: true, InsecureSkipVerify: true},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.InsecureSkipVerify || cfg.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("unexpected config: skip=%v min=%d", cfg.InsecureSkipVerify, cfg.MinVersion)
+	}
+
+	if _, err := tlsConfigFromDeviceSpec(&ciskov1.DeviceSpec{
+		TLS: &ciskov1.TLSConfig{Enabled: true, CAFile: "/nonexistent/cvk-ca.pem"},
+	}); err == nil {
+		t.Fatal("expected error for unreadable caFile, got nil")
+	}
+}

--- a/internal/drivers/nxos/client.go
+++ b/internal/drivers/nxos/client.go
@@ -17,6 +17,7 @@ package nxos
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -63,15 +64,17 @@ func newNXAPIClientWithOptions(spec *v1alpha1.DeviceSpec, opts nxapiClientOption
 	}
 	scheme := "http"
 	defaultPort := 80
-	// Shared device-client helper: TLS 1.2 minimum, InsecureSkipVerify
-	// copied verbatim (operator-controlled for lab devices), spec.tls.caFile
-	// loaded into RootCAs so private-CA Nexus front panels verify, and the
-	// certFile/keyFile client pair when both are set.
-	tlsConfig, err := tlsutil.ClientTLSFromDeviceTLS(spec.TLS) // #nosec G402 - InsecureSkipVerify is operator-controlled.
-	if err != nil {
-		return nil, fmt.Errorf("nxos nxapi: TLS from spec: %w", err)
-	}
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
 	if spec.TLS != nil && spec.TLS.Enabled {
+		// Shared device-client helper: TLS 1.2 minimum, InsecureSkipVerify
+		// copied verbatim (operator-controlled for lab devices), spec.tls.caFile
+		// loaded into RootCAs so private-CA Nexus front panels verify, and the
+		// certFile/keyFile client pair when both are set.
+		var err error
+		tlsConfig, err = tlsutil.ClientTLSFromDeviceTLS(spec.TLS) // #nosec G402 - InsecureSkipVerify is operator-controlled.
+		if err != nil {
+			return nil, fmt.Errorf("nxos nxapi: TLS from spec: %w", err)
+		}
 		scheme = "https"
 		defaultPort = 443
 	}

--- a/internal/drivers/nxos/client.go
+++ b/internal/drivers/nxos/client.go
@@ -17,7 +17,6 @@ package nxos
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -29,6 +28,7 @@ import (
 	"time"
 
 	"github.com/cisco/virtual-kubelet-cisco/api/v1alpha1"
+	"github.com/cisco/virtual-kubelet-cisco/internal/tlsutil"
 )
 
 const (
@@ -63,11 +63,17 @@ func newNXAPIClientWithOptions(spec *v1alpha1.DeviceSpec, opts nxapiClientOption
 	}
 	scheme := "http"
 	defaultPort := 80
-	tlsConfig := &tls.Config{} // #nosec G402 - InsecureSkipVerify is operator-controlled for lab devices.
+	// Shared device-client helper: TLS 1.2 minimum, InsecureSkipVerify
+	// copied verbatim (operator-controlled for lab devices), spec.tls.caFile
+	// loaded into RootCAs so private-CA Nexus front panels verify, and the
+	// certFile/keyFile client pair when both are set.
+	tlsConfig, err := tlsutil.ClientTLSFromDeviceTLS(spec.TLS) // #nosec G402 - InsecureSkipVerify is operator-controlled.
+	if err != nil {
+		return nil, fmt.Errorf("nxos nxapi: TLS from spec: %w", err)
+	}
 	if spec.TLS != nil && spec.TLS.Enabled {
 		scheme = "https"
 		defaultPort = 443
-		tlsConfig.InsecureSkipVerify = spec.TLS.InsecureSkipVerify // #nosec G402
 	}
 	port := spec.Port
 	if port == 0 {

--- a/internal/drivers/nxos/client_tls_test.go
+++ b/internal/drivers/nxos/client_tls_test.go
@@ -43,4 +43,13 @@ func TestNXAPIClientTLSFromSpec(t *testing.T) {
 	}); err == nil {
 		t.Fatal("expected error for unreadable caFile, got nil")
 	}
+
+	if c, err := newNXAPIClient(&v1alpha1.DeviceSpec{
+		Address: "192.0.2.9",
+		TLS:     &v1alpha1.TLSConfig{Enabled: false, CAFile: "/nonexistent/cvk-ca.pem"},
+	}); err != nil {
+		t.Fatalf("disabled TLS loaded caFile: %v", err)
+	} else if c.rootURL != "http://192.0.2.9:80" {
+		t.Fatalf("disabled TLS root URL = %q, want HTTP", c.rootURL)
+	}
 }

--- a/internal/drivers/nxos/client_tls_test.go
+++ b/internal/drivers/nxos/client_tls_test.go
@@ -1,0 +1,46 @@
+// Copyright © 2026 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package nxos
+
+import (
+	"crypto/tls"
+	"net/http"
+	"testing"
+
+	"github.com/cisco/virtual-kubelet-cisco/api/v1alpha1"
+)
+
+// TestNXAPIClientTLSFromSpec asserts the NX-API HTTP client is built through
+// the shared device-client TLS helper: the TLS 1.2 floor and skip-verify
+// passthrough apply, and an unreadable caFile fails construction rather than
+// silently producing an unverified client.
+func TestNXAPIClientTLSFromSpec(t *testing.T) {
+	c, err := newNXAPIClient(&v1alpha1.DeviceSpec{
+		Address: "192.0.2.9",
+		TLS:     &v1alpha1.TLSConfig{Enabled: true, InsecureSkipVerify: true},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	tr, ok := c.client.Transport.(*http.Transport)
+	if !ok || tr.TLSClientConfig == nil {
+		t.Fatalf("expected *http.Transport with TLS config, got %#v", c.client.Transport)
+	}
+	if !tr.TLSClientConfig.InsecureSkipVerify || tr.TLSClientConfig.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("unexpected TLS config: skip=%v min=%d",
+			tr.TLSClientConfig.InsecureSkipVerify, tr.TLSClientConfig.MinVersion)
+	}
+
+	if _, err := newNXAPIClient(&v1alpha1.DeviceSpec{
+		Address: "192.0.2.9",
+		TLS:     &v1alpha1.TLSConfig{Enabled: true, CAFile: "/nonexistent/cvk-ca.pem"},
+	}); err == nil {
+		t.Fatal("expected error for unreadable caFile, got nil")
+	}
+}

--- a/internal/tlsutil/client.go
+++ b/internal/tlsutil/client.go
@@ -1,0 +1,70 @@
+// Copyright © 2026 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tlsutil
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+
+	ciskov1 "github.com/cisco/virtual-kubelet-cisco/api/v1alpha1"
+)
+
+// ClientTLSFromDeviceTLS builds the *tls.Config used by device-facing
+// clients (RESTCONF, gNMI, gNOI, NX-API) from a CiscoDevice spec.tls block.
+//
+// Semantics match the app-hosting driver, which was previously the only
+// consumer that honoured the full block:
+//   - MinVersion is always TLS 1.2.
+//   - InsecureSkipVerify is copied verbatim (operator-controlled).
+//   - CAFile, when set, is loaded into RootCAs so devices with private-CA
+//     certificates get verified TLS instead of forcing skip-verify.
+//   - CertFile/KeyFile, when both set, are loaded as the client pair
+//     (device-side mTLS).
+//
+// A nil block returns the TLS 1.2 default config. Errors are returned for
+// unreadable or unparseable files; callers should fail fast rather than
+// silently downgrade to an unverified connection.
+func ClientTLSFromDeviceTLS(t *ciskov1.TLSConfig) (*tls.Config, error) {
+	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
+	if t == nil {
+		return cfg, nil
+	}
+
+	cfg.InsecureSkipVerify = t.InsecureSkipVerify
+
+	if t.CertFile != "" && t.KeyFile != "" {
+		cert, err := tls.LoadX509KeyPair(t.CertFile, t.KeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load client certificate: %w", err)
+		}
+		cfg.Certificates = []tls.Certificate{cert}
+	}
+
+	if t.CAFile != "" {
+		caCert, err := os.ReadFile(t.CAFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA certificate: %w", err)
+		}
+		caCertPool := x509.NewCertPool()
+		if !caCertPool.AppendCertsFromPEM(caCert) {
+			return nil, fmt.Errorf("failed to parse CA certificate from %q", t.CAFile)
+		}
+		cfg.RootCAs = caCertPool
+	}
+
+	return cfg, nil
+}

--- a/internal/tlsutil/client_test.go
+++ b/internal/tlsutil/client_test.go
@@ -1,0 +1,125 @@
+// Copyright © 2026 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package tlsutil
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	ciskov1 "github.com/cisco/virtual-kubelet-cisco/api/v1alpha1"
+)
+
+// writeTestCA writes a freshly generated self-signed CA certificate PEM to
+// dir and returns its path.
+func writeTestCA(t *testing.T, dir string) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "cvk-test-ca"},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	path := filepath.Join(dir, "ca.pem")
+	if err := os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600); err != nil {
+		t.Fatalf("write CA pem: %v", err)
+	}
+	return path
+}
+
+func TestClientTLSFromDeviceTLS(t *testing.T) {
+	dir := t.TempDir()
+	caPath := writeTestCA(t, dir)
+	badPEM := filepath.Join(dir, "not-a-cert.pem")
+	if err := os.WriteFile(badPEM, []byte("this is not PEM"), 0o600); err != nil {
+		t.Fatalf("write bad pem: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		in          *ciskov1.TLSConfig
+		wantErr     bool
+		wantRootCAs bool
+		wantSkip    bool
+	}{
+		{
+			name: "nil spec yields TLS 1.2 default",
+			in:   nil,
+		},
+		{
+			name:     "insecureSkipVerify is copied",
+			in:       &ciskov1.TLSConfig{Enabled: true, InsecureSkipVerify: true},
+			wantSkip: true,
+		},
+		{
+			name:        "caFile is loaded into RootCAs",
+			in:          &ciskov1.TLSConfig{Enabled: true, CAFile: caPath},
+			wantRootCAs: true,
+		},
+		{
+			name:    "missing caFile is an error",
+			in:      &ciskov1.TLSConfig{Enabled: true, CAFile: filepath.Join(dir, "absent.pem")},
+			wantErr: true,
+		},
+		{
+			name:    "unparseable caFile is an error",
+			in:      &ciskov1.TLSConfig{Enabled: true, CAFile: badPEM},
+			wantErr: true,
+		},
+		{
+			name:    "mismatched client pair is an error",
+			in:      &ciskov1.TLSConfig{Enabled: true, CertFile: caPath, KeyFile: badPEM},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := ClientTLSFromDeviceTLS(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got config %#v", cfg)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cfg.MinVersion != tls.VersionTLS12 {
+				t.Errorf("MinVersion = %d, want TLS 1.2", cfg.MinVersion)
+			}
+			if got := cfg.RootCAs != nil; got != tc.wantRootCAs {
+				t.Errorf("RootCAs set = %v, want %v", got, tc.wantRootCAs)
+			}
+			if cfg.InsecureSkipVerify != tc.wantSkip {
+				t.Errorf("InsecureSkipVerify = %v, want %v", cfg.InsecureSkipVerify, tc.wantSkip)
+			}
+		})
+	}
+}


### PR DESCRIPTION
docs/security.md documents spec.tls (caFile, certFile/keyFile,
insecureSkipVerify) as the device-side TLS contract, but only the
apphosting RESTCONF driver honoured the full block. The configdriver
RESTCONF fallback, MDT-over-gNMI telemetry, gNOI, and the NX-API client
each built a bare skip-verify-or-nothing config, so a device with a
private-CA certificate could only be reached by disabling verification
on those paths.

- New internal/tlsutil.ClientTLSFromDeviceTLS is the shared device-client
  builder: TLS 1.2 floor, InsecureSkipVerify copied verbatim, caFile
  loaded into RootCAs, certFile/keyFile loaded as the client pair when
  both are set. Semantics match the apphosting driver; errors are
  returned so callers fail fast instead of silently downgrading.
- transport.buildTLSFromSpec, telemetry.tlsConfigFromDeviceSpec, the gNOI
  dial wiring, and the NX-API client now delegate to it, threading the
  new error at each call site. The NX-API path also gains the TLS 1.2
  floor it previously lacked.
- The NETCONF diagnostic probe (CONFIG_NETCONF_PROBE) dialled with
  ssh.InsecureIgnoreHostKey() unconditionally while authenticating with
  real device credentials. It now honours CONFIG_SSH_KNOWN_HOSTS via the
  existing transport.LoadKnownHostsCallback, and on a load failure skips
  the SSH phase rather than dialling unpinned. Unset keeps the historical
  lab default. Wiring known_hosts into the production NETCONF/CLI
  transports (a FactoryOptions field) is intentionally left as a
  follow-up; this change stops the probe from being the counterexample.
- docs/security.md: note that all device paths honour the full spec.tls
  block, and add an SSH host keys subsection for CONFIG_SSH_KNOWN_HOSTS.

Tests: a table test for the shared builder (generated CA loads into
RootCAs; missing/unparseable caFile and mismatched client pair error;
skip-verify and the 1.2 floor asserted), plus per-consumer tests in the
transport, telemetry, and nxos packages asserting the wiring propagates
skip-verify/MinVersion and fails fast on an unreadable caFile. No
existing tests referenced the changed internal signatures.

Verified here: gofmt -e parses all edited files; gofmt -l clean for the
touched set. The unit suite runs in this PR's CI.

