### PR TITLE
chore(release): prepare v2026.08.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,16 +80,16 @@ The chart and its container image are published to GitHub Container Registry wit
 
 ```bash
 helm install cvk oci://ghcr.io/cisco-open/charts/cisco-virtual-kubelet \
-  --version 2026.7.1 \
+  --version 2026.8.0 \
   --namespace cvk-system --create-namespace
 ```
 
-This deploys the signed `ghcr.io/cisco-open/cisco-virtual-kubelet` image by default — no `--set image.*` needed. The chart `--version` is the release normalised to SemVer (e.g. `v2026.07.1` → `2026.7.1`); see [Releases](https://github.com/cisco-open/cisco-virtual-kubelet/releases) for the current version.
+This deploys the signed `ghcr.io/cisco-open/cisco-virtual-kubelet` image by default — no `--set image.*` needed. The chart `--version` is the release normalised to SemVer (e.g. `v2026.08.0` → `2026.8.0`); see [Releases](https://github.com/cisco-open/cisco-virtual-kubelet/releases) for the current version.
 
 Optionally verify the chart signature before installing:
 
 ```bash
-cosign verify ghcr.io/cisco-open/charts/cisco-virtual-kubelet:2026.7.1 \
+cosign verify ghcr.io/cisco-open/charts/cisco-virtual-kubelet:2026.8.0 \
   --certificate-identity-regexp "https://github.com/cisco-open/cisco-virtual-kubelet/.github/workflows/release.yml@refs/tags/v.*" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```

--- a/charts/cisco-virtual-kubelet/Chart.yaml
+++ b/charts/cisco-virtual-kubelet/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # from the git tag by the release workflow; the values below are the
 # source-tree defaults used for local installs.
 version: 0.1.0
-appVersion: "v2026.07.1"
+appVersion: "v2026.08.0"
 keywords:
   - cisco
   - virtual-kubelet

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -76,11 +76,11 @@ so step 1's custom build is optional and you can install directly:
 
 ```bash
 helm install cvk oci://ghcr.io/cisco-open/charts/cisco-virtual-kubelet \
-  --version 2026.7.1 \
+  --version 2026.8.0 \
   --namespace cvk-system --create-namespace
 ```
 
-This pulls the signed `ghcr.io/cisco-open/cisco-virtual-kubelet` image by default. The chart `--version` is the release normalised to SemVer (e.g. `v2026.07.1` → `2026.7.1`); see [Releases](https://github.com/cisco-open/cisco-virtual-kubelet/releases) for the current one.
+This pulls the signed `ghcr.io/cisco-open/cisco-virtual-kubelet` image by default. The chart `--version` is the release normalised to SemVer (e.g. `v2026.08.0` → `2026.8.0`); see [Releases](https://github.com/cisco-open/cisco-virtual-kubelet/releases) for the current one.
 
 **From source with a custom image** — to run the build from step 1 instead:
 


### PR DESCRIPTION
## Scope

- Set the source chart `appVersion` to `v2026.08.0`.
- Update the published Helm install and signature-verification examples to chart `2026.8.0`.
- Preserve the release workflow's source chart version (`0.1.0`); the tag workflow derives the published chart version.
- No runtime, API, dependency, or workflow changes.

## Validation

- `git diff --check origin/main...HEAD`
- `helm lint charts/cisco-virtual-kubelet`
- `helm template cvk charts/cisco-virtual-kubelet --namespace cvk-system` renders `ghcr.io/cisco-open/cisco-virtual-kubelet:v2026.08.0`
- `mkdocs build --strict`
- Exact three-file diff: `README.md`, `charts/cisco-virtual-kubelet/Chart.yaml`, `docs/getting-started.md`
- Stable patch ID: `fbe98765ad40e3ed36cdea48d45cdb17159cffe7`

## Approved release notes — use verbatim for the GitHub release

## v2026.08.0

### Highlights

- NX-OS Network-as-Code parity contracts now use platform-neutral validation and writer interfaces plus a pinned oracle for NetAsCode module 0.3.0 and NX-OS provider 0.13.1.
- NX-OS reconciliation now fails fast on mutating errors and residual drift, exposes bounded redacted typed DME diagnostics, retries only idempotent reads for 429/5xx responses, never automatically replays mutations, and includes deterministic recovery evidence and a recovery runbook.
- App-hosting and DeviceOperation paths have stronger input validation, secret and error redaction, bounded responses, redirect rejection, stale-cache, generation, and UID safety, and restricted pod-security and TLS-CA handling.
- CI now runs from `cisco-open` with approval-triggered trusted Cat8kv and Cat9k canaries and seven protected contexts.

### NX-OS qualification and scope

NX-OS remains **Beta** and is **offline-oracle-qualified only** for v2026.08.0. The pinned conformance oracle covers NetAsCode module 0.3.0, NX-OS provider 0.13.1, and the `system`, `feature`, `feature_set`, `vlan`, and `interface_ethernet` families. Credentialed live qualification is pending, and NX-OS live CI remains disabled/non-required. This release does not claim full IOS-XE parity or full live NX-OS parity.

### Security

- Patched `github.com/google/cel-go` to v0.29.0 and `sharp` to 0.35.3; Dependabot alerts #83 and #70 are fixed, not dismissed.
- Patched `minimatch` to 10.2.4 and `brace-expansion` to 5.0.8; `npm audit` reports zero vulnerabilities.
- Updated `golang.org/x/text` in both Go modules and kept the controller and Terraform-provider `govulncheck` gates green.

### Artifacts

- Multi-architecture `linux/amd64` and `linux/arm64` image at `ghcr.io/cisco-open/cisco-virtual-kubelet:v2026.08.0`
- Signed OCI Helm chart `oci://ghcr.io/cisco-open/charts/cisco-virtual-kubelet` version `2026.8.0`, with appVersion `v2026.08.0`
- CycloneDX SBOM, keyless image and chart signatures, and image SBOM attestation

**Full changelog:** https://github.com/cisco-open/cisco-virtual-kubelet/compare/v2026.07.1...v2026.08.0

The release notes above are a hard pre-tag gate. After the annotated tag is created on the frozen canonical-main commit, they will be staged unchanged in a draft GitHub release. The draft must remain unpublished until the tag workflow, artifacts, signatures, SBOM/attestation, chart metadata, docs, and scans are verified.
