### PR TITLE
ci: wait for terminal lab report state

### DIFF
--- a/.github/scripts/post-pr-report.py
+++ b/.github/scripts/post-pr-report.py
@@ -22,6 +22,8 @@ wrappers. It deliberately does not consume raw Argo objects or pod logs.
 Required environment variables:
   REPOSITORY  Current ``owner/repo`` (status and comment destination)
   HEAD_SHA    Verified PR head SHA to which statuses were posted
+  BASE_SHA    Verified base SHA used by both lab workflows
+  MERGE_SHA   Verified prospective merge SHA tested by both lab workflows
   PR_NUMBER   Verified open PR number
   GH_TOKEN    Built-in token for this repository
 """
@@ -44,6 +46,8 @@ from typing import Any
 GITHUB_API = "https://api.github.com"
 EVIDENCE_SCHEMA = "cvk-lab-evidence/v1"
 COMMENT_MARKER = "<!-- lab-ci-next-report -->"
+GITHUB_ACTIONS_BOT_ID = 41_898_282
+TERMINAL_STATES = frozenset({"success", "failure", "error"})
 
 CONTEXTS: tuple[dict[str, str], ...] = (
     {
@@ -154,9 +158,15 @@ def api(
     return json.loads(payload) if payload else None
 
 
-def latest_status_per_context(repository: str, sha: str) -> dict[str, dict[str, Any]]:
-    """Return the newest native lab status for each context."""
+def latest_status_per_context(
+    repository: str,
+    sha: str,
+    base_sha: str,
+    merge_sha: str,
+) -> dict[str, dict[str, Any]]:
+    """Return each newest trusted status for this exact prospective merge."""
     wanted = {entry["context"] for entry in CONTEXTS}
+    expected_pin = f"base={base_sha}; merge={merge_sha}"
     latest: dict[str, dict[str, Any]] = {}
     for page in range(1, 11):
         statuses = api(
@@ -164,11 +174,27 @@ def latest_status_per_context(repository: str, sha: str) -> dict[str, dict[str, 
         ) or []
         for status in statuses:
             context = status.get("context")
-            if context in wanted and context not in latest:
+            creator = status.get("creator") or {}
+            description = str(status.get("description") or "")
+            if (
+                context in wanted
+                and context not in latest
+                and creator.get("id") == GITHUB_ACTIONS_BOT_ID
+                and expected_pin in description
+            ):
                 latest[context] = status
         if wanted.issubset(latest) or len(statuses) < 100:
             break
     return latest
+
+
+def all_contexts_terminal(latest: dict[str, dict[str, Any]]) -> bool:
+    """Return true only when every expected native lab context has finished."""
+    return all(
+        str((latest.get(entry["context"]) or {}).get("state") or "")
+        in TERMINAL_STATES
+        for entry in CONTEXTS
+    )
 
 
 def run_id_from_target_url(url: str) -> int | None:
@@ -593,11 +619,21 @@ def upsert_comment(repository: str, pr_number: str, body: str) -> None:
         )
 
 
-def validate_inputs(repository: str, head_sha: str, pr_number: str) -> None:
+def validate_inputs(
+    repository: str,
+    head_sha: str,
+    base_sha: str,
+    merge_sha: str,
+    pr_number: str,
+) -> None:
     if not REPOSITORY_RE.fullmatch(repository):
         raise ValueError("REPOSITORY must be an owner/repo name")
     if not SHA_RE.fullmatch(head_sha):
         raise ValueError("HEAD_SHA must be a 40-character lowercase hex SHA")
+    if not SHA_RE.fullmatch(base_sha):
+        raise ValueError("BASE_SHA must be a 40-character lowercase hex SHA")
+    if not SHA_RE.fullmatch(merge_sha):
+        raise ValueError("MERGE_SHA must be a 40-character lowercase hex SHA")
     if not PR_RE.fullmatch(pr_number):
         raise ValueError("PR_NUMBER must be a positive integer")
 
@@ -609,7 +645,14 @@ def pr_still_has_head(repository: str, pr_number: str, head_sha: str) -> bool:
 
 
 def main() -> int:
-    required = ("REPOSITORY", "HEAD_SHA", "PR_NUMBER", "GH_TOKEN")
+    required = (
+        "REPOSITORY",
+        "HEAD_SHA",
+        "BASE_SHA",
+        "MERGE_SHA",
+        "PR_NUMBER",
+        "GH_TOKEN",
+    )
     missing = [name for name in required if not os.environ.get(name)]
     if missing:
         print(f"error: missing required environment: {', '.join(missing)}", file=sys.stderr)
@@ -617,13 +660,28 @@ def main() -> int:
 
     repository = os.environ["REPOSITORY"]
     head_sha = os.environ["HEAD_SHA"]
+    base_sha = os.environ["BASE_SHA"]
+    merge_sha = os.environ["MERGE_SHA"]
     pr_number = os.environ["PR_NUMBER"]
     try:
-        validate_inputs(repository, head_sha, pr_number)
+        validate_inputs(repository, head_sha, base_sha, merge_sha, pr_number)
         if not pr_still_has_head(repository, pr_number, head_sha):
             print("notice: PR head changed or PR closed; skipping stale report")
             return 0
-        latest = latest_status_per_context(repository, head_sha)
+        latest = latest_status_per_context(
+            repository,
+            head_sha,
+            base_sha,
+            merge_sha,
+        )
+        if not all_contexts_terminal(latest):
+            states = ", ".join(
+                f"{entry['context']}="
+                f"{(latest.get(entry['context']) or {}).get('state', 'missing')}"
+                for entry in CONTEXTS
+            )
+            print(f"notice: waiting for terminal native lab statuses ({states})")
+            return 0
         report = render_report(repository, head_sha, latest)
         upsert_comment(repository, pr_number, report)
     except (ValueError, json.JSONDecodeError, zipfile.BadZipFile) as error:

--- a/.github/scripts/test_post_pr_report.py
+++ b/.github/scripts/test_post_pr_report.py
@@ -33,6 +33,10 @@ SPEC.loader.exec_module(reporter)
 
 
 class ReporterTests(unittest.TestCase):
+    BASE_SHA = "b" * 40
+    HEAD_SHA = "a" * 40
+    MERGE_SHA = "c" * 40
+
     def test_only_native_lab_contexts_are_reported(self) -> None:
         contexts = [entry["context"] for entry in reporter.CONTEXTS]
         self.assertEqual(
@@ -324,6 +328,159 @@ class ReporterTests(unittest.TestCase):
         self.assertNotIn("Unit tests", body)
         self.assertNotIn("<!-- lab-ci-report:", body)
 
+    def test_latest_statuses_require_actions_bot_and_exact_merge_pin(self) -> None:
+        pin = f"base={self.BASE_SHA}; merge={self.MERGE_SHA}"
+        statuses = [
+            {
+                "context": "lab-ci-next / cat8kv",
+                "state": "success",
+                "description": pin,
+                "creator": {"id": 1234},
+            },
+            {
+                "context": "lab-ci-next / cat8kv",
+                "state": "success",
+                "description": f"base={'d' * 40}; merge={'e' * 40}",
+                "creator": {"id": reporter.GITHUB_ACTIONS_BOT_ID},
+            },
+            {
+                "context": "lab-ci-next / cat8kv",
+                "state": "failure",
+                "description": f"Cat8kv failed; {pin}",
+                "creator": {"id": reporter.GITHUB_ACTIONS_BOT_ID},
+            },
+            {
+                "context": "lab-ci-next / cat9k",
+                "state": "success",
+                "description": f"Cat9k passed; {pin}",
+                "creator": {"id": reporter.GITHUB_ACTIONS_BOT_ID},
+            },
+        ]
+
+        with mock.patch.object(reporter, "api", return_value=statuses):
+            latest = reporter.latest_status_per_context(
+                "cisco-open/repo",
+                self.HEAD_SHA,
+                self.BASE_SHA,
+                self.MERGE_SHA,
+            )
+
+        self.assertEqual(latest["lab-ci-next / cat8kv"]["state"], "failure")
+        self.assertEqual(latest["lab-ci-next / cat9k"]["state"], "success")
+
+    def test_latest_statuses_continue_past_untrusted_first_page(self) -> None:
+        pin = f"base={self.BASE_SHA}; merge={self.MERGE_SHA}"
+        untrusted = [
+            {
+                "context": "lab-ci-next / cat8kv",
+                "state": "success",
+                "description": pin,
+                "creator": {"id": 1234},
+            }
+            for _ in range(100)
+        ]
+        trusted = [
+            {
+                "context": entry["context"],
+                "state": "success",
+                "description": pin,
+                "creator": {"id": reporter.GITHUB_ACTIONS_BOT_ID},
+            }
+            for entry in reporter.CONTEXTS
+        ]
+
+        with mock.patch.object(reporter, "api", side_effect=[untrusted, trusted]) as api:
+            latest = reporter.latest_status_per_context(
+                "cisco-open/repo",
+                self.HEAD_SHA,
+                self.BASE_SHA,
+                self.MERGE_SHA,
+            )
+
+        self.assertEqual(len(latest), len(reporter.CONTEXTS))
+        self.assertEqual(api.call_count, 2)
+
+    def test_terminal_barrier_requires_every_context(self) -> None:
+        cat8kv = {"state": "success"}
+        cat9k = {"state": "failure"}
+        self.assertFalse(reporter.all_contexts_terminal({}))
+        self.assertFalse(
+            reporter.all_contexts_terminal({"lab-ci-next / cat8kv": cat8kv})
+        )
+        self.assertFalse(
+            reporter.all_contexts_terminal(
+                {
+                    "lab-ci-next / cat8kv": cat8kv,
+                    "lab-ci-next / cat9k": {"state": "pending"},
+                }
+            )
+        )
+        self.assertTrue(
+            reporter.all_contexts_terminal(
+                {
+                    "lab-ci-next / cat8kv": cat8kv,
+                    "lab-ci-next / cat9k": cat9k,
+                }
+            )
+        )
+
+    def test_main_skips_report_while_any_context_is_not_terminal(self) -> None:
+        environment = {
+            "REPOSITORY": "cisco-open/repo",
+            "HEAD_SHA": self.HEAD_SHA,
+            "BASE_SHA": self.BASE_SHA,
+            "MERGE_SHA": self.MERGE_SHA,
+            "PR_NUMBER": "147",
+            "GH_TOKEN": "token",
+        }
+        latest = {"lab-ci-next / cat8kv": {"state": "success"}}
+        with (
+            mock.patch.dict(reporter.os.environ, environment, clear=True),
+            mock.patch.object(reporter, "pr_still_has_head", return_value=True),
+            mock.patch.object(
+                reporter,
+                "latest_status_per_context",
+                return_value=latest,
+            ),
+            mock.patch.object(reporter, "render_report") as render,
+            mock.patch.object(reporter, "upsert_comment") as upsert,
+        ):
+            result = reporter.main()
+
+        self.assertEqual(result, 0)
+        render.assert_not_called()
+        upsert.assert_not_called()
+
+    def test_main_upserts_once_all_contexts_are_terminal(self) -> None:
+        environment = {
+            "REPOSITORY": "cisco-open/repo",
+            "HEAD_SHA": self.HEAD_SHA,
+            "BASE_SHA": self.BASE_SHA,
+            "MERGE_SHA": self.MERGE_SHA,
+            "PR_NUMBER": "147",
+            "GH_TOKEN": "token",
+        }
+        latest = {
+            "lab-ci-next / cat8kv": {"state": "success"},
+            "lab-ci-next / cat9k": {"state": "error"},
+        }
+        with (
+            mock.patch.dict(reporter.os.environ, environment, clear=True),
+            mock.patch.object(reporter, "pr_still_has_head", return_value=True),
+            mock.patch.object(
+                reporter,
+                "latest_status_per_context",
+                return_value=latest,
+            ),
+            mock.patch.object(reporter, "render_report", return_value="report") as render,
+            mock.patch.object(reporter, "upsert_comment") as upsert,
+        ):
+            result = reporter.main()
+
+        self.assertEqual(result, 0)
+        render.assert_called_once_with("cisco-open/repo", self.HEAD_SHA, latest)
+        upsert.assert_called_once_with("cisco-open/repo", "147", "report")
+
     def test_user_preseeded_marker_is_not_patched(self) -> None:
         user_comment = {
             "id": 41,
@@ -360,7 +517,31 @@ class ReporterTests(unittest.TestCase):
 
     def test_validate_inputs_rejects_non_numeric_pr(self) -> None:
         with self.assertRaises(ValueError):
-            reporter.validate_inputs("cisco-open/repo", "a" * 40, "1; rm -rf")
+            reporter.validate_inputs(
+                "cisco-open/repo",
+                self.HEAD_SHA,
+                self.BASE_SHA,
+                self.MERGE_SHA,
+                "1; rm -rf",
+            )
+
+    def test_validate_inputs_rejects_invalid_base_or_merge_sha(self) -> None:
+        with self.assertRaisesRegex(ValueError, "BASE_SHA"):
+            reporter.validate_inputs(
+                "cisco-open/repo",
+                self.HEAD_SHA,
+                "not-a-sha",
+                self.MERGE_SHA,
+                "147",
+            )
+        with self.assertRaisesRegex(ValueError, "MERGE_SHA"):
+            reporter.validate_inputs(
+                "cisco-open/repo",
+                self.HEAD_SHA,
+                self.BASE_SHA,
+                "not-a-sha",
+                "147",
+            )
 
     def test_stale_pr_head_is_detected(self) -> None:
         with mock.patch.object(

--- a/.github/workflows/lab-ci-cat8kv.yaml
+++ b/.github/workflows/lab-ci-cat8kv.yaml
@@ -345,8 +345,10 @@ jobs:
       - name: Upsert native Lab CI report
         if: always() && needs.prepare.result == 'success'
         env:
+          BASE_SHA: ${{ needs.prepare.outputs.base_sha }}
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           HEAD_SHA: ${{ needs.prepare.outputs.head_sha }}
+          MERGE_SHA: ${{ needs.prepare.outputs.merge_sha }}
           PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}
         run: python3 .github/scripts/post-pr-report.py

--- a/.github/workflows/lab-ci-cat9k.yaml
+++ b/.github/workflows/lab-ci-cat9k.yaml
@@ -347,8 +347,10 @@ jobs:
       - name: Upsert native Lab CI report
         if: always() && needs.prepare.result == 'success'
         env:
+          BASE_SHA: ${{ needs.prepare.outputs.base_sha }}
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           HEAD_SHA: ${{ needs.prepare.outputs.head_sha }}
+          MERGE_SHA: ${{ needs.prepare.outputs.merge_sha }}
           PR_NUMBER: ${{ needs.prepare.outputs.pr_number }}
         run: python3 .github/scripts/post-pr-report.py


### PR DESCRIPTION
## Summary

- wait until both native Cat8kv and Cat9k statuses are terminal before creating or updating the PR report
- accept only statuses created by `github-actions[bot]` for the exact verified base and prospective merge SHAs
- pass the verified base and merge SHAs from each trusted wrapper into the reporter
- cover missing, pending, forged, stale-pin, paginated, and terminal status cases

This prevents the first completed lab wrapper from publishing an interim report and triggering an email while the other target is still running. The final wrapper still upserts the single existing report under the per-PR report concurrency lock.

## Merge order

Merge #160 first. This PR is stacked on its dependency/vulnerability baseline so the complete required suite remains green; the reporting change itself is isolated to the four files above.

## Validation

- `python3 -m unittest discover -s .github/scripts -p 'test_*.py' -v` (48 tests)
- `actionlint -config-file .github/actionlint.yaml .github/workflows/lab-ci-*.yaml`
- Ruby YAML parse for both modified workflows
- `git diff --check`
