### PR TITLE
ci: run native lab tests after PR approval

### DIFF
--- a/.github/scripts/dispatch-approved-lab-ci.py
+++ b/.github/scripts/dispatch-approved-lab-ci.py
@@ -45,7 +45,6 @@ GITHUB_API = "https://api.github.com"
 GITHUB_ACTIONS_APP_ID = 15368
 GITHUB_ACTIONS_BOT_ID = 41898282
 REQUIRED_CHECKS = ("build-and-smoke", "ygot-validate")
-TRUSTED_REVIEW_ASSOCIATIONS = {"COLLABORATOR", "MEMBER", "OWNER"}
 OPINIONATED_REVIEW_STATES = {"APPROVED", "CHANGES_REQUESTED", "DISMISSED"}
 ACTIVE_WORKFLOW_STATES = {"in_progress", "pending", "queued", "requested", "waiting"}
 MAX_API_PAGES = 100
@@ -237,9 +236,7 @@ def _verify_review(
     approval_candidates = [
         review
         for review in latest.values()
-        if review.get("state") == "APPROVED"
-        and review.get("commit_id") == head_sha
-        and review.get("author_association") in TRUSTED_REVIEW_ASSOCIATIONS
+        if review.get("state") == "APPROVED" and review.get("commit_id") == head_sha
     ]
     for review in approval_candidates:
         login = (review.get("user") or {}).get("login", "")

--- a/.github/scripts/dispatch-approved-lab-ci.py
+++ b/.github/scripts/dispatch-approved-lab-ci.py
@@ -1,0 +1,775 @@
+#!/usr/bin/env python3
+# Copyright 2026 Cisco Systems Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Gate and dispatch native Lab CI for approved pull requests.
+
+The reconciler runs only from trusted ``main``.  It never checks out pull
+request code.  Before dispatching a credentialed lab wrapper it verifies the
+current PR head and base, an approval for that head, and the two protected
+GitHub-hosted checks.  The same verification is also called by each wrapper's
+``prepare`` job and again on the lab runner immediately before submission.
+Those checks close queue-time races and protect manual workflow dispatches.
+
+Required environment variables:
+  GH_TOKEN  Built-in token for the current repository.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import asdict, dataclass
+from typing import Any, Callable
+
+
+GITHUB_API = "https://api.github.com"
+GITHUB_ACTIONS_APP_ID = 15368
+GITHUB_ACTIONS_BOT_ID = 41898282
+REQUIRED_CHECKS = ("build-and-smoke", "ygot-validate")
+TRUSTED_REVIEW_ASSOCIATIONS = {"COLLABORATOR", "MEMBER", "OWNER"}
+OPINIONATED_REVIEW_STATES = {"APPROVED", "CHANGES_REQUESTED", "DISMISSED"}
+ACTIVE_WORKFLOW_STATES = {"in_progress", "pending", "queued", "requested", "waiting"}
+MAX_API_PAGES = 100
+MAX_AUTOMATIC_DISPATCH_ATTEMPTS = 3
+RETRY_CONFIRMATION_SECONDS = 10 * 60
+STALE_PENDING_SECONDS = 12 * 60 * 60
+STATUS_DESCRIPTION_LIMIT = 140
+
+TARGETS: tuple[dict[str, str], ...] = (
+    {
+        "key": "cat8kv",
+        "context": "lab-ci-next / cat8kv",
+        "description": "Approved PR queued for Cat8kv",
+        "run_title": "Lab CI Cat8kv",
+        "workflow": "lab-ci-cat8kv.yaml",
+    },
+    {
+        "key": "cat9k",
+        "context": "lab-ci-next / cat9k",
+        "description": "Approved PR queued for Cat9k",
+        "run_title": "Lab CI Cat9k",
+        "workflow": "lab-ci-cat9k.yaml",
+    },
+)
+
+REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+PR_RE = re.compile(r"^[1-9][0-9]*$")
+
+
+class GateError(RuntimeError):
+    """The pull request is not currently eligible for native Lab CI."""
+
+
+@dataclass(frozen=True)
+class VerifiedPullRequest:
+    pr_number: int
+    head_sha: str
+    base_sha: str
+    merge_sha: str
+
+
+ApiCall = Callable[..., Any]
+
+
+def validate_repository(repository: str) -> str:
+    if not REPOSITORY_RE.fullmatch(repository):
+        raise GateError(f"invalid repository: {repository!r}")
+    return repository
+
+
+def validate_sha(name: str, value: str) -> str:
+    if not SHA_RE.fullmatch(value):
+        raise GateError(f"invalid {name}: {value!r}")
+    return value
+
+
+def validate_pr_number(value: str | int) -> int:
+    rendered = str(value)
+    if not PR_RE.fullmatch(rendered):
+        raise GateError(f"invalid PR number: {rendered!r}")
+    return int(rendered)
+
+
+def api(
+    path: str,
+    method: str = "GET",
+    body: dict[str, Any] | None = None,
+    token: str | None = None,
+) -> Any:
+    """Call the GitHub REST API and decode a JSON response."""
+    if not path.startswith("/"):
+        raise ValueError("GitHub API paths must start with '/'")
+    auth_token = token if token is not None else os.environ.get("GH_TOKEN", "")
+    if not auth_token:
+        raise GateError("GH_TOKEN is required")
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {auth_token}",
+        "Content-Type": "application/json",
+        "User-Agent": "cisco-virtual-kubelet-approved-lab-ci",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    request = urllib.request.Request(
+        f"{GITHUB_API}{path}",
+        data=data,
+        headers=headers,
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = response.read()
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode("utf-8", errors="replace")[:500]
+        raise GateError(
+            f"GitHub API {method} {path} failed with HTTP {error.code}: {detail}"
+        ) from error
+    except urllib.error.URLError as error:
+        raise GateError(f"GitHub API {method} {path} failed: {error.reason}") from error
+    return json.loads(payload) if payload else None
+
+
+def _get_pull_request(
+    repository: str,
+    pr_number: int,
+    api_call: ApiCall,
+    sleep: Callable[[float], None],
+) -> dict[str, Any]:
+    """Fetch a PR, retrying briefly while GitHub computes mergeability."""
+    pull: dict[str, Any] = {}
+    for attempt in range(1, 6):
+        pull = api_call(f"/repos/{repository}/pulls/{pr_number}")
+        if pull.get("mergeable") is not None:
+            return pull
+        sleep(float(attempt * 2))
+    raise GateError(f"PR #{pr_number}: GitHub did not compute mergeability")
+
+
+def _paginated_items(
+    path: str,
+    *,
+    api_call: ApiCall,
+    response_key: str | None = None,
+) -> list[dict[str, Any]]:
+    """Read every page of a list endpoint, rejecting unsafe truncation."""
+    items: list[dict[str, Any]] = []
+    separator = "&" if "?" in path else "?"
+    for page in range(1, MAX_API_PAGES + 1):
+        response = api_call(f"{path}{separator}per_page=100&page={page}")
+        batch = response if response_key is None else (response or {}).get(response_key)
+        if not isinstance(batch, list):
+            raise GateError(f"GitHub API {path} returned an invalid paginated response")
+        items.extend(batch)
+        if len(batch) < 100:
+            return items
+    raise GateError(f"GitHub API {path} exceeded the pagination safety limit")
+
+
+def _latest_reviews_by_user(reviews: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    latest: dict[str, dict[str, Any]] = {}
+    for review in reviews:
+        # COMMENTED and PENDING reviews do not change a reviewer's approval or
+        # change-request state. GitHub's aggregate reviewDecision follows the
+        # same opinionated-review semantics.
+        if review.get("state") not in OPINIONATED_REVIEW_STATES:
+            continue
+        login = (review.get("user") or {}).get("login")
+        if not login:
+            continue
+        previous = latest.get(login)
+        if previous is None or int(review.get("id") or 0) > int(
+            previous.get("id") or 0
+        ):
+            latest[login] = review
+    return latest
+
+
+def _verify_review(
+    repository: str,
+    reviews: list[dict[str, Any]],
+    head_sha: str,
+    pr_number: int,
+    api_call: ApiCall,
+) -> None:
+    owner, name = repository.split("/", 1)
+    decision_data = api_call(
+        "/graphql",
+        method="POST",
+        body={
+            "query": """
+                query($owner: String!, $name: String!, $number: Int!) {
+                  repository(owner: $owner, name: $name) {
+                    pullRequest(number: $number) { reviewDecision }
+                  }
+                }
+            """,
+            "variables": {"owner": owner, "name": name, "number": pr_number},
+        },
+    )
+    pull_request_data = (
+        ((decision_data or {}).get("data") or {}).get("repository") or {}
+    ).get("pullRequest") or {}
+    decision = pull_request_data.get("reviewDecision")
+    if decision != "APPROVED":
+        raise GateError(f"PR #{pr_number}: aggregate review decision is {decision!r}")
+
+    latest = _latest_reviews_by_user(reviews)
+    approval_candidates = [
+        review
+        for review in latest.values()
+        if review.get("state") == "APPROVED"
+        and review.get("commit_id") == head_sha
+        and review.get("author_association") in TRUSTED_REVIEW_ASSOCIATIONS
+    ]
+    for review in approval_candidates:
+        login = (review.get("user") or {}).get("login", "")
+        permission = api_call(
+            f"/repos/{repository}/collaborators/"
+            f"{urllib.parse.quote(login, safe='')}/permission"
+        )
+        if permission.get("permission") in {"admin", "write"}:
+            return
+
+    if not approval_candidates:
+        raise GateError(
+            f"PR #{pr_number}: no trusted approval applies to current head {head_sha}"
+        )
+    raise GateError(
+        f"PR #{pr_number}: current-head approver does not have write permission"
+    )
+
+
+def _verify_required_checks(
+    check_runs: list[dict[str, Any]], head_sha: str, pr_number: int
+) -> None:
+    for required_name in REQUIRED_CHECKS:
+        candidates = [
+            run
+            for run in check_runs
+            if run.get("name") == required_name
+            and (run.get("app") or {}).get("id") == GITHUB_ACTIONS_APP_ID
+            and run.get("head_sha") == head_sha
+        ]
+        if not candidates:
+            raise GateError(
+                f"PR #{pr_number}: required check {required_name!r} is missing"
+            )
+        latest = max(candidates, key=lambda run: int(run.get("id") or 0))
+        if latest.get("status") != "completed" or latest.get("conclusion") != "success":
+            raise GateError(
+                f"PR #{pr_number}: required check {required_name!r} is not successful"
+            )
+
+
+def verify_pull_request(
+    repository: str,
+    pr_number: str | int,
+    expected_head_sha: str | None = None,
+    expected_base_sha: str | None = None,
+    expected_merge_sha: str | None = None,
+    *,
+    api_call: ApiCall = api,
+    sleep: Callable[[float], None] = time.sleep,
+) -> VerifiedPullRequest:
+    """Return pinned PR inputs after every trust and readiness check passes."""
+    repository = validate_repository(repository)
+    number = validate_pr_number(pr_number)
+    if expected_head_sha is not None:
+        expected_head_sha = validate_sha("expected head SHA", expected_head_sha)
+    if expected_base_sha is not None:
+        expected_base_sha = validate_sha("expected base SHA", expected_base_sha)
+    if expected_merge_sha is not None:
+        expected_merge_sha = validate_sha("expected merge SHA", expected_merge_sha)
+
+    pull = _get_pull_request(repository, number, api_call, sleep)
+    if pull.get("state") != "open":
+        raise GateError(f"PR #{number}: PR is not open")
+    if pull.get("draft") is not False:
+        raise GateError(f"PR #{number}: draft PRs are not eligible")
+    if (pull.get("base") or {}).get("ref") != "main":
+        raise GateError(f"PR #{number}: base branch is not main")
+    if ((pull.get("base") or {}).get("repo") or {}).get("full_name") != repository:
+        raise GateError(f"PR #{number}: base repository does not match {repository}")
+    if pull.get("mergeable") is not True:
+        raise GateError(f"PR #{number}: PR is not mergeable")
+
+    head_sha = validate_sha("PR head SHA", (pull.get("head") or {}).get("sha", ""))
+    base_sha = validate_sha("PR base SHA", (pull.get("base") or {}).get("sha", ""))
+    merge_sha = validate_sha("prospective merge SHA", pull.get("merge_commit_sha", ""))
+    if head_sha == merge_sha:
+        raise GateError(f"PR #{number}: prospective merge SHA equals head SHA")
+    if expected_head_sha is not None and head_sha != expected_head_sha:
+        raise GateError(
+            f"PR #{number}: head changed from {expected_head_sha} to {head_sha}"
+        )
+    if expected_base_sha is not None and base_sha != expected_base_sha:
+        raise GateError(
+            f"PR #{number}: base changed from {expected_base_sha} to {base_sha}"
+        )
+    if expected_merge_sha is not None and merge_sha != expected_merge_sha:
+        raise GateError(
+            f"PR #{number}: prospective merge changed from {expected_merge_sha} to {merge_sha}"
+        )
+
+    main = api_call(f"/repos/{repository}/branches/main")
+    current_main_sha = validate_sha(
+        "current main SHA", (main.get("commit") or {}).get("sha", "")
+    )
+    if base_sha != current_main_sha:
+        raise GateError(
+            f"PR #{number}: base {base_sha} is not current main {current_main_sha}"
+        )
+
+    comparison = api_call(f"/repos/{repository}/compare/{base_sha}...{head_sha}") or {}
+    if comparison.get("behind_by") != 0:
+        raise GateError(f"PR #{number}: branch is not up to date with main")
+
+    reviews = _paginated_items(
+        f"/repos/{repository}/pulls/{number}/reviews",
+        api_call=api_call,
+    )
+    _verify_review(repository, reviews, head_sha, number, api_call)
+
+    check_runs = _paginated_items(
+        f"/repos/{repository}/commits/{head_sha}/check-runs",
+        api_call=api_call,
+        response_key="check_runs",
+    )
+    _verify_required_checks(check_runs, head_sha, number)
+
+    # Close the verification race before returning inputs to a dispatcher.
+    refreshed = api_call(f"/repos/{repository}/pulls/{number}")
+    if (refreshed.get("head") or {}).get("sha") != head_sha:
+        raise GateError(f"PR #{number}: head changed during verification")
+    if (refreshed.get("base") or {}).get("sha") != base_sha:
+        raise GateError(f"PR #{number}: base changed during verification")
+    if refreshed.get("merge_commit_sha") != merge_sha:
+        raise GateError(f"PR #{number}: prospective merge changed during verification")
+    refreshed_main = api_call(f"/repos/{repository}/branches/main")
+    if (refreshed_main.get("commit") or {}).get("sha") != base_sha:
+        raise GateError(f"PR #{number}: main changed during verification")
+
+    return VerifiedPullRequest(number, head_sha, base_sha, merge_sha)
+
+
+def list_open_pr_numbers(repository: str, *, api_call: ApiCall = api) -> list[int]:
+    pulls = _paginated_items(
+        f"/repos/{repository}/pulls?state=open&base=main",
+        api_call=api_call,
+    )
+    return [validate_pr_number(pull.get("number", "")) for pull in pulls]
+
+
+def native_status_history(
+    repository: str, head_sha: str, *, api_call: ApiCall = api
+) -> dict[str, list[dict[str, Any]]]:
+    wanted = {target["context"] for target in TARGETS}
+    history = {context: [] for context in wanted}
+    statuses = _paginated_items(
+        f"/repos/{repository}/statuses/{head_sha}",
+        api_call=api_call,
+    )
+    for status in statuses:
+        context = status.get("context", "")
+        if context in wanted:
+            history[context].append(status)
+    for context in history:
+        history[context].sort(
+            key=lambda status: int(status.get("id") or 0), reverse=True
+        )
+    return history
+
+
+def status_pin(verified: VerifiedPullRequest) -> str:
+    return f"base={verified.base_sha}; merge={verified.merge_sha}"
+
+
+def status_is_for_verified_merge(
+    status: dict[str, Any], verified: VerifiedPullRequest
+) -> bool:
+    return status_pin(verified) in str(status.get("description") or "")
+
+
+def dispatch_id(
+    verified: VerifiedPullRequest, target: dict[str, str], attempt: int
+) -> str:
+    if attempt < 1 or attempt > MAX_AUTOMATIC_DISPATCH_ATTEMPTS:
+        raise GateError(f"invalid automatic dispatch attempt: {attempt}")
+    return (
+        f"{target['key']}-pr{verified.pr_number}"
+        f"-h{verified.head_sha[:12]}-b{verified.base_sha[:12]}"
+        f"-m{verified.merge_sha[:12]}-a{attempt}"
+    )
+
+
+def dispatch_run_title(
+    verified: VerifiedPullRequest, target: dict[str, str], attempt: int
+) -> str:
+    return f"{target['run_title']} - {dispatch_id(verified, target, attempt)}"
+
+
+def _status_attempt(status: dict[str, Any]) -> int | None:
+    match = re.search(
+        r"(?:^|; )try=([1-9][0-9]*)(?:;|$)", str(status.get("description") or "")
+    )
+    return int(match.group(1)) if match else None
+
+
+def _automatic_dispatch_attempts(
+    statuses: list[dict[str, Any]],
+    target: dict[str, str],
+    verified: VerifiedPullRequest,
+) -> int:
+    return sum(
+        1
+        for status in statuses
+        if status_is_for_verified_merge(status, verified)
+        and str(status.get("description") or "").startswith(target["description"])
+    )
+
+
+def _has_active_correlated_run(
+    repository: str,
+    verified: VerifiedPullRequest,
+    target: dict[str, str],
+    attempt: int,
+    *,
+    api_call: ApiCall,
+) -> bool:
+    expected_title = dispatch_run_title(verified, target, attempt)
+    workflow = urllib.parse.quote(target["workflow"], safe="")
+    runs = _paginated_items(
+        f"/repos/{repository}/actions/workflows/{workflow}/runs"
+        "?event=workflow_dispatch&branch=main",
+        api_call=api_call,
+        response_key="workflow_runs",
+    )
+    return any(
+        run.get("display_title") == expected_title
+        and run.get("status") in ACTIVE_WORKFLOW_STATES
+        for run in runs
+    )
+
+
+def _is_trusted_terminal_status(
+    repository: str,
+    status: dict[str, Any],
+    verified: VerifiedPullRequest,
+    target: dict[str, str],
+    *,
+    api_call: ApiCall,
+) -> bool:
+    attempt = _status_attempt(status)
+    creator_id = int(((status.get("creator") or {}).get("id") or 0))
+    run_id = _workflow_run_id(repository, str(status.get("target_url") or ""))
+    if attempt is None or creator_id != GITHUB_ACTIONS_BOT_ID or run_id is None:
+        return False
+    run = api_call(f"/repos/{repository}/actions/runs/{run_id}") or {}
+    run_path = str(run.get("path") or "").split("@", 1)[0]
+    return (
+        int(run.get("id") or 0) == run_id
+        and run.get("event") == "workflow_dispatch"
+        and run.get("head_branch") == "main"
+        and run.get("head_sha") == verified.base_sha
+        and run_path == f".github/workflows/{target['workflow']}"
+        and run.get("display_title") == dispatch_run_title(verified, target, attempt)
+    )
+
+
+def _status_age_seconds(status: dict[str, Any], now: datetime.datetime) -> float | None:
+    rendered = str(status.get("created_at") or "")
+    try:
+        created = datetime.datetime.fromisoformat(rendered.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if created.tzinfo is None:
+        created = created.replace(tzinfo=datetime.timezone.utc)
+    return max(0.0, (now - created).total_seconds())
+
+
+def _workflow_run_id(repository: str, target_url: str) -> int | None:
+    match = re.fullmatch(
+        rf"https://github\.com/{re.escape(repository)}/actions/runs/([1-9][0-9]*)",
+        target_url,
+    )
+    return int(match.group(1)) if match else None
+
+
+def status_blocks_automatic_dispatch(
+    repository: str,
+    statuses: list[dict[str, Any]],
+    target: dict[str, str],
+    verified: VerifiedPullRequest,
+    *,
+    api_call: ApiCall = api,
+    now: datetime.datetime | None = None,
+) -> bool:
+    """Return whether the latest exact-pin status should suppress a dispatch."""
+    if not statuses:
+        return False
+    latest = statuses[0]
+    if not status_is_for_verified_merge(latest, verified):
+        return False
+
+    state = str(latest.get("state") or "")
+    description = str(latest.get("description") or "")
+    attempts = _automatic_dispatch_attempts(statuses, target, verified)
+    if state in {"success", "failure"}:
+        return _is_trusted_terminal_status(
+            repository,
+            latest,
+            verified,
+            target,
+            api_call=api_call,
+        )
+    if state == "error":
+        retryable = description.startswith("Automatic dispatch failed;") or any(
+            marker in description for marker in (" gate rejected;", " incomplete;")
+        )
+        if not retryable or attempts >= MAX_AUTOMATIC_DISPATCH_ATTEMPTS:
+            return True
+        current_time = now or datetime.datetime.now(datetime.timezone.utc)
+        age = _status_age_seconds(latest, current_time)
+        if age is None or age < RETRY_CONFIRMATION_SECONDS:
+            return True
+        attempt = _status_attempt(latest)
+        if attempt is None:
+            return True
+        return _has_active_correlated_run(
+            repository,
+            verified,
+            target,
+            attempt,
+            api_call=api_call,
+        )
+    if state != "pending":
+        return True
+
+    current_time = now or datetime.datetime.now(datetime.timezone.utc)
+    age = _status_age_seconds(latest, current_time)
+    workflow_url = (
+        f"https://github.com/{repository}/actions/workflows/{target['workflow']}"
+    )
+    is_dispatch_marker = (
+        description.startswith(target["description"])
+        and str(latest.get("target_url") or "") == workflow_url
+    )
+    stale_after = (
+        RETRY_CONFIRMATION_SECONDS if is_dispatch_marker else STALE_PENDING_SECONDS
+    )
+    if age is None or age < stale_after:
+        return True
+
+    run_id = _workflow_run_id(repository, str(latest.get("target_url") or ""))
+    if run_id is not None:
+        run = api_call(f"/repos/{repository}/actions/runs/{run_id}") or {}
+        if run.get("status") in ACTIVE_WORKFLOW_STATES:
+            return True
+        if run.get("status") != "completed":
+            return True
+    attempt = _status_attempt(latest)
+    if attempt is None:
+        return True
+    if _has_active_correlated_run(
+        repository,
+        verified,
+        target,
+        attempt,
+        api_call=api_call,
+    ):
+        return True
+    return attempts >= MAX_AUTOMATIC_DISPATCH_ATTEMPTS
+
+
+def post_status(
+    repository: str,
+    head_sha: str,
+    *,
+    context: str,
+    state: str,
+    description: str,
+    target_url: str,
+    api_call: ApiCall = api,
+) -> None:
+    if len(description) > STATUS_DESCRIPTION_LIMIT:
+        raise GateError(
+            f"status description exceeds {STATUS_DESCRIPTION_LIMIT} characters"
+        )
+    api_call(
+        f"/repos/{repository}/statuses/{head_sha}",
+        method="POST",
+        body={
+            "context": context,
+            "description": description,
+            "state": state,
+            "target_url": target_url,
+        },
+    )
+
+
+def dispatch_target(
+    repository: str,
+    verified: VerifiedPullRequest,
+    target: dict[str, str],
+    attempt: int,
+    *,
+    api_call: ApiCall = api,
+) -> None:
+    correlation = dispatch_id(verified, target, attempt)
+    workflow = target["workflow"]
+    workflow_url = f"https://github.com/{repository}/actions/workflows/{workflow}"
+    post_status(
+        repository,
+        verified.head_sha,
+        context=target["context"],
+        state="pending",
+        description=(f"{target['description']}; try={attempt}; {status_pin(verified)}"),
+        target_url=workflow_url,
+        api_call=api_call,
+    )
+    try:
+        api_call(
+            f"/repos/{repository}/actions/workflows/{workflow}/dispatches",
+            method="POST",
+            body={
+                "ref": "main",
+                "inputs": {
+                    "upstream_pr": str(verified.pr_number),
+                    "expected_head_sha": verified.head_sha,
+                    "expected_base_sha": verified.base_sha,
+                    "expected_merge_sha": verified.merge_sha,
+                    "dispatch_attempt": str(attempt),
+                    "dispatch_id": correlation,
+                },
+            },
+        )
+    except Exception:
+        post_status(
+            repository,
+            verified.head_sha,
+            context=target["context"],
+            state="error",
+            description=(
+                f"Automatic dispatch failed; try={attempt}; {status_pin(verified)}"
+            ),
+            target_url=workflow_url,
+            api_call=api_call,
+        )
+        raise
+
+
+def reconcile(repository: str, *, api_call: ApiCall = api) -> None:
+    repository = validate_repository(repository)
+    failures: list[str] = []
+    for pr_number in list_open_pr_numbers(repository, api_call=api_call):
+        try:
+            verified = verify_pull_request(
+                repository,
+                pr_number,
+                api_call=api_call,
+            )
+        except GateError as error:
+            print(f"skip PR #{pr_number}: {error}")
+            continue
+
+        status_history = native_status_history(
+            repository,
+            verified.head_sha,
+            api_call=api_call,
+        )
+        for target in TARGETS:
+            statuses = status_history.get(target["context"], [])
+            try:
+                blocked = status_blocks_automatic_dispatch(
+                    repository,
+                    statuses,
+                    target,
+                    verified,
+                    api_call=api_call,
+                )
+            except GateError as error:
+                failures.append(f"PR #{pr_number} {target['context']}: {error}")
+                continue
+            if blocked:
+                print(
+                    f"skip PR #{pr_number} {target['context']}: "
+                    "current prospective merge is already handled"
+                )
+                continue
+            print(f"dispatch PR #{pr_number} {target['context']}")
+            try:
+                attempt = _automatic_dispatch_attempts(statuses, target, verified) + 1
+                dispatch_target(
+                    repository,
+                    verified,
+                    target,
+                    attempt,
+                    api_call=api_call,
+                )
+            except Exception as error:  # report every target before failing the run
+                failures.append(f"PR #{pr_number} {target['context']}: {error}")
+
+    if failures:
+        raise GateError("; ".join(failures))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    verify = subparsers.add_parser("verify", help="verify and pin one PR")
+    verify.add_argument("--repository", required=True)
+    verify.add_argument("--pr-number", required=True)
+    verify.add_argument("--expected-head-sha", required=True)
+    verify.add_argument("--expected-base-sha", required=True)
+    verify.add_argument("--expected-merge-sha", required=True)
+
+    reconcile_parser = subparsers.add_parser(
+        "reconcile", help="dispatch missing native tests for eligible PRs"
+    )
+    reconcile_parser.add_argument("--repository", required=True)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        if args.command == "verify":
+            verified = verify_pull_request(
+                args.repository,
+                args.pr_number,
+                args.expected_head_sha,
+                args.expected_base_sha,
+                args.expected_merge_sha,
+            )
+            print(json.dumps(asdict(verified), sort_keys=True))
+        else:
+            reconcile(args.repository)
+    except (GateError, ValueError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_dispatch_approved_lab_ci.py
+++ b/.github/scripts/test_dispatch_approved_lab_ci.py
@@ -146,10 +146,9 @@ class DispatcherTests(unittest.TestCase):
             dispatcher.VerifiedPullRequest(7, HEAD, BASE, MERGE),
         )
 
-    def test_stale_or_untrusted_approval_is_rejected(self) -> None:
+    def test_stale_or_dismissed_approval_is_rejected(self) -> None:
         cases = (
             approved_review(commit_id="d" * 40),
-            approved_review(author_association="CONTRIBUTOR"),
             approved_review(state="DISMISSED"),
         )
         for review in cases:
@@ -163,6 +162,17 @@ class DispatcherTests(unittest.TestCase):
                         api_call=VerificationApi(reviews=[review]),
                         sleep=lambda _: None,
                     )
+
+    def test_write_reviewer_is_accepted_despite_unreliable_association(self) -> None:
+        result = dispatcher.verify_pull_request(
+            REPOSITORY,
+            7,
+            api_call=VerificationApi(
+                reviews=[approved_review(author_association="CONTRIBUTOR")]
+            ),
+            sleep=lambda _: None,
+        )
+        self.assertEqual(result.head_sha, HEAD)
 
     def test_non_approved_aggregate_review_decision_is_rejected(self) -> None:
         with self.assertRaisesRegex(dispatcher.GateError, "aggregate review decision"):
@@ -798,12 +808,12 @@ class DispatcherTests(unittest.TestCase):
         self.assertIn("LAB_CI_AUTO_DISPATCH_ENABLED", dispatcher_workflow)
         self.assertIn("ref: main", dispatcher_workflow)
         self.assertIn("workflow_run.conclusion == 'success'", dispatcher_workflow)
-        self.assertIn("[approved] [MEMBER]", dispatcher_workflow)
+        self.assertIn("approval signal [approved] for PR #", dispatcher_workflow)
         self.assertNotIn("self-hosted", dispatcher_workflow)
 
         self.assertIn("pull_request_review:", signal_workflow)
         self.assertIn("github.event.review.state", signal_workflow)
-        self.assertIn("github.event.review.author_association", signal_workflow)
+        self.assertNotIn("github.event.review.author_association", signal_workflow)
         self.assertIn("permissions: {}", signal_workflow)
         self.assertNotIn("actions/checkout", signal_workflow)
 

--- a/.github/scripts/test_dispatch_approved_lab_ci.py
+++ b/.github/scripts/test_dispatch_approved_lab_ci.py
@@ -1,0 +1,848 @@
+# Copyright 2026 Cisco Systems Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import copy
+import datetime
+import io
+import importlib.util
+import pathlib
+import re
+import sys
+import unittest
+from contextlib import redirect_stdout
+from unittest import mock
+
+
+MODULE_PATH = pathlib.Path(__file__).with_name("dispatch-approved-lab-ci.py")
+SPEC = importlib.util.spec_from_file_location("dispatch_approved_lab_ci", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+dispatcher = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = dispatcher
+SPEC.loader.exec_module(dispatcher)
+
+REPOSITORY = "cisco-open/cisco-virtual-kubelet"
+HEAD = "a" * 40
+BASE = "b" * 40
+MERGE = "c" * 40
+
+
+def eligible_pull() -> dict[str, object]:
+    return {
+        "state": "open",
+        "draft": False,
+        "mergeable": True,
+        "merge_commit_sha": MERGE,
+        "head": {"sha": HEAD},
+        "base": {
+            "ref": "main",
+            "sha": BASE,
+            "repo": {"full_name": REPOSITORY},
+        },
+    }
+
+
+def approved_review(**overrides: object) -> dict[str, object]:
+    review: dict[str, object] = {
+        "id": 10,
+        "state": "APPROVED",
+        "commit_id": HEAD,
+        "author_association": "MEMBER",
+        "user": {"login": "reviewer"},
+    }
+    review.update(overrides)
+    return review
+
+
+def successful_checks() -> list[dict[str, object]]:
+    return [
+        {
+            "id": index,
+            "name": name,
+            "head_sha": HEAD,
+            "status": "completed",
+            "conclusion": "success",
+            "app": {"id": dispatcher.GITHUB_ACTIONS_APP_ID},
+        }
+        for index, name in enumerate(dispatcher.REQUIRED_CHECKS, start=20)
+    ]
+
+
+class VerificationApi:
+    def __init__(
+        self,
+        *,
+        pull: dict[str, object] | None = None,
+        reviews: list[dict[str, object]] | None = None,
+        checks: list[dict[str, object]] | None = None,
+        review_decision: str | None = "APPROVED",
+        reviewer_permission: str = "write",
+        compare_behind_by: int = 0,
+    ) -> None:
+        self.pull = pull if pull is not None else eligible_pull()
+        self.reviews = reviews if reviews is not None else [approved_review()]
+        self.checks = checks if checks is not None else successful_checks()
+        self.review_decision = review_decision
+        self.reviewer_permission = reviewer_permission
+        self.compare_behind_by = compare_behind_by
+        self.pull_calls = 0
+
+    def __call__(
+        self,
+        path: str,
+        method: str = "GET",
+        body: dict[str, object] | None = None,
+    ) -> object:
+        del method, body
+        if path.endswith("/branches/main"):
+            return {"commit": {"sha": BASE}}
+        if "/compare/" in path:
+            return {"behind_by": self.compare_behind_by}
+        if path == "/graphql":
+            return {
+                "data": {
+                    "repository": {
+                        "pullRequest": {"reviewDecision": self.review_decision}
+                    }
+                }
+            }
+        if "/collaborators/" in path and path.endswith("/permission"):
+            return {"permission": self.reviewer_permission}
+        if "/reviews?" in path:
+            return copy.deepcopy(self.reviews)
+        if "/check-runs?" in path:
+            return {"check_runs": copy.deepcopy(self.checks)}
+        if path.endswith("/pulls/7"):
+            self.pull_calls += 1
+            return copy.deepcopy(self.pull)
+        raise AssertionError(f"unexpected API call: {path}")
+
+
+class DispatcherTests(unittest.TestCase):
+    def test_current_head_approval_and_protected_checks_are_accepted(self) -> None:
+        result = dispatcher.verify_pull_request(
+            REPOSITORY,
+            7,
+            HEAD,
+            BASE,
+            MERGE,
+            api_call=VerificationApi(),
+            sleep=lambda _: None,
+        )
+        self.assertEqual(
+            result,
+            dispatcher.VerifiedPullRequest(7, HEAD, BASE, MERGE),
+        )
+
+    def test_stale_or_untrusted_approval_is_rejected(self) -> None:
+        cases = (
+            approved_review(commit_id="d" * 40),
+            approved_review(author_association="CONTRIBUTOR"),
+            approved_review(state="DISMISSED"),
+        )
+        for review in cases:
+            with self.subTest(review=review):
+                with self.assertRaisesRegex(
+                    dispatcher.GateError, "no trusted approval"
+                ):
+                    dispatcher.verify_pull_request(
+                        REPOSITORY,
+                        7,
+                        api_call=VerificationApi(reviews=[review]),
+                        sleep=lambda _: None,
+                    )
+
+    def test_non_approved_aggregate_review_decision_is_rejected(self) -> None:
+        with self.assertRaisesRegex(dispatcher.GateError, "aggregate review decision"):
+            dispatcher.verify_pull_request(
+                REPOSITORY,
+                7,
+                api_call=VerificationApi(review_decision="CHANGES_REQUESTED"),
+                sleep=lambda _: None,
+            )
+
+    def test_comment_does_not_replace_an_opinionated_review(self) -> None:
+        approval_then_comment = [
+            approved_review(),
+            approved_review(id=11, state="COMMENTED"),
+        ]
+        result = dispatcher.verify_pull_request(
+            REPOSITORY,
+            7,
+            api_call=VerificationApi(reviews=approval_then_comment),
+            sleep=lambda _: None,
+        )
+        self.assertEqual(result.head_sha, HEAD)
+
+        changes_then_comment = [
+            approved_review(state="CHANGES_REQUESTED"),
+            approved_review(id=11, state="COMMENTED"),
+        ]
+        self.assertEqual(
+            dispatcher._latest_reviews_by_user(changes_then_comment)["reviewer"][
+                "state"
+            ],
+            "CHANGES_REQUESTED",
+        )
+
+    def test_reviews_are_paginated_before_current_head_approval_check(self) -> None:
+        delegate = VerificationApi()
+
+        def paginated_api(
+            path: str,
+            method: str = "GET",
+            body: dict[str, object] | None = None,
+        ) -> object:
+            if "/reviews?" in path:
+                if path.endswith("&page=1"):
+                    return [
+                        approved_review(
+                            id=index,
+                            state="COMMENTED",
+                            user={"login": f"commenter-{index}"},
+                        )
+                        for index in range(1, 101)
+                    ]
+                if path.endswith("&page=2"):
+                    return [approved_review(id=101)]
+            return delegate(path, method, body)
+
+        result = dispatcher.verify_pull_request(
+            REPOSITORY,
+            7,
+            api_call=paginated_api,
+            sleep=lambda _: None,
+        )
+        self.assertEqual(result.head_sha, HEAD)
+
+    def test_read_only_member_approval_is_rejected(self) -> None:
+        with self.assertRaisesRegex(dispatcher.GateError, "write permission"):
+            dispatcher.verify_pull_request(
+                REPOSITORY,
+                7,
+                api_call=VerificationApi(reviewer_permission="read"),
+                sleep=lambda _: None,
+            )
+
+    def test_missing_failed_or_spoofed_required_check_is_rejected(self) -> None:
+        cases: list[tuple[str, list[dict[str, object]]]] = []
+        missing = successful_checks()[1:]
+        cases.append(("missing", missing))
+
+        failed = successful_checks()
+        failed[0]["conclusion"] = "failure"
+        cases.append(("not successful", failed))
+
+        pending = successful_checks()
+        pending[0]["status"] = "in_progress"
+        pending[0]["conclusion"] = None
+        cases.append(("not successful", pending))
+
+        spoofed = successful_checks()
+        spoofed[0]["app"] = {"id": 1}
+        cases.append(("missing", spoofed))
+
+        for message, checks in cases:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(dispatcher.GateError, message):
+                    dispatcher.verify_pull_request(
+                        REPOSITORY,
+                        7,
+                        api_call=VerificationApi(checks=checks),
+                        sleep=lambda _: None,
+                    )
+
+    def test_wrong_pr_shape_or_pinned_sha_is_rejected(self) -> None:
+        mutations = (
+            ("draft", lambda pull: pull.update(draft=True)),
+            ("base branch", lambda pull: pull["base"].update(ref="develop")),
+            (
+                "base repository",
+                lambda pull: pull["base"]["repo"].update(full_name="evil/fork"),
+            ),
+            ("not mergeable", lambda pull: pull.update(mergeable=False)),
+        )
+        for message, mutate in mutations:
+            pull = eligible_pull()
+            mutate(pull)
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(dispatcher.GateError, message):
+                    dispatcher.verify_pull_request(
+                        REPOSITORY,
+                        7,
+                        api_call=VerificationApi(pull=pull),
+                        sleep=lambda _: None,
+                    )
+
+        with self.assertRaisesRegex(dispatcher.GateError, "head changed"):
+            dispatcher.verify_pull_request(
+                REPOSITORY,
+                7,
+                "d" * 40,
+                BASE,
+                MERGE,
+                api_call=VerificationApi(),
+                sleep=lambda _: None,
+            )
+
+    def test_branch_behind_main_is_rejected(self) -> None:
+        with self.assertRaisesRegex(dispatcher.GateError, "not up to date"):
+            dispatcher.verify_pull_request(
+                REPOSITORY,
+                7,
+                api_call=VerificationApi(compare_behind_by=1),
+                sleep=lambda _: None,
+            )
+
+    def test_head_change_during_verification_is_rejected(self) -> None:
+        api_call = VerificationApi()
+
+        def changing_api(
+            path: str,
+            method: str = "GET",
+            body: dict[str, object] | None = None,
+        ) -> object:
+            result = api_call(path, method, body)
+            if path.endswith("/pulls/7") and api_call.pull_calls == 2:
+                changed = copy.deepcopy(result)
+                changed["head"]["sha"] = "d" * 40
+                return changed
+            return result
+
+        with self.assertRaisesRegex(
+            dispatcher.GateError, "changed during verification"
+        ):
+            dispatcher.verify_pull_request(
+                REPOSITORY,
+                7,
+                api_call=changing_api,
+                sleep=lambda _: None,
+            )
+
+    def test_dispatch_posts_pending_and_pins_all_shas(self) -> None:
+        calls: list[tuple[str, str, dict[str, object] | None]] = []
+
+        def record(
+            path: str,
+            method: str = "GET",
+            body: dict[str, object] | None = None,
+        ) -> None:
+            calls.append((path, method, body))
+
+        target = dispatcher.TARGETS[0]
+        verified = dispatcher.VerifiedPullRequest(7, HEAD, BASE, MERGE)
+        dispatcher.dispatch_target(REPOSITORY, verified, target, 1, api_call=record)
+
+        self.assertEqual(calls[0][1], "POST")
+        self.assertEqual(calls[0][2]["state"], "pending")
+        self.assertIn(f"base={BASE}; merge={MERGE}", calls[0][2]["description"])
+        self.assertIn("try=1", calls[0][2]["description"])
+        self.assertEqual(
+            calls[1][2]["inputs"],
+            {
+                "upstream_pr": "7",
+                "expected_head_sha": HEAD,
+                "expected_base_sha": BASE,
+                "expected_merge_sha": MERGE,
+                "dispatch_attempt": "1",
+                "dispatch_id": dispatcher.dispatch_id(verified, target, 1),
+            },
+        )
+
+    def test_dispatch_failure_replaces_pending_with_error(self) -> None:
+        states: list[str] = []
+
+        def fail_dispatch(
+            path: str,
+            method: str = "GET",
+            body: dict[str, object] | None = None,
+        ) -> None:
+            del method
+            if "/dispatches" in path:
+                raise dispatcher.GateError("dispatch failed")
+            if body and "state" in body:
+                states.append(str(body["state"]))
+
+        with self.assertRaisesRegex(dispatcher.GateError, "dispatch failed"):
+            dispatcher.dispatch_target(
+                REPOSITORY,
+                dispatcher.VerifiedPullRequest(7, HEAD, BASE, MERGE),
+                dispatcher.TARGETS[0],
+                1,
+                api_call=fail_dispatch,
+            )
+        self.assertEqual(states, ["pending", "error"])
+
+    def test_reconcile_suppresses_existing_context_independently(self) -> None:
+        verified = dispatcher.VerifiedPullRequest(7, HEAD, BASE, MERGE)
+        target = dispatcher.TARGETS[0]
+        run_id = 123
+        trusted_terminal = {
+            "creator": {"id": dispatcher.GITHUB_ACTIONS_BOT_ID},
+            "description": f"passed; try=1; {dispatcher.status_pin(verified)}",
+            "state": "success",
+            "target_url": f"https://github.com/{REPOSITORY}/actions/runs/{run_id}",
+        }
+        run = {
+            "id": run_id,
+            "display_title": dispatcher.dispatch_run_title(verified, target, 1),
+            "event": "workflow_dispatch",
+            "head_branch": "main",
+            "head_sha": BASE,
+            "path": ".github/workflows/lab-ci-cat8kv.yaml",
+        }
+        with (
+            mock.patch.object(dispatcher, "list_open_pr_numbers", return_value=[7]),
+            mock.patch.object(dispatcher, "verify_pull_request", return_value=verified),
+            mock.patch.object(
+                dispatcher,
+                "native_status_history",
+                return_value={
+                    dispatcher.TARGETS[0]["context"]: [trusted_terminal],
+                    dispatcher.TARGETS[1]["context"]: [],
+                },
+            ),
+            mock.patch.object(dispatcher, "dispatch_target") as dispatch,
+        ):
+            with redirect_stdout(io.StringIO()):
+                dispatcher.reconcile(REPOSITORY, api_call=mock.Mock(return_value=run))
+
+        dispatch.assert_called_once()
+        self.assertEqual(dispatch.call_args.args[2], dispatcher.TARGETS[1])
+        self.assertEqual(dispatch.call_args.args[3], 1)
+
+    def test_status_for_old_prospective_merge_does_not_suppress_dispatch(self) -> None:
+        verified = dispatcher.VerifiedPullRequest(7, HEAD, BASE, MERGE)
+        stale = {
+            "description": f"passed; base={'d' * 40}; merge={'e' * 40}",
+            "state": "success",
+        }
+        self.assertFalse(dispatcher.status_is_for_verified_merge(stale, verified))
+
+    def test_dispatch_error_is_retried_but_attempts_are_bounded(self) -> None:
+        verified = dispatcher.VerifiedPullRequest(7, HEAD, BASE, MERGE)
+        target = dispatcher.TARGETS[0]
+        pin = dispatcher.status_pin(verified)
+        one_failed_attempt = [
+            {
+                "id": 2,
+                "created_at": "2026-07-01T00:00:00Z",
+                "description": f"Automatic dispatch failed; try=1; {pin}",
+                "state": "error",
+            },
+            {
+                "id": 1,
+                "description": f"{target['description']}; try=1; {pin}",
+                "state": "pending",
+            },
+        ]
+        now = datetime.datetime(2026, 7, 2, tzinfo=datetime.timezone.utc)
+        no_runs = lambda *_args, **_kwargs: {"workflow_runs": []}
+        self.assertFalse(
+            dispatcher.status_blocks_automatic_dispatch(
+                REPOSITORY,
+                one_failed_attempt,
+                target,
+                verified,
+                api_call=no_runs,
+                now=now,
+            )
+        )
+
+        exhausted = list(one_failed_attempt)
+        for attempt in range(2, dispatcher.MAX_AUTOMATIC_DISPATCH_ATTEMPTS + 1):
+            exhausted.extend(
+                [
+                    {
+                        "id": attempt * 2,
+                        "created_at": "2026-07-01T00:00:00Z",
+                        "description": f"Automatic dispatch failed; try={attempt}; {pin}",
+                        "state": "error",
+                    },
+                    {
+                        "id": attempt * 2 - 1,
+                        "description": f"{target['description']}; try={attempt}; {pin}",
+                        "state": "pending",
+                    },
+                ]
+            )
+        exhausted.sort(key=lambda status: int(status["id"]), reverse=True)
+        self.assertTrue(
+            dispatcher.status_blocks_automatic_dispatch(
+                REPOSITORY,
+                exhausted,
+                target,
+                verified,
+                api_call=no_runs,
+                now=now,
+            )
+        )
+
+    def test_accepted_dispatch_timeout_does_not_duplicate_an_active_run(self) -> None:
+        verified = dispatcher.VerifiedPullRequest(7, HEAD, BASE, MERGE)
+        target = dispatcher.TARGETS[0]
+        pin = dispatcher.status_pin(verified)
+        statuses = [
+            {
+                "id": 2,
+                "created_at": "2026-07-01T00:00:00Z",
+                "description": f"Automatic dispatch failed; try=1; {pin}",
+                "state": "error",
+            },
+            {
+                "id": 1,
+                "description": f"{target['description']}; try=1; {pin}",
+                "state": "pending",
+            },
+        ]
+
+        def active_run(
+            _path: str,
+            method: str = "GET",
+            body: dict[str, object] | None = None,
+        ) -> object:
+            del method, body
+            return {
+                "workflow_runs": [
+                    {
+                        "display_title": dispatcher.dispatch_run_title(
+                            verified, target, 1
+                        ),
+                        "status": "queued",
+                    }
+                ]
+            }
+
+        self.assertTrue(
+            dispatcher.status_blocks_automatic_dispatch(
+                REPOSITORY,
+                statuses,
+                target,
+                verified,
+                api_call=active_run,
+                now=datetime.datetime(2026, 7, 2, tzinfo=datetime.timezone.utc),
+            )
+        )
+
+    def test_pre_argo_errors_retry_after_approval_or_tooling_recovers(self) -> None:
+        verified = dispatcher.VerifiedPullRequest(7, HEAD, BASE, MERGE)
+        target = dispatcher.TARGETS[0]
+        pin = dispatcher.status_pin(verified)
+        dispatch_marker = {
+            "id": 1,
+            "description": f"{target['description']}; try=1; {pin}",
+            "state": "pending",
+        }
+        for description in (
+            f"Cat8kv gate rejected; try=1; {pin}",
+            f"Cat8kv incomplete; try=1; {pin}",
+        ):
+            with self.subTest(description=description):
+                error = {
+                    "id": 2,
+                    "created_at": "2026-07-01T00:00:00Z",
+                    "description": description,
+                    "state": "error",
+                }
+                self.assertFalse(
+                    dispatcher.status_blocks_automatic_dispatch(
+                        REPOSITORY,
+                        [error, dispatch_marker],
+                        target,
+                        verified,
+                        api_call=lambda *_args, **_kwargs: {"workflow_runs": []},
+                        now=datetime.datetime(2026, 7, 2, tzinfo=datetime.timezone.utc),
+                    )
+                )
+
+    def test_next_reconcile_retries_a_failed_dispatch(self) -> None:
+        verified = dispatcher.VerifiedPullRequest(7, HEAD, BASE, MERGE)
+        target = dispatcher.TARGETS[0]
+        pin = dispatcher.status_pin(verified)
+        history = {
+            target["context"]: [
+                {
+                    "id": 2,
+                    "created_at": "2020-01-01T00:00:00Z",
+                    "description": f"Automatic dispatch failed; try=1; {pin}",
+                    "state": "error",
+                },
+                {
+                    "id": 1,
+                    "description": f"{target['description']}; try=1; {pin}",
+                    "state": "pending",
+                },
+            ],
+            dispatcher.TARGETS[1]["context"]: [
+                {
+                    "id": 3,
+                    "description": f"Cat9k cancelled; try=1; {pin}",
+                    "state": "error",
+                }
+            ],
+        }
+        api_call = mock.Mock(return_value={"workflow_runs": []})
+        with (
+            mock.patch.object(dispatcher, "list_open_pr_numbers", return_value=[7]),
+            mock.patch.object(dispatcher, "verify_pull_request", return_value=verified),
+            mock.patch.object(
+                dispatcher, "native_status_history", return_value=history
+            ),
+            mock.patch.object(dispatcher, "dispatch_target") as dispatch,
+        ):
+            with redirect_stdout(io.StringIO()):
+                dispatcher.reconcile(REPOSITORY, api_call=api_call)
+        dispatch.assert_called_once_with(
+            REPOSITORY,
+            verified,
+            target,
+            2,
+            api_call=mock.ANY,
+        )
+
+    def test_stale_pending_retries_only_after_workflow_is_complete(self) -> None:
+        verified = dispatcher.VerifiedPullRequest(7, HEAD, BASE, MERGE)
+        target = dispatcher.TARGETS[0]
+        pending = {
+            "id": 2,
+            "created_at": "2026-07-01T00:00:00Z",
+            "description": f"Cat8kv testing; try=1; {dispatcher.status_pin(verified)}",
+            "state": "pending",
+            "target_url": f"https://github.com/{REPOSITORY}/actions/runs/123",
+        }
+        dispatch_marker = {
+            "id": 1,
+            "description": f"{target['description']}; try=1; {dispatcher.status_pin(verified)}",
+            "state": "pending",
+        }
+        now = datetime.datetime(2026, 7, 2, tzinfo=datetime.timezone.utc)
+
+        def workflow_with_status(status: str):
+            def response(path: str, *_args, **_kwargs) -> object:
+                if path.endswith("/actions/runs/123"):
+                    return {"status": status}
+                if "/actions/workflows/" in path:
+                    return {"workflow_runs": []}
+                raise AssertionError(f"unexpected API call: {path}")
+
+            return response
+
+        self.assertTrue(
+            dispatcher.status_blocks_automatic_dispatch(
+                REPOSITORY,
+                [pending, dispatch_marker],
+                target,
+                verified,
+                api_call=workflow_with_status("in_progress"),
+                now=now,
+            )
+        )
+        self.assertFalse(
+            dispatcher.status_blocks_automatic_dispatch(
+                REPOSITORY,
+                [pending, dispatch_marker],
+                target,
+                verified,
+                api_call=workflow_with_status("completed"),
+                now=now,
+            )
+        )
+
+    def test_stale_generic_marker_does_not_duplicate_a_correlated_queue(self) -> None:
+        verified = dispatcher.VerifiedPullRequest(7, HEAD, BASE, MERGE)
+        target = dispatcher.TARGETS[0]
+        pending = {
+            "id": 1,
+            "created_at": "2026-07-01T00:00:00Z",
+            "description": (
+                f"{target['description']}; try=1; {dispatcher.status_pin(verified)}"
+            ),
+            "state": "pending",
+            "target_url": (
+                f"https://github.com/{REPOSITORY}/actions/workflows/"
+                f"{target['workflow']}"
+            ),
+        }
+
+        def correlated_queue(path: str, *_args, **_kwargs) -> object:
+            if "/actions/workflows/" not in path:
+                raise AssertionError(f"unexpected API call: {path}")
+            return {
+                "workflow_runs": [
+                    {
+                        "display_title": dispatcher.dispatch_run_title(
+                            verified, target, 1
+                        ),
+                        "status": "waiting",
+                    }
+                ]
+            }
+
+        self.assertTrue(
+            dispatcher.status_blocks_automatic_dispatch(
+                REPOSITORY,
+                [pending],
+                target,
+                verified,
+                api_call=correlated_queue,
+                now=datetime.datetime(2026, 7, 2, tzinfo=datetime.timezone.utc),
+            )
+        )
+        self.assertFalse(
+            dispatcher.status_blocks_automatic_dispatch(
+                REPOSITORY,
+                [pending],
+                target,
+                verified,
+                api_call=lambda *_args, **_kwargs: {"workflow_runs": []},
+                now=datetime.datetime(2026, 7, 2, tzinfo=datetime.timezone.utc),
+            )
+        )
+
+    def test_test_failure_is_terminal_for_automatic_retry(self) -> None:
+        verified = dispatcher.VerifiedPullRequest(7, HEAD, BASE, MERGE)
+        target = dispatcher.TARGETS[0]
+        run_id = 123
+        status = {
+            "creator": {"id": dispatcher.GITHUB_ACTIONS_BOT_ID},
+            "description": f"Cat8kv failed; try=1; {dispatcher.status_pin(verified)}",
+            "state": "failure",
+            "target_url": f"https://github.com/{REPOSITORY}/actions/runs/{run_id}",
+        }
+        trusted_run = {
+            "id": run_id,
+            "display_title": dispatcher.dispatch_run_title(verified, target, 1),
+            "event": "workflow_dispatch",
+            "head_branch": "main",
+            "head_sha": BASE,
+            "path": ".github/workflows/lab-ci-cat8kv.yaml",
+        }
+        self.assertTrue(
+            dispatcher.status_blocks_automatic_dispatch(
+                REPOSITORY,
+                [status],
+                target,
+                verified,
+                api_call=mock.Mock(return_value=trusted_run),
+            )
+        )
+        forged = copy.deepcopy(status)
+        forged["creator"] = {"id": 1}
+        self.assertFalse(
+            dispatcher.status_blocks_automatic_dispatch(
+                REPOSITORY,
+                [forged],
+                target,
+                verified,
+                api_call=mock.Mock(),
+            )
+        )
+
+    def test_status_descriptions_preserve_pin_and_fit_github_limit(self) -> None:
+        verified = dispatcher.VerifiedPullRequest(7, HEAD, BASE, MERGE)
+        pin = dispatcher.status_pin(verified)
+        descriptions = [
+            f"{target['description']}; try=1; {pin}" for target in dispatcher.TARGETS
+        ] + [f"Automatic dispatch failed; try=1; {pin}"]
+        for description in descriptions:
+            with self.subTest(description=description):
+                self.assertIn(pin, description)
+                self.assertLessEqual(
+                    len(description), dispatcher.STATUS_DESCRIPTION_LIMIT
+                )
+
+        with self.assertRaisesRegex(dispatcher.GateError, "exceeds"):
+            dispatcher.post_status(
+                REPOSITORY,
+                HEAD,
+                context="test",
+                state="pending",
+                description="x" * (dispatcher.STATUS_DESCRIPTION_LIMIT + 1),
+                target_url="https://example.invalid",
+                api_call=mock.Mock(),
+            )
+
+    def test_untrusted_cli_values_are_rejected(self) -> None:
+        with self.assertRaises(dispatcher.GateError):
+            dispatcher.validate_repository("owner/repo;touch-pwned")
+        with self.assertRaises(dispatcher.GateError):
+            dispatcher.validate_pr_number("7; rm -rf")
+        with self.assertRaises(dispatcher.GateError):
+            dispatcher.validate_sha("head", "not-a-sha")
+
+    def test_workflow_security_contracts_are_present(self) -> None:
+        repository_root = MODULE_PATH.parents[2]
+        dispatcher_workflow = (
+            repository_root / ".github/workflows/lab-ci-auto-dispatch.yaml"
+        ).read_text()
+        signal_workflow = (
+            repository_root / ".github/workflows/lab-ci-approval-signal.yaml"
+        ).read_text()
+
+        self.assertIn("workflow_run:", dispatcher_workflow)
+        self.assertIn("schedule:", dispatcher_workflow)
+        self.assertIn("actions: write", dispatcher_workflow)
+        self.assertIn("checks: read", dispatcher_workflow)
+        self.assertIn("LAB_CI_AUTO_DISPATCH_ENABLED", dispatcher_workflow)
+        self.assertIn("ref: main", dispatcher_workflow)
+        self.assertIn("workflow_run.conclusion == 'success'", dispatcher_workflow)
+        self.assertIn("[approved] [MEMBER]", dispatcher_workflow)
+        self.assertNotIn("self-hosted", dispatcher_workflow)
+
+        self.assertIn("pull_request_review:", signal_workflow)
+        self.assertIn("github.event.review.state", signal_workflow)
+        self.assertIn("github.event.review.author_association", signal_workflow)
+        self.assertIn("permissions: {}", signal_workflow)
+        self.assertNotIn("actions/checkout", signal_workflow)
+
+        for workflow_name in ("lab-ci-cat8kv.yaml", "lab-ci-cat9k.yaml"):
+            wrapper = (
+                repository_root / ".github/workflows" / workflow_name
+            ).read_text()
+            self.assertIn("expected_head_sha:", wrapper)
+            self.assertIn("expected_base_sha:", wrapper)
+            self.assertIn("expected_merge_sha:", wrapper)
+            self.assertIn("dispatch_attempt:", wrapper)
+            self.assertIn("dispatch_id:", wrapper)
+            self.assertIn("run-name: Lab CI", wrapper)
+            self.assertIn("checks: read", wrapper)
+            self.assertEqual(wrapper.count("dispatch-approved-lab-ci.py verify"), 2)
+            self.assertIn("Checkout trusted gate at the verified base", wrapper)
+            self.assertIn("ref: ${{ needs.prepare.outputs.base_sha }}", wrapper)
+            self.assertIn("gate_outcome: ${{ steps.gate.outcome }}", wrapper)
+            self.assertIn('"$GATE_OUTCOME" == "failure"', wrapper)
+            self.assertIn(
+                '[[ -n "$ARGO_WORKFLOW" && "$ARGO_PHASE" == "Failed" ]]',
+                wrapper,
+            )
+            self.assertIn("environment: lab-ci", wrapper)
+            status_templates = [
+                template
+                for template in re.findall(
+                    r'(?:description=|DESCRIPTION=)"([^"]+)"', wrapper
+                )
+                if "$BASE_SHA" in template and "$MERGE_SHA" in template
+            ]
+            self.assertEqual(len(status_templates), 6)
+            for template in status_templates:
+                rendered = template.replace("$BASE_SHA", BASE).replace(
+                    "$MERGE_SHA", MERGE
+                )
+                self.assertIn(f"base={BASE}; merge={MERGE}", rendered)
+                self.assertLessEqual(len(rendered), dispatcher.STATUS_DESCRIPTION_LIMIT)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/lab-ci-approval-signal.yaml
+++ b/.github/workflows/lab-ci-approval-signal.yaml
@@ -19,7 +19,6 @@
 name: Lab CI approval signal
 run-name: >-
   Lab CI approval signal [${{ github.event.review.state }}]
-  [${{ github.event.review.author_association }}]
   for PR #${{ github.event.pull_request.number }}
 
 on:
@@ -43,7 +42,6 @@ jobs:
           PR_DRAFT: ${{ github.event.pull_request.draft }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_STATE: ${{ github.event.pull_request.state }}
-          REVIEW_ASSOCIATION: ${{ github.event.review.author_association }}
           REVIEW_COMMIT_SHA: ${{ github.event.review.commit_id }}
         run: |
           set -euo pipefail
@@ -54,4 +52,3 @@ jobs:
           [[ "$PR_DRAFT" == "false" ]]
           [[ "$BASE_REF" == "main" ]]
           [[ "$BASE_REPOSITORY" == "$GITHUB_REPOSITORY" ]]
-          [[ "$REVIEW_ASSOCIATION" =~ ^(COLLABORATOR|MEMBER|OWNER)$ ]]

--- a/.github/workflows/lab-ci-approval-signal.yaml
+++ b/.github/workflows/lab-ci-approval-signal.yaml
@@ -1,0 +1,57 @@
+# Copyright 2026 Cisco Systems Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This unprivileged workflow turns an approval event into a workflow_run
+# signal. It deliberately has no token permissions, checkout, artifacts, or
+# secrets. The privileged dispatcher always re-reads and validates server-side
+# PR state from trusted main before it writes anything.
+name: Lab CI approval signal
+run-name: >-
+  Lab CI approval signal [${{ github.event.review.state }}]
+  [${{ github.event.review.author_association }}]
+  for PR #${{ github.event.pull_request.number }}
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions: {}
+
+jobs:
+  current-head-approved:
+    if: github.event.review.state == 'approved'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions: {}
+    steps:
+      - name: Validate unprivileged approval signal
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_DRAFT: ${{ github.event.pull_request.draft }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_STATE: ${{ github.event.pull_request.state }}
+          REVIEW_ASSOCIATION: ${{ github.event.review.author_association }}
+          REVIEW_COMMIT_SHA: ${{ github.event.review.commit_id }}
+        run: |
+          set -euo pipefail
+          [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]
+          [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$REVIEW_COMMIT_SHA" == "$HEAD_SHA" ]]
+          [[ "$PR_STATE" == "open" ]]
+          [[ "$PR_DRAFT" == "false" ]]
+          [[ "$BASE_REF" == "main" ]]
+          [[ "$BASE_REPOSITORY" == "$GITHUB_REPOSITORY" ]]
+          [[ "$REVIEW_ASSOCIATION" =~ ^(COLLABORATOR|MEMBER|OWNER)$ ]]

--- a/.github/workflows/lab-ci-auto-dispatch.yaml
+++ b/.github/workflows/lab-ci-auto-dispatch.yaml
@@ -42,9 +42,7 @@ jobs:
       (github.event_name != 'workflow_run' ||
         (github.event.workflow_run.name == 'smoke' ||
           (github.event.workflow_run.conclusion == 'success' &&
-            startsWith(github.event.workflow_run.display_title, 'Lab CI approval signal [approved] [COLLABORATOR]') ||
-            startsWith(github.event.workflow_run.display_title, 'Lab CI approval signal [approved] [MEMBER]') ||
-            startsWith(github.event.workflow_run.display_title, 'Lab CI approval signal [approved] [OWNER]'))))
+            startsWith(github.event.workflow_run.display_title, 'Lab CI approval signal [approved] for PR #'))))
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/lab-ci-auto-dispatch.yaml
+++ b/.github/workflows/lab-ci-auto-dispatch.yaml
@@ -1,0 +1,68 @@
+# Copyright 2026 Cisco Systems Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Reconcile approved PRs from trusted main. workflow_run handles both event
+# orderings (approval before smoke, or smoke before approval); the schedule is
+# a fail-safe for delayed/missed signals and replaces the external host poller.
+name: Lab CI approved dispatcher
+
+on:
+  workflow_run:
+    workflows: [Lab CI approval signal, smoke]
+    types: [completed]
+  schedule:
+    # Event-driven runs are the normal path; this is only a missed-event
+    # reconciliation fallback.
+    - cron: "17 * * * *"
+  workflow_dispatch: {}
+
+permissions: {}
+
+concurrency:
+  group: lab-ci-approved-dispatcher
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    # Merge the dispatcher inertly, then enable it only after the native
+    # wrappers are on main and the environment/branch protections are updated.
+    if: >-
+      vars.LAB_CI_AUTO_DISPATCH_ENABLED == 'true' &&
+      (github.event_name != 'workflow_run' ||
+        (github.event.workflow_run.name == 'smoke' ||
+          (github.event.workflow_run.conclusion == 'success' &&
+            startsWith(github.event.workflow_run.display_title, 'Lab CI approval signal [approved] [COLLABORATOR]') ||
+            startsWith(github.event.workflow_run.display_title, 'Lab CI approval signal [approved] [MEMBER]') ||
+            startsWith(github.event.workflow_run.display_title, 'Lab CI approval signal [approved] [OWNER]'))))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: write
+      checks: read
+      contents: read
+      pull-requests: read
+      statuses: write
+    steps:
+      - name: Checkout trusted dispatcher from main
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Dispatch missing native tests for eligible PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          python3 .github/scripts/dispatch-approved-lab-ci.py reconcile
+          --repository "$GITHUB_REPOSITORY"

--- a/.github/workflows/lab-ci-cat8kv.yaml
+++ b/.github/workflows/lab-ci-cat8kv.yaml
@@ -15,8 +15,10 @@
 # Trusted, cisco-open-native wrapper for the cat8kv-pr-test Argo
 # WorkflowTemplate. The workflow must be dispatched from main. GitHub-hosted
 # jobs validate the PR and own all GitHub writes; the credentialed lab runner
-# receives only the verified prospective merge SHA.
+# receives the verified prospective merge SHA and a read-only token for its
+# final pre-submission revalidation.
 name: Lab CI (Cat8kv)
+run-name: Lab CI Cat8kv - ${{ inputs.dispatch_id }}
 
 on:
   workflow_dispatch:
@@ -25,6 +27,26 @@ on:
         description: "Open PR number to validate"
         required: true
         type: number
+      expected_head_sha:
+        description: "Approved PR head SHA pinned by the trusted dispatcher"
+        required: true
+        type: string
+      expected_base_sha:
+        description: "Current main SHA pinned by the trusted dispatcher"
+        required: true
+        type: string
+      expected_merge_sha:
+        description: "Prospective merge SHA pinned by the trusted dispatcher"
+        required: true
+        type: string
+      dispatch_attempt:
+        description: "Bounded automatic dispatch attempt"
+        required: true
+        type: number
+      dispatch_id:
+        description: "Deterministic dispatcher correlation ID"
+        required: true
+        type: string
 
 concurrency:
   # Do not auto-cancel a device run: an abandoned Argo workflow could retain
@@ -43,17 +65,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
+      checks: read
       contents: read
       pull-requests: read
       statuses: write
     outputs:
+      base_sha: ${{ steps.pr.outputs.base_sha }}
       head_sha: ${{ steps.pr.outputs.head_sha }}
       merge_sha: ${{ steps.pr.outputs.merge_sha }}
       pr_number: ${{ steps.pr.outputs.pr_number }}
     steps:
+      - name: Checkout trusted gate from main
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
       - name: Resolve and verify open PR
         id: pr
         env:
+          EXPECTED_BASE_SHA: ${{ inputs.expected_base_sha }}
+          EXPECTED_HEAD_SHA: ${{ inputs.expected_head_sha }}
+          EXPECTED_MERGE_SHA: ${{ inputs.expected_merge_sha }}
+          DISPATCH_ATTEMPT: ${{ inputs.dispatch_attempt }}
+          DISPATCH_ID: ${{ inputs.dispatch_id }}
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.upstream_pr }}
           EXPECTED_REPO: ${{ github.repository }}
@@ -62,40 +96,41 @@ jobs:
           set -euo pipefail
           [[ "$GITHUB_REF" == "refs/heads/main" ]]
           [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]
+          [[ "$DISPATCH_ATTEMPT" =~ ^[1-3]$ ]]
+          [[ "$DISPATCH_ID" =~ ^cat8kv-pr[1-9][0-9]*-h[0-9a-f]{12}-b[0-9a-f]{12}-m[0-9a-f]{12}-a[1-3]$ ]]
+          [[ "$EXPECTED_BASE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EXPECTED_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EXPECTED_MERGE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$DISPATCH_ID" == "cat8kv-pr${PR_NUMBER}-h${EXPECTED_HEAD_SHA:0:12}-b${EXPECTED_BASE_SHA:0:12}-m${EXPECTED_MERGE_SHA:0:12}-a${DISPATCH_ATTEMPT}" ]]
+          {
+            echo "base_sha=$EXPECTED_BASE_SHA"
+            echo "head_sha=$EXPECTED_HEAD_SHA"
+            echo "pr_number=$PR_NUMBER"
+          } >> "$GITHUB_OUTPUT"
 
-          # GitHub may initially return mergeable=null while it computes the
-          # prospective merge. Retry briefly, then fail closed.
-          PR_JSON=""
-          for attempt in 1 2 3 4 5; do
-            PR_JSON=$(gh api "repos/${EXPECTED_REPO}/pulls/${PR_NUMBER}")
-            if [[ $(jq -r '.mergeable' <<<"$PR_JSON") != "null" ]]; then
-              break
-            fi
-            sleep $((attempt * 2))
-          done
-
-          [[ $(jq -r '.state' <<<"$PR_JSON") == "open" ]]
-          [[ $(jq -r '.draft' <<<"$PR_JSON") == "false" ]]
-          [[ $(jq -r '.base.ref' <<<"$PR_JSON") == "main" ]]
-          [[ $(jq -r '.base.repo.full_name' <<<"$PR_JSON") == "$EXPECTED_REPO" ]]
-          [[ $(jq -r '.mergeable' <<<"$PR_JSON") == "true" ]]
-
-          HEAD_SHA=$(jq -r '.head.sha' <<<"$PR_JSON")
-          MERGE_SHA=$(jq -r '.merge_commit_sha' <<<"$PR_JSON")
-          [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
-          [[ "$MERGE_SHA" =~ ^[0-9a-f]{40}$ ]]
-          [[ "$HEAD_SHA" != "$MERGE_SHA" ]]
+          VERIFY_JSON=$(python3 .github/scripts/dispatch-approved-lab-ci.py verify \
+            --repository "$EXPECTED_REPO" \
+            --pr-number "$PR_NUMBER" \
+            --expected-head-sha "$EXPECTED_HEAD_SHA" \
+            --expected-base-sha "$EXPECTED_BASE_SHA" \
+            --expected-merge-sha "$EXPECTED_MERGE_SHA")
+          HEAD_SHA=$(jq -r '.head_sha' <<<"$VERIFY_JSON")
+          BASE_SHA=$(jq -r '.base_sha' <<<"$VERIFY_JSON")
+          MERGE_SHA=$(jq -r '.merge_sha' <<<"$VERIFY_JSON")
+          VERIFIED_PR=$(jq -r '.pr_number' <<<"$VERIFY_JSON")
+          [[ "$GITHUB_SHA" == "$BASE_SHA" ]]
 
           {
+            echo "base_sha=$BASE_SHA"
             echo "head_sha=$HEAD_SHA"
             echo "merge_sha=$MERGE_SHA"
-            echo "pr_number=$PR_NUMBER"
+            echo "pr_number=$VERIFIED_PR"
           } >> "$GITHUB_OUTPUT"
 
           gh api -X POST "repos/${EXPECTED_REPO}/statuses/${HEAD_SHA}" \
             -f state=pending \
             -f target_url="$TARGET_URL" \
-            -f description="Cat8kv is testing the prospective merge" \
+            -f description="Cat8kv testing; try=$DISPATCH_ATTEMPT; base=$BASE_SHA; merge=$MERGE_SHA" \
             -f context="$STATUS_CONTEXT" >/dev/null
 
   cat8kv:
@@ -104,20 +139,50 @@ jobs:
     runs-on: [self-hosted, lab-cvk-upstream]
     environment: lab-ci
     timeout-minutes: 70
-    permissions: {}
+    permissions:
+      checks: read
+      contents: read
+      pull-requests: read
+    outputs:
+      argo_phase: ${{ steps.argo.outputs.phase }}
+      argo_workflow: ${{ steps.argo.outputs.workflow }}
+      gate_outcome: ${{ steps.gate.outcome }}
     env:
+      TEST_BASE_SHA: ${{ needs.prepare.outputs.base_sha }}
+      TEST_HEAD_SHA: ${{ needs.prepare.outputs.head_sha }}
       UPSTREAM_REPO: ${{ github.repository }}
       UPSTREAM_PR: ${{ needs.prepare.outputs.pr_number }}
       TEST_MERGE_SHA: ${{ needs.prepare.outputs.merge_sha }}
       PATH: /home/cisco/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
-      - name: Verify trusted lab inputs and tooling
+      - name: Checkout trusted gate at the verified base
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.prepare.outputs.base_sha }}
+          persist-credentials: false
+
+      - name: Revalidate approval immediately before lab submission
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           [[ "$GITHUB_REF" == "refs/heads/main" ]]
           [[ "$UPSTREAM_REPO" == "$GITHUB_REPOSITORY" ]]
           [[ "$UPSTREAM_PR" =~ ^[1-9][0-9]*$ ]]
+          [[ "$TEST_BASE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$TEST_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
           [[ "$TEST_MERGE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          python3 .github/scripts/dispatch-approved-lab-ci.py verify \
+            --repository "$UPSTREAM_REPO" \
+            --pr-number "$UPSTREAM_PR" \
+            --expected-head-sha "$TEST_HEAD_SHA" \
+            --expected-base-sha "$TEST_BASE_SHA" \
+            --expected-merge-sha "$TEST_MERGE_SHA" >/dev/null
+
+      - name: Verify trusted lab tooling
+        run: |
+          set -euo pipefail
           command -v argo
           command -v jq
           argo version --short
@@ -215,7 +280,7 @@ jobs:
           retention-days: 7
 
   report:
-    if: always() && github.ref == 'refs/heads/main' && needs.prepare.result == 'success'
+    if: always() && github.ref == 'refs/heads/main'
     needs: [prepare, cat8kv]
     concurrency:
       group: lab-ci-next-report-${{ needs.prepare.outputs.pr_number }}
@@ -232,17 +297,38 @@ jobs:
       - name: Post final status
         env:
           GH_TOKEN: ${{ github.token }}
-          HEAD_SHA: ${{ needs.prepare.outputs.head_sha }}
+          ARGO_PHASE: ${{ needs.cat8kv.outputs.argo_phase }}
+          ARGO_WORKFLOW: ${{ needs.cat8kv.outputs.argo_workflow }}
+          BASE_SHA: ${{ needs.prepare.outputs.base_sha || inputs.expected_base_sha }}
+          DISPATCH_ATTEMPT: ${{ inputs.dispatch_attempt }}
+          GATE_OUTCOME: ${{ needs.cat8kv.outputs.gate_outcome }}
+          HEAD_SHA: ${{ needs.prepare.outputs.head_sha || inputs.expected_head_sha }}
           LAB_RESULT: ${{ needs.cat8kv.result }}
+          MERGE_SHA: ${{ needs.prepare.outputs.merge_sha || inputs.expected_merge_sha }}
+          PREPARE_RESULT: ${{ needs.prepare.result }}
           TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-          case "$LAB_RESULT" in
-            success)   STATE=success; DESCRIPTION="Cat8kv passed on the prospective merge" ;;
-            failure)   STATE=failure; DESCRIPTION="Cat8kv failed on the prospective merge" ;;
-            cancelled) STATE=error;   DESCRIPTION="Cat8kv run was cancelled" ;;
-            *)         STATE=error;   DESCRIPTION="Cat8kv did not complete ($LAB_RESULT)" ;;
-          esac
+          [[ "$BASE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$DISPATCH_ATTEMPT" =~ ^[1-3]$ ]]
+          [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$MERGE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          if [[ "$PREPARE_RESULT" != "success" || "$GATE_OUTCOME" == "failure" ]]; then
+            STATE=error
+            DESCRIPTION="Cat8kv gate rejected; try=$DISPATCH_ATTEMPT; base=$BASE_SHA; merge=$MERGE_SHA"
+          elif [[ "$LAB_RESULT" == "cancelled" ]]; then
+            STATE=error
+            DESCRIPTION="Cat8kv cancelled; try=$DISPATCH_ATTEMPT; base=$BASE_SHA; merge=$MERGE_SHA"
+          elif [[ -n "$ARGO_WORKFLOW" && "$ARGO_PHASE" == "Failed" ]]; then
+            STATE=failure
+            DESCRIPTION="Cat8kv failed; try=$DISPATCH_ATTEMPT; base=$BASE_SHA; merge=$MERGE_SHA"
+          elif [[ "$LAB_RESULT" == "success" && "$ARGO_PHASE" == "Succeeded" ]]; then
+            STATE=success
+            DESCRIPTION="Cat8kv passed; try=$DISPATCH_ATTEMPT; base=$BASE_SHA; merge=$MERGE_SHA"
+          else
+            STATE=error
+            DESCRIPTION="Cat8kv incomplete; try=$DISPATCH_ATTEMPT; base=$BASE_SHA; merge=$MERGE_SHA"
+          fi
           gh api -X POST "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
             -f state="$STATE" \
             -f target_url="$TARGET_URL" \
@@ -250,7 +336,7 @@ jobs:
             -f context="$STATUS_CONTEXT" >/dev/null
 
       - name: Checkout trusted reporting code
-        if: always()
+        if: always() && needs.prepare.result == 'success'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: main
@@ -258,7 +344,7 @@ jobs:
           persist-credentials: false
 
       - name: Upsert native Lab CI report
-        if: always()
+        if: always() && needs.prepare.result == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/lab-ci-cat9k.yaml
+++ b/.github/workflows/lab-ci-cat9k.yaml
@@ -15,8 +15,10 @@
 # Trusted, cisco-open-native wrapper for the physical cat9k-pr-test Argo
 # WorkflowTemplate. The workflow must be dispatched from main. GitHub-hosted
 # jobs validate the PR and own all GitHub writes; the credentialed lab runner
-# receives only the verified prospective merge SHA.
+# receives the verified prospective merge SHA and a read-only token for its
+# final pre-submission revalidation.
 name: Lab CI (Cat9k)
+run-name: Lab CI Cat9k - ${{ inputs.dispatch_id }}
 
 on:
   workflow_dispatch:
@@ -25,6 +27,26 @@ on:
         description: "Open PR number to validate"
         required: true
         type: number
+      expected_head_sha:
+        description: "Approved PR head SHA pinned by the trusted dispatcher"
+        required: true
+        type: string
+      expected_base_sha:
+        description: "Current main SHA pinned by the trusted dispatcher"
+        required: true
+        type: string
+      expected_merge_sha:
+        description: "Prospective merge SHA pinned by the trusted dispatcher"
+        required: true
+        type: string
+      dispatch_attempt:
+        description: "Bounded automatic dispatch attempt"
+        required: true
+        type: number
+      dispatch_id:
+        description: "Deterministic dispatcher correlation ID"
+        required: true
+        type: string
 
 concurrency:
   # The physical switch is singular. The Argo template also holds the device
@@ -43,17 +65,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
+      checks: read
       contents: read
       pull-requests: read
       statuses: write
     outputs:
+      base_sha: ${{ steps.pr.outputs.base_sha }}
       head_sha: ${{ steps.pr.outputs.head_sha }}
       merge_sha: ${{ steps.pr.outputs.merge_sha }}
       pr_number: ${{ steps.pr.outputs.pr_number }}
     steps:
+      - name: Checkout trusted gate from main
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
       - name: Resolve and verify open PR
         id: pr
         env:
+          EXPECTED_BASE_SHA: ${{ inputs.expected_base_sha }}
+          EXPECTED_HEAD_SHA: ${{ inputs.expected_head_sha }}
+          EXPECTED_MERGE_SHA: ${{ inputs.expected_merge_sha }}
+          DISPATCH_ATTEMPT: ${{ inputs.dispatch_attempt }}
+          DISPATCH_ID: ${{ inputs.dispatch_id }}
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ inputs.upstream_pr }}
           EXPECTED_REPO: ${{ github.repository }}
@@ -62,38 +96,41 @@ jobs:
           set -euo pipefail
           [[ "$GITHUB_REF" == "refs/heads/main" ]]
           [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]
+          [[ "$DISPATCH_ATTEMPT" =~ ^[1-3]$ ]]
+          [[ "$DISPATCH_ID" =~ ^cat9k-pr[1-9][0-9]*-h[0-9a-f]{12}-b[0-9a-f]{12}-m[0-9a-f]{12}-a[1-3]$ ]]
+          [[ "$EXPECTED_BASE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EXPECTED_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EXPECTED_MERGE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$DISPATCH_ID" == "cat9k-pr${PR_NUMBER}-h${EXPECTED_HEAD_SHA:0:12}-b${EXPECTED_BASE_SHA:0:12}-m${EXPECTED_MERGE_SHA:0:12}-a${DISPATCH_ATTEMPT}" ]]
+          {
+            echo "base_sha=$EXPECTED_BASE_SHA"
+            echo "head_sha=$EXPECTED_HEAD_SHA"
+            echo "pr_number=$PR_NUMBER"
+          } >> "$GITHUB_OUTPUT"
 
-          PR_JSON=""
-          for attempt in 1 2 3 4 5; do
-            PR_JSON=$(gh api "repos/${EXPECTED_REPO}/pulls/${PR_NUMBER}")
-            if [[ $(jq -r '.mergeable' <<<"$PR_JSON") != "null" ]]; then
-              break
-            fi
-            sleep $((attempt * 2))
-          done
-
-          [[ $(jq -r '.state' <<<"$PR_JSON") == "open" ]]
-          [[ $(jq -r '.draft' <<<"$PR_JSON") == "false" ]]
-          [[ $(jq -r '.base.ref' <<<"$PR_JSON") == "main" ]]
-          [[ $(jq -r '.base.repo.full_name' <<<"$PR_JSON") == "$EXPECTED_REPO" ]]
-          [[ $(jq -r '.mergeable' <<<"$PR_JSON") == "true" ]]
-
-          HEAD_SHA=$(jq -r '.head.sha' <<<"$PR_JSON")
-          MERGE_SHA=$(jq -r '.merge_commit_sha' <<<"$PR_JSON")
-          [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
-          [[ "$MERGE_SHA" =~ ^[0-9a-f]{40}$ ]]
-          [[ "$HEAD_SHA" != "$MERGE_SHA" ]]
+          VERIFY_JSON=$(python3 .github/scripts/dispatch-approved-lab-ci.py verify \
+            --repository "$EXPECTED_REPO" \
+            --pr-number "$PR_NUMBER" \
+            --expected-head-sha "$EXPECTED_HEAD_SHA" \
+            --expected-base-sha "$EXPECTED_BASE_SHA" \
+            --expected-merge-sha "$EXPECTED_MERGE_SHA")
+          HEAD_SHA=$(jq -r '.head_sha' <<<"$VERIFY_JSON")
+          BASE_SHA=$(jq -r '.base_sha' <<<"$VERIFY_JSON")
+          MERGE_SHA=$(jq -r '.merge_sha' <<<"$VERIFY_JSON")
+          VERIFIED_PR=$(jq -r '.pr_number' <<<"$VERIFY_JSON")
+          [[ "$GITHUB_SHA" == "$BASE_SHA" ]]
 
           {
+            echo "base_sha=$BASE_SHA"
             echo "head_sha=$HEAD_SHA"
             echo "merge_sha=$MERGE_SHA"
-            echo "pr_number=$PR_NUMBER"
+            echo "pr_number=$VERIFIED_PR"
           } >> "$GITHUB_OUTPUT"
 
           gh api -X POST "repos/${EXPECTED_REPO}/statuses/${HEAD_SHA}" \
             -f state=pending \
             -f target_url="$TARGET_URL" \
-            -f description="Cat9k is testing the prospective merge" \
+            -f description="Cat9k testing; try=$DISPATCH_ATTEMPT; base=$BASE_SHA; merge=$MERGE_SHA" \
             -f context="$STATUS_CONTEXT" >/dev/null
 
   cat9k:
@@ -104,20 +141,50 @@ jobs:
     # Argo's activeDeadlineSeconds is 3000 (50 minutes). Leave time for
     # evidence capture and runner-side termination before GitHub stops the job.
     timeout-minutes: 60
-    permissions: {}
+    permissions:
+      checks: read
+      contents: read
+      pull-requests: read
+    outputs:
+      argo_phase: ${{ steps.argo.outputs.phase }}
+      argo_workflow: ${{ steps.argo.outputs.workflow }}
+      gate_outcome: ${{ steps.gate.outcome }}
     env:
+      TEST_BASE_SHA: ${{ needs.prepare.outputs.base_sha }}
+      TEST_HEAD_SHA: ${{ needs.prepare.outputs.head_sha }}
       UPSTREAM_REPO: ${{ github.repository }}
       UPSTREAM_PR: ${{ needs.prepare.outputs.pr_number }}
       TEST_MERGE_SHA: ${{ needs.prepare.outputs.merge_sha }}
       PATH: /home/cisco/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     steps:
-      - name: Verify trusted lab inputs and tooling
+      - name: Checkout trusted gate at the verified base
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.prepare.outputs.base_sha }}
+          persist-credentials: false
+
+      - name: Revalidate approval immediately before lab submission
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           [[ "$GITHUB_REF" == "refs/heads/main" ]]
           [[ "$UPSTREAM_REPO" == "$GITHUB_REPOSITORY" ]]
           [[ "$UPSTREAM_PR" =~ ^[1-9][0-9]*$ ]]
+          [[ "$TEST_BASE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$TEST_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
           [[ "$TEST_MERGE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          python3 .github/scripts/dispatch-approved-lab-ci.py verify \
+            --repository "$UPSTREAM_REPO" \
+            --pr-number "$UPSTREAM_PR" \
+            --expected-head-sha "$TEST_HEAD_SHA" \
+            --expected-base-sha "$TEST_BASE_SHA" \
+            --expected-merge-sha "$TEST_MERGE_SHA" >/dev/null
+
+      - name: Verify trusted lab tooling
+        run: |
+          set -euo pipefail
           command -v argo
           command -v jq
           argo version --short
@@ -215,7 +282,7 @@ jobs:
           retention-days: 7
 
   report:
-    if: always() && github.ref == 'refs/heads/main' && needs.prepare.result == 'success'
+    if: always() && github.ref == 'refs/heads/main'
     needs: [prepare, cat9k]
     concurrency:
       group: lab-ci-next-report-${{ needs.prepare.outputs.pr_number }}
@@ -232,17 +299,38 @@ jobs:
       - name: Post final status
         env:
           GH_TOKEN: ${{ github.token }}
-          HEAD_SHA: ${{ needs.prepare.outputs.head_sha }}
+          ARGO_PHASE: ${{ needs.cat9k.outputs.argo_phase }}
+          ARGO_WORKFLOW: ${{ needs.cat9k.outputs.argo_workflow }}
+          BASE_SHA: ${{ needs.prepare.outputs.base_sha || inputs.expected_base_sha }}
+          DISPATCH_ATTEMPT: ${{ inputs.dispatch_attempt }}
+          GATE_OUTCOME: ${{ needs.cat9k.outputs.gate_outcome }}
+          HEAD_SHA: ${{ needs.prepare.outputs.head_sha || inputs.expected_head_sha }}
           LAB_RESULT: ${{ needs.cat9k.result }}
+          MERGE_SHA: ${{ needs.prepare.outputs.merge_sha || inputs.expected_merge_sha }}
+          PREPARE_RESULT: ${{ needs.prepare.result }}
           TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-          case "$LAB_RESULT" in
-            success)   STATE=success; DESCRIPTION="Cat9k passed on the prospective merge" ;;
-            failure)   STATE=failure; DESCRIPTION="Cat9k failed on the prospective merge" ;;
-            cancelled) STATE=error;   DESCRIPTION="Cat9k run was cancelled" ;;
-            *)         STATE=error;   DESCRIPTION="Cat9k did not complete ($LAB_RESULT)" ;;
-          esac
+          [[ "$BASE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$DISPATCH_ATTEMPT" =~ ^[1-3]$ ]]
+          [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$MERGE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          if [[ "$PREPARE_RESULT" != "success" || "$GATE_OUTCOME" == "failure" ]]; then
+            STATE=error
+            DESCRIPTION="Cat9k gate rejected; try=$DISPATCH_ATTEMPT; base=$BASE_SHA; merge=$MERGE_SHA"
+          elif [[ "$LAB_RESULT" == "cancelled" ]]; then
+            STATE=error
+            DESCRIPTION="Cat9k cancelled; try=$DISPATCH_ATTEMPT; base=$BASE_SHA; merge=$MERGE_SHA"
+          elif [[ -n "$ARGO_WORKFLOW" && "$ARGO_PHASE" == "Failed" ]]; then
+            STATE=failure
+            DESCRIPTION="Cat9k failed; try=$DISPATCH_ATTEMPT; base=$BASE_SHA; merge=$MERGE_SHA"
+          elif [[ "$LAB_RESULT" == "success" && "$ARGO_PHASE" == "Succeeded" ]]; then
+            STATE=success
+            DESCRIPTION="Cat9k passed; try=$DISPATCH_ATTEMPT; base=$BASE_SHA; merge=$MERGE_SHA"
+          else
+            STATE=error
+            DESCRIPTION="Cat9k incomplete; try=$DISPATCH_ATTEMPT; base=$BASE_SHA; merge=$MERGE_SHA"
+          fi
           gh api -X POST "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
             -f state="$STATE" \
             -f target_url="$TARGET_URL" \
@@ -250,7 +338,7 @@ jobs:
             -f context="$STATUS_CONTEXT" >/dev/null
 
       - name: Checkout trusted reporting code
-        if: always()
+        if: always() && needs.prepare.result == 'success'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: main
@@ -258,7 +346,7 @@ jobs:
           persist-credentials: false
 
       - name: Upsert native Lab CI report
-        if: always()
+        if: always() && needs.prepare.result == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/lab-ci-static.yaml
+++ b/.github/workflows/lab-ci-static.yaml
@@ -19,14 +19,18 @@ on:
     branches: [main]
     paths:
       - .github/actionlint.yaml
+      - .github/scripts/dispatch-approved-lab-ci.py
       - .github/scripts/post-pr-report.py
+      - .github/scripts/test_dispatch_approved_lab_ci.py
       - .github/scripts/test_post_pr_report.py
       - .github/workflows/lab-ci-*.yaml
   pull_request:
     branches: [main]
     paths:
       - .github/actionlint.yaml
+      - .github/scripts/dispatch-approved-lab-ci.py
       - .github/scripts/post-pr-report.py
+      - .github/scripts/test_dispatch_approved_lab_ci.py
       - .github/scripts/test_post_pr_report.py
       - .github/workflows/lab-ci-*.yaml
   workflow_dispatch: {}
@@ -44,7 +48,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Test Lab CI reporter
+      - name: Test Lab CI scripts
         run: python3 -m unittest discover -s .github/scripts -p 'test_*.py' -v
 
       - name: Install actionlint 1.7.12


### PR DESCRIPTION
## Summary

- add an unprivileged review signal and a trusted default-branch reconciler for both approval/check orderings, with an hourly missed-event fallback
- require an open, non-draft, mergeable and up-to-date PR; aggregate approval plus a current-head approval from a write/admin reviewer; and successful protected `build-and-smoke` / `ygot-validate` checks
- pin head, base, and prospective merge SHAs through dispatch and both native wrappers
- revalidate on a hosted runner and again immediately before Argo submission with a read-only token
- correlate bounded retries so ambiguous GitHub dispatch failures do not duplicate active hardware runs; reserve terminal failure for an Argo workflow that actually ran and failed
- extend static Lab CI validation with pagination, review-state, retry, correlation, status-provenance, race, and workflow-contract coverage

## Rollout safety

- the dispatcher remains inert until `LAB_CI_AUTO_DISPATCH_ENABLED=true`
- this PR does not change the live `lab-ci` environment reviewer or branch protection
- after merge: cancel and confirm old waiting runs 29487319159 and 29487320836; enable stale-review dismissal; remove only the environment required reviewer while preserving protected-branch/admin-bypass policy; then enable the repository variable

## Validation

- `black --check`
- 33 Python unit tests
- actionlint 1.7.12 over all `lab-ci-*.yaml` workflows
- `git diff --check`
- live read-only gate verification against PRs #149, #150, and #151