### PR TITLE
test(nxos): add deterministic Kind wiring smoke

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 # Smoke pipeline — runs on every push and PR. The point is not to
-# verify the *device* side (which needs a real Cat9K reachable on
-# RESTCONF/NETCONF/gNMI and so cannot live in CI) but to verify the
-# *cluster-side plumbing* of the controller: build, image side-load,
+# verify the *device* side (which needs real IOS-XE and NX-OS devices
+# reachable on their management transports and so cannot live in CI).
+# It verifies the *cluster-side plumbing* of the controller: build, image side-load,
 # Helm install, CRDs, RBAC, and that the cisco-vk pod actually
 # reaches the device-call boundary. The connection-refused beyond
 # that boundary is expected and is treated as a passing condition.
@@ -194,12 +194,15 @@ jobs:
           kubectl -n cisco-vk-system get pods
 
       - name: Apply test CRs
-        # The device address is RFC 5737 documentation space — the
-        # connection-refused we expect is what tells us the cisco-vk
-        # binary reached the transport-build path. We are not asking
-        # CI to talk to a real Cat9K.
+        # The IOS-XE address is RFC 5737 documentation space. The NX-OS
+        # address is the pod's own loopback on a deliberately closed port,
+        # which makes the expected connection refusal deterministic instead
+        # of waiting for the NX-API client's network timeout. In both cases,
+        # reaching that transport error proves the platform-specific binary
+        # path was constructed without asking public CI to reach a device.
         run: |
           kubectl create namespace cisco-vk-smoke
+          kubectl create namespace cisco-vk-nxos-smoke
           cat <<'EOF' | kubectl apply -f -
           apiVersion: v1
           kind: Secret
@@ -259,29 +262,94 @@ jobs:
             driftPolicy: report
             source:
               configMapRef: { name: smoke-data, key: data.nac.yaml }
+          ---
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: smoke-creds
+            namespace: cisco-vk-nxos-smoke
+          type: Opaque
+          stringData:
+            password: nxos-kind-credential-sentinel
+          ---
+          apiVersion: cisco.vk/v1alpha1
+          kind: CiscoDevice
+          metadata:
+            name: nxos-smoke
+            namespace: cisco-vk-nxos-smoke
+          spec:
+            driver: NXOS
+            address: 127.0.0.1
+            port: 1
+            username: smoke
+            credentialSecretRef: { name: smoke-creds }
+            tls: { enabled: true, insecureSkipVerify: true }
+            transport: rest
+            maxPods: 1
+            nxos:
+              networking:
+                interface:
+                  type: Management
+                  management:
+                    guestInterface: 0
+          ---
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: smoke-data
+            namespace: cisco-vk-nxos-smoke
+          data:
+            data.nac.yaml: |
+              system:
+                hostname: nxos-smoke
+          ---
+          apiVersion: config.cisco.vk/v1alpha1
+          kind: NXOSConfig
+          metadata:
+            name: nxos-smoke
+            namespace: cisco-vk-nxos-smoke
+          spec:
+            deviceRef: { name: nxos-smoke }
+            managedFamilies: [system]
+            transactional: false
+            writeStartup: false
+            driftDetectInterval: 5m
+            driftPolicy: report
+            source:
+              configMapRef: { name: smoke-data, key: data.nac.yaml }
           EOF
 
       - name: Verify VK SA and RoleBinding auto-provisioned
         # Assertion of the controller fix: a CiscoDevice in a tenant
         # namespace must cause the VK SA + RoleBinding to appear there.
         run: |
-          for i in $(seq 1 30); do
-            if kubectl -n cisco-vk-smoke get sa cisco-virtual-kubelet >/dev/null 2>&1 \
-               && kubectl -n cisco-vk-smoke get rolebinding cisco-virtual-kubelet >/dev/null 2>&1; then
-              echo "VK access provisioned"
-              break
-            fi
-            sleep 2
+          for target in \
+            cisco-vk-smoke:smoke \
+            cisco-vk-nxos-smoke:nxos-smoke; do
+            namespace="${target%%:*}"
+            device="${target##*:}"
+            for i in $(seq 1 30); do
+              if kubectl -n "$namespace" get sa cisco-virtual-kubelet >/dev/null 2>&1 \
+                 && kubectl -n "$namespace" get rolebinding cisco-virtual-kubelet >/dev/null 2>&1 \
+                 && kubectl -n "$namespace" get cm "${device}-config" >/dev/null 2>&1 \
+                 && kubectl -n "$namespace" get deploy "${device}-vk" >/dev/null 2>&1; then
+                echo "VK access and deployment provisioned for ${namespace}/${device}"
+                break
+              fi
+              sleep 2
+            done
+            kubectl -n "$namespace" get sa cisco-virtual-kubelet
+            kubectl -n "$namespace" get rolebinding cisco-virtual-kubelet
+            kubectl -n "$namespace" get cm "${device}-config"
+            kubectl -n "$namespace" get deploy "${device}-vk"
           done
-          kubectl -n cisco-vk-smoke get sa,rolebinding,deploy
+          kubectl -n cisco-vk-smoke get iosxeconfig smoke
+          kubectl -n cisco-vk-nxos-smoke get nxosconfig nxos-smoke
 
-      - name: Verify cisco-vk pod reaches device-call boundary
-        # The only blocker past this point is an unreachable device,
-        # which CI does not provide. Either:
-        #   - pod is Running (e.g. on a future stub-driver path), OR
-        #   - pod is CrashLoopBackOff/Error with a transport-level
-        #     connection-refused or timeout — proves the binary
-        #     reached the device call.
+      - name: Verify IOS-XE and NX-OS pods reach device-call boundary
+        # The only expected blocker past this point is an unreachable device,
+        # which CI does not provide. A transport-level connection refusal or
+        # timeout proves the binary reached the device call.
         # Any RBAC, schema, or config-shape failure surfaces here as
         # a non-transport error and fails the job.
         run: |
@@ -290,44 +358,56 @@ jobs:
           # chance to attempt the device call. We need to wait until the
           # logs actually surface a device-call boundary marker (success
           # path) or an upstream-defect marker (fail path).
-          ok_re='connect: connection refused|i/o timeout|context deadline exceeded|no route to host|failed to validate device connection'
-          bad_re='requires xe config section|forbidden|cannot list|cannot get'
-          # Concatenate current + previous container logs each cycle. If the
-          # binary crashes within the poll window (observed: pod Restarts=1
-          # with empty current-container logs), --previous keeps the markers
-          # visible. `|| true` swallows the "previous terminated container
-          # not found" message during normal startup.
-          cur=""
-          prev=""
-          logs=""
-          for i in $(seq 1 60); do
-            cur=$(kubectl -n cisco-vk-smoke logs -l app.kubernetes.io/instance=smoke --tail=200 2>&1 || true)
-            prev=$(kubectl -n cisco-vk-smoke logs -l app.kubernetes.io/instance=smoke --previous --tail=200 2>&1 || true)
-            logs="${prev}"$'\n'"${cur}"
-            if echo "$logs" | grep -qE "$ok_re"; then
-              kubectl -n cisco-vk-smoke get pods
-              echo "$logs"
-              echo "Reached device-call boundary as expected"
-              exit 0
+          check_device_boundary() {
+            namespace="$1"
+            device="$2"
+            platform="$3"
+            ok_re='connect: connection refused|i/o timeout|context deadline exceeded|no route to host|failed to validate device connection'
+            bad_re='requires (xe|nxos) config section|forbidden|cannot list|cannot get|driver .* not registered|unsupported device driver'
+            if [ "$platform" = NX-OS ]; then
+              ok_re='nxapi cli_show_ascii.*127\.0\.0\.1:1/ins.*connection refused'
+              bad_re="${bad_re}|nxos-kind-credential-sentinel|nxapi cli_conf"
             fi
-            if echo "$logs" | grep -qE "$bad_re"; then
-              kubectl -n cisco-vk-smoke get pods
-              echo "$logs"
-              echo "Failure was upstream of the device call — surfaces a real defect"
-              exit 1
-            fi
-            sleep 3
-          done
-          # Timeout path: dump everything that helps explain WHY no marker
-          # was seen — pod state, restart reason, and both log streams.
-          kubectl -n cisco-vk-smoke get pods -o wide
-          kubectl -n cisco-vk-smoke describe pods -l app.kubernetes.io/instance=smoke
-          echo "--- current container logs ---"
-          echo "$cur"
-          echo "--- previous container logs (--previous) ---"
-          echo "$prev"
-          echo "cisco-vk did not reach a recognised state in time"
-          exit 1
+            # Concatenate current + previous container logs each cycle. If the
+            # binary crashes within the poll window (observed: pod Restarts=1
+            # with empty current-container logs), --previous keeps the markers
+            # visible. `|| true` swallows the "previous terminated container
+            # not found" message during normal startup.
+            cur=""
+            prev=""
+            logs=""
+            for i in $(seq 1 60); do
+              cur=$(kubectl -n "$namespace" logs -l "app.kubernetes.io/instance=${device}" --tail=200 2>&1 || true)
+              prev=$(kubectl -n "$namespace" logs -l "app.kubernetes.io/instance=${device}" --previous --tail=200 2>&1 || true)
+              logs="${prev}"$'\n'"${cur}"
+              if echo "$logs" | grep -qE "$bad_re"; then
+                kubectl -n "$namespace" get pods
+                echo "$logs"
+                echo "${platform} failed upstream of the device call — surfaces a real defect"
+                return 1
+              fi
+              if echo "$logs" | grep -qE "$ok_re"; then
+                kubectl -n "$namespace" get pods
+                echo "$logs"
+                echo "${platform} reached the device-call boundary as expected"
+                return 0
+              fi
+              sleep 3
+            done
+            # Timeout path: dump everything that helps explain WHY no marker
+            # was seen — pod state, restart reason, and both log streams.
+            kubectl -n "$namespace" get pods -o wide
+            kubectl -n "$namespace" describe pods -l "app.kubernetes.io/instance=${device}"
+            echo "--- current container logs ---"
+            echo "$cur"
+            echo "--- previous container logs (--previous) ---"
+            echo "$prev"
+            echo "${platform} cisco-vk did not reach a recognised state in time"
+            return 1
+          }
+
+          check_device_boundary cisco-vk-smoke smoke IOS-XE
+          check_device_boundary cisco-vk-nxos-smoke nxos-smoke NX-OS
 
       - name: Diagnostics on failure
         if: failure()
@@ -339,6 +419,9 @@ jobs:
           kubectl -n cisco-vk-smoke describe ciscodevice smoke || true
           kubectl -n cisco-vk-smoke describe iosxeconfig smoke || true
           kubectl -n cisco-vk-smoke get events --sort-by=.lastTimestamp || true
+          kubectl -n cisco-vk-nxos-smoke describe ciscodevice nxos-smoke || true
+          kubectl -n cisco-vk-nxos-smoke describe nxosconfig nxos-smoke || true
+          kubectl -n cisco-vk-nxos-smoke get events --sort-by=.lastTimestamp || true
 
   terraform-provider:
     name: terraform-provider

--- a/cmd/cisco-vk/drivers_register_test.go
+++ b/cmd/cisco-vk/drivers_register_test.go
@@ -1,0 +1,169 @@
+// Copyright © 2026 Cisco Systems Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	ciskov1 "github.com/cisco/virtual-kubelet-cisco/api/v1alpha1"
+	"github.com/cisco/virtual-kubelet-cisco/internal/drivers"
+)
+
+func TestCompiledDriverRegistryHasSupportedAppHostingPlatforms(t *testing.T) {
+	for _, kind := range []ciskov1.DeviceDriver{
+		ciskov1.DeviceDriverXE,
+		ciskov1.DeviceDriverNXOS,
+		ciskov1.DeviceDriverFAKE,
+	} {
+		if !drivers.Registered(kind) {
+			t.Fatalf("app-hosting driver %s is not compiled into cisco-vk; registered=%v", kind, drivers.RegisteredKinds())
+		}
+	}
+}
+
+func TestCompiledConfigDriverRegistryHasDeviceCentricPlatforms(t *testing.T) {
+	for _, kind := range []ciskov1.DeviceDriver{
+		ciskov1.DeviceDriverXE,
+		ciskov1.DeviceDriverNXOS,
+	} {
+		if !drivers.ConfigDriverRegistered(kind) {
+			t.Fatalf("config driver %s is not compiled into cisco-vk; registered=%v", kind, drivers.RegisteredConfigDriverKinds())
+		}
+	}
+}
+
+func TestCompiledNXOSDriverStartsWithReadOnlyNXAPIProbe(t *testing.T) {
+	const (
+		username = "nxos-registry-test"
+		password = "nxos-registry-test-credential"
+	)
+	type capturedRequest struct {
+		Type  string
+		Input string
+	}
+
+	var (
+		mu          sync.Mutex
+		requests    []capturedRequest
+		handlerErrs []string
+		authOK      = true
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload struct {
+			InsAPI struct {
+				Type  string `json:"type"`
+				Input string `json:"input"`
+			} `json:"ins_api"`
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		if r.Method != http.MethodPost {
+			handlerErrs = append(handlerErrs, "NX-API probe did not use POST")
+		}
+		if r.URL.Path != "/ins" {
+			handlerErrs = append(handlerErrs, "NX-API probe did not target /ins")
+		}
+		gotUser, gotPassword, ok := r.BasicAuth()
+		if !ok || gotUser != username || gotPassword != password {
+			authOK = false
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			handlerErrs = append(handlerErrs, "NX-API probe body was not valid JSON")
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		requests = append(requests, capturedRequest{
+			Type:  payload.InsAPI.Type,
+			Input: payload.InsAPI.Input,
+		})
+
+		body := "NAME: chassis, PID: N9K-C9300v, SN: KIND-SMOKE"
+		if payload.InsAPI.Input == "show version" {
+			body = "Device name: nxos-kind-smoke\nNXOS: version 10.3(9)\n"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"ins_api": map[string]any{
+				"outputs": map[string]any{
+					"output": map[string]any{
+						"input": payload.InsAPI.Input,
+						"code":  "200",
+						"msg":   "Success",
+						"body":  body,
+					},
+				},
+			},
+		}); err != nil {
+			handlerErrs = append(handlerErrs, "NX-API test server could not encode its response")
+		}
+	}))
+	defer server.Close()
+
+	endpoint, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse NX-API test endpoint: %v", err)
+	}
+	host, portText, err := net.SplitHostPort(endpoint.Host)
+	if err != nil {
+		t.Fatalf("split NX-API test endpoint: %v", err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatalf("parse NX-API test port: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	driver, err := drivers.NewDriver(ctx, &ciskov1.DeviceSpec{
+		Driver:   ciskov1.DeviceDriverNXOS,
+		Address:  host,
+		Port:     port,
+		Username: username,
+		Password: password,
+		TLS:      &ciskov1.TLSConfig{Enabled: false},
+	})
+	if err != nil {
+		t.Fatalf("construct compiled NX-OS driver: %v", err)
+	}
+	if driver == nil {
+		t.Fatal("compiled NX-OS driver constructor returned nil")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(handlerErrs) > 0 {
+		t.Fatalf("NX-API probe contract errors: %v", handlerErrs)
+	}
+	if !authOK {
+		t.Fatal("NX-API probe did not use the configured Basic authentication")
+	}
+	want := []capturedRequest{
+		{Type: "cli_show_ascii", Input: "show version"},
+		{Type: "cli_show_ascii", Input: "show inventory"},
+	}
+	if !reflect.DeepEqual(requests, want) {
+		t.Fatalf("NX-API startup requests=%v, want read-only probes %v", requests, want)
+	}
+}


### PR DESCRIPTION
## Summary

- exercise an NX-OS `CiscoDevice` and `NXOSConfig` in the clean Kind smoke cluster
- use the pod-local closed endpoint `https://127.0.0.1:1/ins` for an immediate, deterministic transport boundary
- assert tenant RBAC, generated configuration, Deployment, CRD admission, and NX-OS driver selection
- reject write-class `cli_conf` activity and credential-sentinel leakage before accepting the read-only NX-API boundary
- verify the compiled binary registers IOS-XE, NX-OS, and FAKE app-hosting drivers plus IOS-XE/NX-OS config drivers
- verify NX-OS startup sends exactly the read-only `show version` and `show inventory` probes

## Dependency

This branch is rebased onto #160 so the smoke runs with the hardened dependency baseline. Merge #160 first; after it lands on `main`, this PR reduces to the NX-OS wiring commit.

## Validation

- `GOCACHE=/tmp/cvk-gocache go test -race -count=1 ./...`
- `actionlint -config-file .github/actionlint.yaml .github/workflows/smoke.yml` (v1.7.12)
- workflow YAML parse
- `git diff --check`

## Scope boundary

This is the hermetic cluster-wiring gate. The NXOSConfig is admitted and the compiled config-driver registration is asserted, but the deliberately unreachable app driver exits at its read-only connection boundary before DME reconciliation begins. Live DME fetch/apply/verify/removal and app-hosting lifecycle remain gates for the trusted NX-OS lab workflow in the next roadmap PR.

The log matcher is compatible with the NX-API error redaction in #160.
