### PR TITLE
fix(release): keep GitHub release draft during verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,10 +140,13 @@ jobs:
           path: sbom.cdx.json
           retention-days: 90
 
+      # action-gh-release publishes an existing draft unless draft is explicit.
+      # Keep publication separate from artifact generation and verification.
       - name: Attach SBOM to GitHub Release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
+          draft: true
           files: sbom.cdx.json
 
       # Advisory vulnerability scan, runs last and never blocks the signed


### PR DESCRIPTION
## Why

`softprops/action-gh-release@v2` publishes an existing draft when the `draft` input is omitted. The v2026.07.1 release was published at the SBOM-upload step, before Trivy completed and before the OCI chart was signed.

That behavior violates the v2026.08.0 release gate requiring the approved draft to remain unpublished until every artifact, signature, attestation, chart, documentation, and scan check is verified.

## Change

- Set `draft: true` on the SBOM release-asset step.
- Document why publication must remain a separate verified action.

No runtime, API, dependency, chart, or release-note content changes.

## Validation

- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/release.yml`
- Parsed the workflow and asserted the named SBOM step has `with.draft == true`
- Confirmed `v2026.08.0` remains untagged and unpublished

After this merges, canonical main must be re-frozen and all required contexts revalidated before tagging.