### PR TITLE
ci: grant reporter pull request comment access

### DIFF
--- a/.github/scripts/test_dispatch_approved_lab_ci.py
+++ b/.github/scripts/test_dispatch_approved_lab_ci.py
@@ -828,6 +828,8 @@ class DispatcherTests(unittest.TestCase):
             self.assertIn("dispatch_id:", wrapper)
             self.assertIn("run-name: Lab CI", wrapper)
             self.assertIn("checks: read", wrapper)
+            self.assertIn("pull-requests: write", wrapper)
+            self.assertNotIn("issues: write", wrapper)
             self.assertEqual(wrapper.count("dispatch-approved-lab-ci.py verify"), 2)
             self.assertIn("Checkout trusted gate at the verified base", wrapper)
             self.assertIn("ref: ${{ needs.prepare.outputs.base_sha }}", wrapper)

--- a/.github/workflows/lab-ci-cat8kv.yaml
+++ b/.github/workflows/lab-ci-cat8kv.yaml
@@ -290,8 +290,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-      issues: write
-      pull-requests: read
+      pull-requests: write
       statuses: write
     steps:
       - name: Post final status

--- a/.github/workflows/lab-ci-cat9k.yaml
+++ b/.github/workflows/lab-ci-cat9k.yaml
@@ -292,8 +292,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-      issues: write
-      pull-requests: read
+      pull-requests: write
       statuses: write
     steps:
       - name: Post final status


### PR DESCRIPTION
The PR #149 canary identified the exact reporter denial: POST /issues/149/comments returned HTTP 403 Resource not accessible by integration even though issues: write was present. Replace that broad issue permission with pull-requests: write on the two report jobs, matching their sole purpose of updating a PR comment. No other job permission changes. Validation: all 40 Lab CI script tests pass.