### PR TITLE
feat(cli): harden kubectl-ciscovk for distribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,17 +1,202 @@
-Apache License
-Version 2.0, January 2004
-http://www.apache.org/licenses/
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-    http://www.apache.org/licenses/LICENSE-2.0
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+   1. Definitions.
 
-Copyright 2026 Cisco Systems, Inc.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,9 @@
 
 # Build variables
 BINARY_NAME=cisco-vk
+PLUGIN_BINARY_NAME=kubectl-ciscovk
 VERSION?=1.0.0
+PLUGIN_VERSION?=$(shell git describe --tags --always --dirty 2>/dev/null || echo "devel")
 BUILD_TIME=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 GIT_COMMIT=$(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 YANG_MODELS_URL=https://github.com/YangModels/yang.git
@@ -49,11 +51,13 @@ CONTROLLER_GEN?=$(GO_BIN) run sigs.k8s.io/controller-tools/cmd/controller-gen@v0
 
 # Go build flags
 LDFLAGS=-ldflags "-X main.Version=$(VERSION) -X main.BuildTime=$(BUILD_TIME) -X main.GitCommit=$(GIT_COMMIT)"
+PLUGIN_LDFLAGS=-ldflags "-s -w -X main.Version=$(PLUGIN_VERSION) -X main.BuildTime=$(BUILD_TIME) -X main.GitCommit=$(GIT_COMMIT)"
 
 # Directories
 BIN_DIR=bin
 PKG_DIR=pkg
 CMD_DIR=cmd/cisco-vk
+PLUGIN_CMD_DIR=tools/kubectl-ciscovk
 
 # Installation directories
 PREFIX?=/usr/local
@@ -61,7 +65,7 @@ INSTALL_DIR=$(PREFIX)/bin
 CONFIG_DIR=/etc/cisco-vk
 SYSTEMD_DIR=/etc/systemd/system
 
-.PHONY: all build clean install uninstall test test-envtest lint fmt deps help generate manifests crd-gen deepcopy-gen rbac-gen helm-sync-crds config-lint netascode-migrate config-docs yang-sync migrate-tool parity-matrix check-parity-matrix check-nxos-oracle vendor-yang apphosting-ygot-gen ygot-validate-gen
+.PHONY: all build build-plugin clean install uninstall test test-envtest lint fmt deps help generate manifests crd-gen deepcopy-gen rbac-gen helm-sync-crds config-lint netascode-migrate config-docs yang-sync migrate-tool parity-matrix check-parity-matrix check-nxos-oracle vendor-yang apphosting-ygot-gen ygot-validate-gen
 
 all: build
 
@@ -72,6 +76,12 @@ build: deps ## Build the binary
 	@mkdir -p $(BIN_DIR)
 	$(GO_BIN) build $(LDFLAGS) -o $(BIN_DIR)/$(BINARY_NAME) ./$(CMD_DIR)
 	@echo "Binary built: $(BIN_DIR)/$(BINARY_NAME)"
+
+build-plugin: ## Build kubectl-ciscovk with version metadata
+	@echo "Building $(PLUGIN_BINARY_NAME)..."
+	@mkdir -p $(BIN_DIR)
+	$(GO_BIN) build $(PLUGIN_LDFLAGS) -o $(BIN_DIR)/$(PLUGIN_BINARY_NAME) ./$(PLUGIN_CMD_DIR)
+	@echo "Plugin built: $(BIN_DIR)/$(PLUGIN_BINARY_NAME)"
 
 build-linux: deps
 	@echo "Building $(BINARY_NAME) for Linux..."

--- a/docs/cisco-vk-cli.md
+++ b/docs/cisco-vk-cli.md
@@ -15,17 +15,16 @@ Cisco Virtual Kubelet exposes two command-line surfaces:
 ### Build and install
 
 Prebuilt plugin binaries are not currently attached to GitHub releases. Build
-the plugin from a release checkout and place it on your `PATH` using the
+the plugin from the current source tree and place it on your `PATH` using the
 standard `kubectl-<name>` filename:
 
 ```bash
 git clone https://github.com/cisco-open/cisco-virtual-kubelet.git
 cd cisco-virtual-kubelet
-git checkout "$(git describe --tags --abbrev=0)"
 
-go build -o kubectl-ciscovk ./tools/kubectl-ciscovk
+make build-plugin
 mkdir -p "$HOME/.local/bin"
-install -m 0755 kubectl-ciscovk "$HOME/.local/bin/kubectl-ciscovk"
+install -m 0755 bin/kubectl-ciscovk "$HOME/.local/bin/kubectl-ciscovk"
 ```
 
 Ensure `$HOME/.local/bin` is on your `PATH`, then verify the plugin:
@@ -35,10 +34,14 @@ kubectl ciscovk version
 kubectl ciscovk --help
 ```
 
-The plugin invokes the `kubectl` binary from `PATH`, so it inherits
-`KUBECONFIG` and the active context. It does not implement its own `--context`
-flag. Select the context with `kubectl config use-context` or `KUBECONFIG`
-before invoking it.
+`make build-plugin` injects the nearest Git tag, commit, and build time into
+the version output. Direct `go build` remains supported and reports a
+`devel` build instead of impersonating a release.
+
+The plugin invokes the `kubectl` binary from `PATH`. By default it inherits
+`KUBECONFIG` and the active context. Pass `--context` and/or `--kubeconfig` to
+select a target explicitly without changing the user's active context; the
+plugin forwards both options to pod discovery and port-forwarding.
 
 ### Execute a read-only IOS-XE command
 
@@ -49,6 +52,7 @@ tunnel:
 ```bash
 kubectl ciscovk exec cat9k-smoke -n cvk-system -- show version
 kubectl ciscovk exec cat9k-smoke -n cvk-system \
+  --context lab --kubeconfig "$HOME/.kube/lab.conf" \
   -- "show running-config | section interface"
 ```
 
@@ -66,7 +70,14 @@ Flags for `exec`:
 | `--truncate-bytes` | `65536` | Maximum output bytes per command; `0` disables truncation. |
 | `--port` | random free port | Local port used for `kubectl port-forward`. |
 | `--timeout` | `30s` | Overall command timeout. |
+| `--context` | active context | Kubeconfig context forwarded to `kubectl`. |
+| `--kubeconfig` | `KUBECONFIG`/kubectl default | Kubeconfig path forwarded to `kubectl`. |
 | `--kubectl` | `kubectl` from `PATH` | Alternate path to the `kubectl` executable. |
+
+The active Kubernetes identity needs permission to get/list pods in the
+selected namespace and create `pods/portforward` connections. `exec` requires
+the per-device deployment mode and its localhost diagnostic admin endpoint; it
+is not available in aggregator mode.
 
 ### DeviceOperation CR — auditable asynchronous path
 

--- a/tools/kubectl-ciscovk/main.go
+++ b/tools/kubectl-ciscovk/main.go
@@ -35,6 +35,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -45,10 +46,25 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 )
+
+// Version, GitCommit, and BuildTime are populated by release builds with
+// -ldflags. Development builds deliberately identify themselves as such
+// instead of reporting a stale release version.
+var (
+	Version   = "devel"
+	GitCommit = "unknown"
+	BuildTime = "unknown"
+)
+
+var commandContext = exec.CommandContext
+
+const kubectlWaitDelay = 2 * time.Second
 
 func main() {
 	if len(os.Args) < 2 {
@@ -64,7 +80,7 @@ func main() {
 	case "-h", "--help", "help":
 		usage()
 	case "version":
-		fmt.Println("kubectl-ciscovk v0.1.0")
+		printVersion(os.Stdout)
 	default:
 		fmt.Fprintf(os.Stderr, "unknown subcommand %q\n\n", os.Args[1])
 		usage()
@@ -93,7 +109,13 @@ Flags for exec:
   --truncate-bytes N       cap each command's output (default 64 KiB; 0 disables)
   --port N                 local port for port-forward (default: random free)
   --timeout DURATION       overall timeout (default 30s)
+  --context NAME           kubeconfig context to use
+  --kubeconfig PATH        path to the kubeconfig file
   --kubectl PATH           path to kubectl binary (default: from PATH)`)
+}
+
+func printVersion(w io.Writer) {
+	fmt.Fprintf(w, "kubectl-ciscovk %s (commit=%s, built=%s)\n", Version, GitCommit, BuildTime)
 }
 
 // execFlags is the parsed argv for the `exec` subcommand. Hand-
@@ -107,6 +129,8 @@ type execFlags struct {
 	localPort    int
 	timeout      time.Duration
 	kubectlBin   string
+	kubeContext  string
+	kubeconfig   string
 	commands     []string
 }
 
@@ -140,7 +164,7 @@ func parseExecArgs(argv []string) (*execFlags, error) {
 			if i >= len(argv) {
 				return nil, errors.New("--truncate-bytes requires a value")
 			}
-			n, err := parsePositiveInt(argv[i])
+			n, err := parseNonNegativeInt(argv[i])
 			if err != nil {
 				return nil, fmt.Errorf("--truncate-bytes: %w", err)
 			}
@@ -150,7 +174,7 @@ func parseExecArgs(argv []string) (*execFlags, error) {
 			if i >= len(argv) {
 				return nil, errors.New("--port requires a value")
 			}
-			n, err := parsePositiveInt(argv[i])
+			n, err := parseNonNegativeInt(argv[i])
 			if err != nil {
 				return nil, fmt.Errorf("--port: %w", err)
 			}
@@ -164,6 +188,9 @@ func parseExecArgs(argv []string) (*execFlags, error) {
 			if err != nil {
 				return nil, fmt.Errorf("--timeout: %w", err)
 			}
+			if d <= 0 {
+				return nil, errors.New("--timeout must be greater than zero")
+			}
 			f.timeout = d
 		case "--kubectl":
 			i++
@@ -171,6 +198,18 @@ func parseExecArgs(argv []string) (*execFlags, error) {
 				return nil, errors.New("--kubectl requires a path")
 			}
 			f.kubectlBin = argv[i]
+		case "--context":
+			i++
+			if i >= len(argv) {
+				return nil, errors.New("--context requires a name")
+			}
+			f.kubeContext = argv[i]
+		case "--kubeconfig":
+			i++
+			if i >= len(argv) {
+				return nil, errors.New("--kubeconfig requires a path")
+			}
+			f.kubeconfig = argv[i]
 		default:
 			if f.device == "" {
 				f.device = a
@@ -182,18 +221,15 @@ func parseExecArgs(argv []string) (*execFlags, error) {
 	return f, validateExec(f)
 }
 
-func parsePositiveInt(s string) (int, error) {
+func parseNonNegativeInt(s string) (int, error) {
 	if s == "" {
 		return 0, errors.New("empty")
 	}
-	n := 0
-	for _, c := range s {
-		if c < '0' || c > '9' {
-			return 0, fmt.Errorf("not a positive integer: %q", s)
-		}
-		n = n*10 + int(c-'0')
+	n, err := strconv.ParseUint(s, 10, 31)
+	if err != nil {
+		return 0, fmt.Errorf("not a non-negative integer: %q", s)
 	}
-	return n, nil
+	return int(n), nil
 }
 
 func validateExec(f *execFlags) error {
@@ -203,6 +239,9 @@ func validateExec(f *execFlags) error {
 	if len(f.commands) == 0 {
 		return errors.New("missing command after `--`; example: kubectl ciscovk exec cat9k-smoke -- show ip route")
 	}
+	if f.localPort > 65535 {
+		return fmt.Errorf("--port must be between 0 and 65535, got %d", f.localPort)
+	}
 	// Defence-in-depth: refuse known-destructive commands explicitly.
 	// The admin server is read-only by design (cli-exec, not
 	// cli-config-data), but a typo on the device side is one fewer
@@ -210,6 +249,9 @@ func validateExec(f *execFlags) error {
 	// RFC's destructive paths land on a different CRD and code path.
 	for _, cmd := range f.commands {
 		head := strings.ToLower(strings.TrimSpace(cmd))
+		if head == "" {
+			return errors.New("command after `--` must not be empty")
+		}
 		for _, banned := range []string{"reload", "write erase", "delete flash:", "format flash:", "clear "} {
 			if strings.HasPrefix(head, banned) {
 				return fmt.Errorf("destructive command %q is not supported by `exec`; see device-operations-rfc.md for IOSXEMaintenance / IOSXEDeviceOp", cmd)
@@ -220,6 +262,10 @@ func validateExec(f *execFlags) error {
 }
 
 func runExec(argv []string) error {
+	return runExecWithIO(argv, os.Stdout, os.Stderr)
+}
+
+func runExecWithIO(argv []string, stdout, stderr io.Writer) error {
 	f, err := parseExecArgs(argv)
 	if err != nil {
 		return err
@@ -229,15 +275,12 @@ func runExec(argv []string) error {
 	ctx, cancelTO := context.WithTimeout(ctx, f.timeout)
 	defer cancelTO()
 
-	pfPort, kubectlCmd, err := startPortForward(ctx, f)
+	pfPort, kubectlCmd, err := startPortForward(ctx, f, stderr)
 	if err != nil {
 		return fmt.Errorf("port-forward: %w", err)
 	}
 	defer func() {
-		if kubectlCmd != nil && kubectlCmd.Process != nil {
-			_ = kubectlCmd.Process.Signal(syscall.SIGTERM)
-			_, _ = kubectlCmd.Process.Wait()
-		}
+		stopProcess(kubectlCmd)
 	}()
 
 	// The /healthz endpoint is the canary for "kubectl port-forward
@@ -291,24 +334,24 @@ func runExec(argv []string) error {
 
 	// Header line for fleet log clarity. Operators piping the output
 	// to grep / less appreciate the device + transport context.
-	fmt.Printf("# device=%s transport=%s captured=%s\n",
+	fmt.Fprintf(stdout, "# device=%s transport=%s captured=%s\n",
 		parsed.Device, parsed.Transport, parsed.CapturedAt)
 
 	if parsed.TransportError != "" {
-		fmt.Fprintf(os.Stderr, "# transport-error: %s\n", parsed.TransportError)
+		fmt.Fprintf(stderr, "# transport-error: %s\n", parsed.TransportError)
 	}
 
 	for i, r := range parsed.Results {
 		if i > 0 || len(parsed.Results) > 1 {
-			fmt.Printf("\n# ─── %s ──────────────────────────────\n", r.Command)
+			fmt.Fprintf(stdout, "\n# ─── %s ──────────────────────────────\n", r.Command)
 		}
 		if r.Err != "" {
-			fmt.Fprintf(os.Stderr, "# error: %s\n", r.Err)
+			fmt.Fprintf(stderr, "# error: %s\n", r.Err)
 			continue
 		}
-		fmt.Println(r.Output)
+		fmt.Fprintln(stdout, r.Output)
 		if r.Truncated {
-			fmt.Fprintln(os.Stderr, "# (output truncated by --truncate-bytes)")
+			fmt.Fprintln(stderr, "# (output truncated by --truncate-bytes)")
 		}
 	}
 	return nil
@@ -321,28 +364,35 @@ func runExec(argv []string) error {
 // We use kubectl's pod-label selector (app.kubernetes.io/instance=
 // <device>) so the plugin doesn't have to know the deployment-
 // generated pod name.
-func startPortForward(ctx context.Context, f *execFlags) (int, *exec.Cmd, error) {
+func startPortForward(ctx context.Context, f *execFlags, liveStderr io.Writer) (int, *exec.Cmd, error) {
+	kubectlPath, err := exec.LookPath(f.kubectlBin)
+	if err != nil {
+		return 0, nil, fmt.Errorf("kubectl executable %q not found: %w", f.kubectlBin, err)
+	}
+
 	port := f.localPort
 	if port == 0 {
-		port = 0 // kubectl picks; we discover by parsing its stderr
+		port = 0 // kubectl picks; we discover by parsing its stdout
 	}
 	// kubectl port-forward takes a concrete pod NAME, not a label
 	// selector. Resolve the pod first via `kubectl get pod -l
 	// app.kubernetes.io/instance=<device> -o name`. The selector
 	// is the canonical label the controller stamps on per-device
-	// pods so this works in both per-pod-kubelet and aggregator
-	// topologies.
-	getArgs := []string{"get", "pod"}
+	// pods in the supported per-device deployment topology.
+	getArgs := kubectlArgs(f, "get", "pod")
 	if f.namespace != "" {
 		getArgs = append(getArgs, "-n", f.namespace)
 	}
 	getArgs = append(getArgs,
 		"-l", "app.kubernetes.io/instance="+f.device,
 		"-o", "jsonpath={.items[0].metadata.name}")
-	getCmd := exec.CommandContext(ctx, f.kubectlBin, getArgs...)
+	getCmd := commandContext(ctx, kubectlPath, getArgs...)
+	getCmd.WaitDelay = kubectlWaitDelay
+	var getStderr bytes.Buffer
+	getCmd.Stderr = &getStderr
 	podOut, err := getCmd.Output()
 	if err != nil {
-		return 0, nil, fmt.Errorf("resolve pod for device %q: %w", f.device, err)
+		return 0, nil, commandError(fmt.Sprintf("resolve pod for device %q", f.device), err, getStderr.String())
 	}
 	podName := strings.TrimSpace(string(podOut))
 	if podName == "" {
@@ -350,7 +400,7 @@ func startPortForward(ctx context.Context, f *execFlags) (int, *exec.Cmd, error)
 			f.device, f.device)
 	}
 
-	args := []string{"port-forward"}
+	args := kubectlArgs(f, "port-forward")
 	if f.namespace != "" {
 		args = append(args, "-n", f.namespace)
 	}
@@ -360,12 +410,15 @@ func startPortForward(ctx context.Context, f *execFlags) (int, *exec.Cmd, error)
 	} else {
 		args = append(args, fmt.Sprintf("%d:8082", port))
 	}
-	cmd := exec.CommandContext(ctx, f.kubectlBin, args...)
+	cmd := commandContext(ctx, kubectlPath, args...)
+	// Bound Cmd.Wait even if a descendant inherits the port-forward pipes.
+	cmd.WaitDelay = kubectlWaitDelay
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return 0, nil, err
 	}
-	cmd.Stderr = os.Stderr
+	diagnostics := newDeferredDiagnostics(liveStderr)
+	cmd.Stderr = diagnostics
 	if err := cmd.Start(); err != nil {
 		return 0, nil, err
 	}
@@ -373,37 +426,114 @@ func startPortForward(ctx context.Context, f *execFlags) (int, *exec.Cmd, error)
 	// on stdout when ready. Parse the local port. Bound the wait
 	// to context — if kubectl never speaks, we surface the issue
 	// rather than hanging.
-	resolved := make(chan int, 1)
-	errCh := make(chan error, 1)
+	type portForwardResult struct {
+		port int
+		err  error
+	}
+	resultCh := make(chan portForwardResult, 1)
 	go func() {
-		defer close(resolved)
-		defer close(errCh)
-		buf := make([]byte, 4096)
-		for {
-			n, err := stdout.Read(buf)
-			if n > 0 {
-				if p := parseForwardingPort(string(buf[:n])); p > 0 {
-					resolved <- p
-					_, _ = io.Copy(io.Discard, stdout) // drain rest
-					return
-				}
-			}
-			if err != nil {
-				errCh <- err
+		scanner := bufio.NewScanner(stdout)
+		for scanner.Scan() {
+			if p := parseForwardingPort(scanner.Text()); p > 0 {
+				resultCh <- portForwardResult{port: p}
+				_, _ = io.Copy(io.Discard, stdout) // drain until the process exits
 				return
 			}
 		}
+		if err := scanner.Err(); err != nil {
+			resultCh <- portForwardResult{err: err}
+			return
+		}
+		resultCh <- portForwardResult{err: io.EOF}
 	}()
 	select {
-	case p := <-resolved:
-		return p, cmd, nil
-	case err := <-errCh:
-		_ = cmd.Process.Kill()
-		return 0, nil, fmt.Errorf("kubectl port-forward exited before binding: %v", err)
+	case result := <-resultCh:
+		if result.err == nil {
+			diagnostics.startStreaming()
+			return result.port, cmd, nil
+		}
+		stopProcess(cmd)
+		return 0, nil, commandError("kubectl port-forward exited before binding", result.err, diagnostics.String())
 	case <-ctx.Done():
-		_ = cmd.Process.Kill()
-		return 0, nil, ctx.Err()
+		stopProcess(cmd)
+		return 0, nil, commandError("kubectl port-forward", ctx.Err(), diagnostics.String())
 	}
+}
+
+// deferredDiagnostics keeps startup errors available for the returned error
+// without printing them twice. Once port-forward is ready, buffered warnings
+// are flushed and later diagnostics stream to the caller in real time.
+type deferredDiagnostics struct {
+	mu        sync.Mutex
+	dst       io.Writer
+	buffer    bytes.Buffer
+	streaming bool
+}
+
+func newDeferredDiagnostics(dst io.Writer) *deferredDiagnostics {
+	if dst == nil {
+		dst = io.Discard
+	}
+	return &deferredDiagnostics{dst: dst}
+}
+
+func (d *deferredDiagnostics) Write(p []byte) (int, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.streaming {
+		_, _ = d.dst.Write(p)
+		return len(p), nil
+	}
+	return d.buffer.Write(p)
+}
+
+func (d *deferredDiagnostics) startStreaming() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.streaming {
+		return
+	}
+	d.streaming = true
+	if d.buffer.Len() > 0 {
+		_, _ = d.dst.Write(d.buffer.Bytes())
+		d.buffer.Reset()
+	}
+}
+
+func (d *deferredDiagnostics) String() string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.buffer.String()
+}
+
+func kubectlArgs(f *execFlags, args ...string) []string {
+	global := make([]string, 0, 4+len(args))
+	if f.kubeconfig != "" {
+		global = append(global, "--kubeconfig", f.kubeconfig)
+	}
+	if f.kubeContext != "" {
+		global = append(global, "--context", f.kubeContext)
+	}
+	return append(global, args...)
+}
+
+func commandError(action string, err error, stderr string) error {
+	if detail := strings.TrimSpace(stderr); detail != "" {
+		return fmt.Errorf("%s: %w: %s", action, err, detail)
+	}
+	return fmt.Errorf("%s: %w", action, err)
+}
+
+// stopProcess terminates the disposable kubectl port-forward subprocess and
+// reaps it through exec.Cmd. Process.Kill is portable across supported
+// platforms, unlike sending SIGTERM. startPortForward sets Cmd.WaitDelay so
+// inherited pipes cannot leave this cleanup blocked indefinitely.
+func stopProcess(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = cmd.Process.Kill()
+	_ = cmd.Wait()
 }
 
 // parseForwardingPort extracts NNNNN from kubectl's "Forwarding
@@ -430,25 +560,31 @@ func parseForwardingPort(s string) int {
 func waitForHealthz(ctx context.Context, port int) error {
 	url := fmt.Sprintf("http://127.0.0.1:%d/healthz", port)
 	deadline := time.Now().Add(5 * time.Second)
+	client := &http.Client{Timeout: 750 * time.Millisecond}
 	var lastErr error
 	for time.Now().Before(deadline) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return err
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			lastErr = err
+		} else {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+			lastErr = fmt.Errorf("healthz returned %s", resp.Status)
+		}
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		default:
+		case <-time.After(150 * time.Millisecond):
 		}
-		resp, err := http.Get(url)
-		if err != nil {
-			lastErr = err
-			time.Sleep(150 * time.Millisecond)
-			continue
-		}
-		_ = resp.Body.Close()
-		if resp.StatusCode == http.StatusOK {
-			return nil
-		}
-		lastErr = fmt.Errorf("healthz returned %s", resp.Status)
-		time.Sleep(150 * time.Millisecond)
 	}
 	if lastErr == nil {
 		lastErr = errors.New("timed out")

--- a/tools/kubectl-ciscovk/main_test.go
+++ b/tools/kubectl-ciscovk/main_test.go
@@ -15,20 +15,35 @@
 package main
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"slices"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestParseExecArgs(t *testing.T) {
 	cases := []struct {
-		name      string
-		argv      []string
-		wantErr   string
-		wantDev   string
-		wantNS    string
-		wantAllow bool
-		wantTrunc int
-		wantCmds  []string
+		name       string
+		argv       []string
+		wantErr    string
+		wantDev    string
+		wantNS     string
+		wantAllow  bool
+		wantTrunc  int
+		wantCtx    string
+		wantConfig string
+		wantCmds   []string
 	}{
 		{
 			name:      "minimal",
@@ -52,6 +67,15 @@ func TestParseExecArgs(t *testing.T) {
 			wantAllow: true,
 			wantTrunc: 1024,
 			wantCmds:  []string{"show running-config"},
+		},
+		{
+			name:       "explicit kube target",
+			argv:       []string{"cat9k-smoke", "--context", "lab", "--kubeconfig", "/tmp/lab.conf", "--", "show", "version"},
+			wantDev:    "cat9k-smoke",
+			wantCtx:    "lab",
+			wantConfig: "/tmp/lab.conf",
+			wantTrunc:  64 * 1024,
+			wantCmds:   []string{"show version"},
 		},
 		{
 			name:    "no command",
@@ -78,6 +102,36 @@ func TestParseExecArgs(t *testing.T) {
 			argv:    []string{"cat9k-smoke", "--", "write", "erase"},
 			wantErr: "destructive command",
 		},
+		{
+			name:    "context requires value",
+			argv:    []string{"cat9k-smoke", "--context"},
+			wantErr: "--context requires a name",
+		},
+		{
+			name:    "kubeconfig requires value",
+			argv:    []string{"cat9k-smoke", "--kubeconfig"},
+			wantErr: "--kubeconfig requires a path",
+		},
+		{
+			name:    "rejects empty command",
+			argv:    []string{"cat9k-smoke", "--"},
+			wantErr: "must not be empty",
+		},
+		{
+			name:    "rejects non-positive timeout",
+			argv:    []string{"cat9k-smoke", "--timeout", "0s", "--", "show version"},
+			wantErr: "greater than zero",
+		},
+		{
+			name:    "rejects invalid port",
+			argv:    []string{"cat9k-smoke", "--port", "65536", "--", "show version"},
+			wantErr: "between 0 and 65535",
+		},
+		{
+			name:    "rejects overflowing integer",
+			argv:    []string{"cat9k-smoke", "--truncate-bytes", "999999999999999999999", "--", "show version"},
+			wantErr: "non-negative integer",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -103,10 +157,210 @@ func TestParseExecArgs(t *testing.T) {
 			if f.truncateB != tc.wantTrunc {
 				t.Errorf("truncateB=%d want %d", f.truncateB, tc.wantTrunc)
 			}
+			if f.kubeContext != tc.wantCtx {
+				t.Errorf("kubeContext=%q want %q", f.kubeContext, tc.wantCtx)
+			}
+			if f.kubeconfig != tc.wantConfig {
+				t.Errorf("kubeconfig=%q want %q", f.kubeconfig, tc.wantConfig)
+			}
 			if !equalStrings(f.commands, tc.wantCmds) {
 				t.Errorf("commands=%v want %v", f.commands, tc.wantCmds)
 			}
 		})
+	}
+}
+
+func TestPrintVersion(t *testing.T) {
+	oldVersion, oldCommit, oldBuildTime := Version, GitCommit, BuildTime
+	Version, GitCommit, BuildTime = "v2026.9.0", "abc1234", "2026-09-01T07:00:00Z"
+	t.Cleanup(func() {
+		Version, GitCommit, BuildTime = oldVersion, oldCommit, oldBuildTime
+	})
+
+	var got bytes.Buffer
+	printVersion(&got)
+	want := "kubectl-ciscovk v2026.9.0 (commit=abc1234, built=2026-09-01T07:00:00Z)\n"
+	if got.String() != want {
+		t.Fatalf("version output = %q, want %q", got.String(), want)
+	}
+}
+
+func TestKubectlArgs(t *testing.T) {
+	f := &execFlags{kubeconfig: "/tmp/lab.conf", kubeContext: "lab"}
+	got := kubectlArgs(f, "get", "pod")
+	want := []string{"--kubeconfig", "/tmp/lab.conf", "--context", "lab", "get", "pod"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("kubectlArgs() = %q, want %q", got, want)
+	}
+}
+
+func TestDeferredDiagnostics(t *testing.T) {
+	var live bytes.Buffer
+	diagnostics := newDeferredDiagnostics(&live)
+	if _, err := diagnostics.Write([]byte("startup warning\n")); err != nil {
+		t.Fatal(err)
+	}
+	if live.Len() != 0 {
+		t.Fatalf("startup diagnostics streamed before readiness: %q", live.String())
+	}
+	if got := diagnostics.String(); got != "startup warning\n" {
+		t.Fatalf("buffered diagnostics = %q", got)
+	}
+
+	diagnostics.startStreaming()
+	if _, err := diagnostics.Write([]byte("lost connection\n")); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := live.String(), "startup warning\nlost connection\n"; got != want {
+		t.Fatalf("live diagnostics = %q, want %q", got, want)
+	}
+	if diagnostics.String() != "" {
+		t.Fatalf("startup buffer was not released after streaming")
+	}
+}
+
+func TestRunExecWithFakeKubectl(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/healthz":
+			w.WriteHeader(http.StatusOK)
+		case "/v1/exec":
+			var request struct {
+				Commands     []string `json:"commands"`
+				AllowSecrets bool     `json:"allowSecrets"`
+				TruncateB    int      `json:"truncateBytes"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			if !slices.Equal(request.Commands, []string{"show version"}) || request.AllowSecrets || request.TruncateB != 4096 {
+				http.Error(w, fmt.Sprintf("unexpected request: %+v", request), http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"device":"cat9k-smoke","transport":"gnoi","capturedAt":"2026-09-01T07:00:00Z","results":[{"command":"show version","output":"Cisco IOS XE"}]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	_, portText, err := net.SplitHostPort(strings.TrimPrefix(server.URL, "http://"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	installFakeKubectl(t, "success", portText)
+
+	var stdout, stderr bytes.Buffer
+	err = runExecWithIO([]string{
+		"cat9k-smoke",
+		"-n", "cvk-system",
+		"--context", "lab",
+		"--kubeconfig", "/tmp/lab.conf",
+		"--kubectl", os.Args[0],
+		"--truncate-bytes", "4096",
+		"--", "show", "version",
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("runExecWithIO() error = %v", err)
+	}
+	if want := "# device=cat9k-smoke transport=gnoi captured=2026-09-01T07:00:00Z\nCisco IOS XE\n"; stdout.String() != want {
+		t.Fatalf("stdout = %q, want %q", stdout.String(), want)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestStartPortForwardReportsKubectlFailure(t *testing.T) {
+	installFakeKubectl(t, "failure", "")
+	f := &execFlags{
+		device:      "cat9k-smoke",
+		namespace:   "cvk-system",
+		kubectlBin:  os.Args[0],
+		kubeContext: "lab",
+		kubeconfig:  "/tmp/lab.conf",
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, _, err := startPortForward(ctx, f, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "simulated port-forward failure") {
+		t.Fatalf("startPortForward() error = %v, want helper stderr", err)
+	}
+}
+
+func installFakeKubectl(t *testing.T, mode, port string) {
+	t.Helper()
+	previous := commandContext
+	commandContext = func(ctx context.Context, _ string, args ...string) *exec.Cmd {
+		helperArgs := append([]string{"-test.run=^TestKubectlHelperProcess$", "--"}, args...)
+		cmd := exec.CommandContext(ctx, os.Args[0], helperArgs...)
+		cmd.Env = append(os.Environ(),
+			"GO_WANT_CVK_KUBECTL_HELPER=1",
+			"CVK_KUBECTL_HELPER_MODE="+mode,
+			"CVK_KUBECTL_HELPER_PORT="+port,
+		)
+		return cmd
+	}
+	t.Cleanup(func() { commandContext = previous })
+}
+
+func TestKubectlHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_CVK_KUBECTL_HELPER") != "1" {
+		return
+	}
+	args := os.Args
+	separator := slices.Index(args, "--")
+	if separator < 0 || separator == len(args)-1 {
+		fmt.Fprintln(os.Stderr, "missing helper arguments")
+		os.Exit(2)
+	}
+	args = args[separator+1:]
+
+	global := []string{"--kubeconfig", "/tmp/lab.conf", "--context", "lab"}
+	if len(args) < len(global) || !slices.Equal(args[:len(global)], global) {
+		fmt.Fprintf(os.Stderr, "unexpected global arguments: %q\n", args)
+		os.Exit(2)
+	}
+	args = args[len(global):]
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "missing kubectl command")
+		os.Exit(2)
+	}
+
+	switch args[0] {
+	case "get":
+		want := []string{"get", "pod", "-n", "cvk-system", "-l", "app.kubernetes.io/instance=cat9k-smoke", "-o", "jsonpath={.items[0].metadata.name}"}
+		if !slices.Equal(args, want) {
+			fmt.Fprintf(os.Stderr, "unexpected get arguments: %q\n", args)
+			os.Exit(2)
+		}
+		fmt.Fprint(os.Stdout, "cat9k-smoke-0")
+		os.Exit(0)
+	case "port-forward":
+		want := []string{"port-forward", "-n", "cvk-system", "cat9k-smoke-0", "--address=127.0.0.1", ":8082"}
+		if !slices.Equal(args, want) {
+			fmt.Fprintf(os.Stderr, "unexpected port-forward arguments: %q\n", args)
+			os.Exit(2)
+		}
+		if os.Getenv("CVK_KUBECTL_HELPER_MODE") == "failure" {
+			fmt.Fprintln(os.Stderr, "simulated port-forward failure")
+			os.Exit(3)
+		}
+		port, err := strconv.Atoi(os.Getenv("CVK_KUBECTL_HELPER_PORT"))
+		if err != nil || port == 0 {
+			fmt.Fprintln(os.Stderr, "invalid helper port")
+			os.Exit(2)
+		}
+		fmt.Fprintf(os.Stdout, "Forwarding from 127.0.0.1:%d -> 8082\n", port)
+		for {
+			time.Sleep(time.Hour)
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "unexpected kubectl command: %q\n", args)
+		os.Exit(2)
 	}
 }
 


### PR DESCRIPTION
## Summary

- replace the stale hard-coded plugin version with linker-injected version, commit, and build time metadata
- add explicit `--context` and `--kubeconfig` forwarding to pod discovery and port-forwarding
- make port-forward cleanup portable and bounded, fix readiness result races, retain live diagnostics, and make health probes context-aware
- add a versioned `make build-plugin` target and document the current runtime/RBAC requirements
- replace the abbreviated license notice with the canonical Apache-2.0 license required in future Krew archives
- expand tests with a fake kubectl subprocess and HTTP admin endpoint integration path

## Validation

- `go test -race -count=1 ./...`
- plugin race tests: 74.7% statement coverage
- `go vet ./tools/kubectl-ciscovk`
- Linux, Darwin, and Windows cross-builds for amd64 and arm64
- Windows amd64 test-binary cross-compilation
- `mkdocs build --strict`
- canonical Apache-2.0 license byte comparison
- independent adversarial review: no remaining P0-P2 findings

## Scope and follow-ups

This is the first of three bounded changes. It intentionally does not modify the release workflow or advertise Krew installation yet. After this merges, follow-up PRs will add draft-safe signed release archives and then the Krew manifest, validation, and post-publication index-update flow. Windows remains compile-verified only and will not be advertised until a native smoke job is green.