### PR TITLE
chore(release): prepare v2026.8.1

### DIFF
--- a/.github/scripts/test_package_kubectl_ciscovk.py
+++ b/.github/scripts/test_package_kubectl_ciscovk.py
@@ -132,6 +132,16 @@ class PackageKubectlCiscoVKTests(unittest.TestCase):
                 4,
             )
 
+    def test_release_workflow_disables_implicit_sbom_uploads(self) -> None:
+        workflow = (
+            MODULE_PATH.parents[2] / ".github/workflows/release.yml"
+        ).read_text(encoding="utf-8")
+        self.assertIn("upload-artifact: false", workflow)
+        self.assertIn("upload-release-assets: false", workflow)
+        self.assertIn("expected-release-assets.tsv", workflow)
+        self.assertIn("remote-release-assets.tsv", workflow)
+        self.assertIn("diff -u \"$expected_metadata\" \"$remote_metadata\"", workflow)
+
     def test_final_release_allowlist_rejects_extra_file(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             dist = pathlib.Path(temp_dir)

--- a/.github/scripts/test_render_krew_manifest.py
+++ b/.github/scripts/test_render_krew_manifest.py
@@ -187,6 +187,8 @@ class RenderKrewManifestTests(unittest.TestCase):
         ).read_text(encoding="utf-8")
         self.assertIn("release:\n    types: [published]", workflow)
         self.assertIn("and .immutable == true", workflow)
+        self.assertIn('test "$total_asset_count" -eq 16', workflow)
+        self.assertIn('select(.name == "sbom.cdx.json")', workflow)
         self.assertIn("contents: read", workflow)
         self.assertNotIn("contents: write", workflow)
         self.assertNotIn("pull_request_target", workflow)

--- a/.github/workflows/krew-index.yml
+++ b/.github/workflows/krew-index.yml
@@ -120,7 +120,16 @@ jobs:
               '[.assets[] | select(.name | startswith($prefix))] | length' \
               "$release_json"
           )"
+          total_asset_count="$(jq '.assets | length' "$release_json")"
+          test "$total_asset_count" -eq 16
           test "$plugin_asset_count" -eq 15
+          jq -e '
+            [.assets[] | select(.name == "sbom.cdx.json")] as $matching
+            | ($matching | length) == 1
+              and $matching[0].state == "uploaded"
+              and $matching[0].size > 0
+              and ($matching[0].digest | test("^sha256:[0-9a-f]{64}$"))
+          ' "$release_json" > /dev/null
           for name in "${expected_plugin_assets[@]}"; do
             jq -e --arg name "$name" '
               [.assets[] | select(.name == $name)] as $matching

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,6 +166,11 @@ jobs:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           format: cyclonedx-json
           output-file: sbom.cdx.json
+          # This workflow stages the exact SBOM explicitly below. Disable the
+          # action defaults so a tag build cannot mutate the curated draft or
+          # create a second workflow artefact outside the release allowlist.
+          upload-artifact: false
+          upload-release-assets: false
 
       - name: Install cosign
         uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
@@ -610,3 +615,17 @@ jobs:
             --clobber \
             --repo "$GITHUB_REPOSITORY"
           assert_draft
+          expected_metadata="$RUNNER_TEMP/expected-release-assets.tsv"
+          remote_metadata="$RUNNER_TEMP/remote-release-assets.tsv"
+          for asset in "${assets[@]}"; do
+            printf '%s\t%s\tsha256:%s\tuploaded\n' \
+              "$(basename "$asset")" \
+              "$(stat -c %s "$asset")" \
+              "$(sha256sum "$asset" | awk '{print $1}')"
+          done | LC_ALL=C sort > "$expected_metadata"
+          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_VERSION}" \
+            --jq '.assets[] | [.name, (.size | tostring), .digest, .state] | @tsv' \
+            | LC_ALL=C sort > "$remote_metadata"
+          test "$(wc -l < "$expected_metadata")" -eq 16
+          test "$(wc -l < "$remote_metadata")" -eq 16
+          diff -u "$expected_metadata" "$remote_metadata"

--- a/README.md
+++ b/README.md
@@ -80,16 +80,16 @@ The chart and its container image are published to GitHub Container Registry wit
 
 ```bash
 helm install cvk oci://ghcr.io/cisco-open/charts/cisco-virtual-kubelet \
-  --version 2026.8.0 \
+  --version 2026.8.1 \
   --namespace cvk-system --create-namespace
 ```
 
-This deploys the signed `ghcr.io/cisco-open/cisco-virtual-kubelet` image by default — no `--set image.*` needed. The chart `--version` is the release normalised to SemVer (e.g. `v2026.08.0` → `2026.8.0`); see [Releases](https://github.com/cisco-open/cisco-virtual-kubelet/releases) for the current version.
+This deploys the signed `ghcr.io/cisco-open/cisco-virtual-kubelet` image by default — no `--set image.*` needed. The chart `--version` matches the release's SemVer-compatible CalVer without the leading `v` (for example, `v2026.8.1` → `2026.8.1`); see [Releases](https://github.com/cisco-open/cisco-virtual-kubelet/releases) for the current version.
 
 Optionally verify the chart signature before installing:
 
 ```bash
-cosign verify ghcr.io/cisco-open/charts/cisco-virtual-kubelet:2026.8.0 \
+cosign verify ghcr.io/cisco-open/charts/cisco-virtual-kubelet:2026.8.1 \
   --certificate-identity-regexp "https://github.com/cisco-open/cisco-virtual-kubelet/.github/workflows/release.yml@refs/tags/v.*" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```
@@ -99,10 +99,9 @@ cosign verify ghcr.io/cisco-open/charts/cisco-virtual-kubelet:2026.8.0 \
 ### Install the optional kubectl plugin
 
 The client-side `kubectl-ciscovk` plugin is not required to run the controller.
-It adds read-only, ad-hoc IOS-XE diagnostics for operators. After the first
-plugin-bearing release following `v2026.08.0` is published and `cisco-vk` is
-accepted into the public Krew index, install and upgrade it without building
-from source:
+It adds read-only, ad-hoc IOS-XE diagnostics for operators. `v2026.8.1` is the
+first plugin-bearing release. After it is published and `cisco-vk` is accepted
+into the public Krew index, install and upgrade it without building from source:
 
 ```bash
 kubectl krew update
@@ -114,8 +113,8 @@ kubectl krew upgrade cisco-vk
 ```
 
 The `v2026.08.0` release predates the plugin assets and public index entry.
-Before the first plugin-bearing release, use the source-build fallback; between
-that release and index acceptance, use its signed archive. See the
+Until `v2026.8.1` is published, use the source-build fallback; between its
+publication and index acceptance, use its signed archive. See the
 [CLI & Plugin Reference](docs/cisco-vk-cli.md) for both verified installation
 paths and the exact availability gate.
 

--- a/charts/cisco-virtual-kubelet/Chart.yaml
+++ b/charts/cisco-virtual-kubelet/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # from the git tag by the release workflow; the values below are the
 # source-tree defaults used for local installs.
 version: 0.1.0
-appVersion: "v2026.08.0"
+appVersion: "v2026.8.1"
 keywords:
   - cisco
   - virtual-kubelet

--- a/docs/cisco-vk-cli.md
+++ b/docs/cisco-vk-cli.md
@@ -33,24 +33,24 @@ The archive's executable remains `kubectl-ciscovk`, so existing manual/source
 installs can continue to use `kubectl ciscovk`. Krew exposes the conventional
 `kubectl cisco-vk` alias. The initial index submission is intentionally gated on
 the first public release that contains the signed plugin archives.
-`v2026.08.0` predates those assets, so the Krew command above will not be
-available until that submission is accepted. The project release workflow
-validates Linux and macOS on both amd64 and arm64; Windows is not advertised
-yet.
+`v2026.08.0` predates those assets; `v2026.8.1` is the first plugin-bearing
+release. The Krew command above will not be available until that release's
+initial index submission is accepted. The project release workflow validates
+Linux and macOS on both amd64 and arm64; Windows is not advertised yet.
 
 ### Install a signed release archive
 
-Starting with the first plugin-bearing release after `v2026.08.0`, the GitHub
-release includes four deterministic archives, a signed checksum manifest, and
-per-archive signatures. The following example selects the local Linux/macOS
-architecture, verifies the signed checksum authority, and installs the plugin:
+Starting with `v2026.8.1`, each plugin-bearing GitHub release includes four
+deterministic archives, a signed checksum manifest, and per-archive signatures.
+The following example selects the local Linux/macOS architecture, verifies the
+signed checksum authority, and installs the plugin:
 
 ```bash
 (
 set -euo pipefail
 
 # Set this to an asset-bearing release shown on the Releases page.
-VERSION=v2026.9.0
+VERSION=v2026.8.1
 OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 case "$OS" in
   darwin|linux) ;;

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -76,11 +76,11 @@ so step 1's custom build is optional and you can install directly:
 
 ```bash
 helm install cvk oci://ghcr.io/cisco-open/charts/cisco-virtual-kubelet \
-  --version 2026.8.0 \
+  --version 2026.8.1 \
   --namespace cvk-system --create-namespace
 ```
 
-This pulls the signed `ghcr.io/cisco-open/cisco-virtual-kubelet` image by default. The chart `--version` is the release normalised to SemVer (e.g. `v2026.08.0` → `2026.8.0`); see [Releases](https://github.com/cisco-open/cisco-virtual-kubelet/releases) for the current one.
+This pulls the signed `ghcr.io/cisco-open/cisco-virtual-kubelet` image by default. The chart `--version` matches the release's SemVer-compatible CalVer without the leading `v` (for example, `v2026.8.1` → `2026.8.1`); see [Releases](https://github.com/cisco-open/cisco-virtual-kubelet/releases) for the current one.
 
 **From source with a custom image** — to run the build from step 1 instead:
 
@@ -112,7 +112,7 @@ If the controller pod is not `Running`, see [Troubleshooting → CiscoDevice stu
 
 The client-side `kubectl-ciscovk` plugin is optional; the controller and normal
 Kubernetes workflows do not depend on it. It provides read-only, ad-hoc IOS-XE
-diagnostics. After the first plugin-bearing release following `v2026.08.0` is
+diagnostics. `v2026.8.1` is the first plugin-bearing release. After it is
 published and `cisco-vk` is accepted into the public Krew index, install and
 upgrade it with:
 
@@ -126,8 +126,8 @@ kubectl krew upgrade cisco-vk
 ```
 
 The `v2026.08.0` release predates the plugin assets and public index entry.
-Before the first plugin-bearing release, use the source-build fallback; between
-that release and index acceptance, use its signed archive. The
+Until `v2026.8.1` is published, use the source-build fallback; between its
+publication and index acceptance, use its signed archive. The
 [CLI & Plugin Reference](cisco-vk-cli.md) documents both verified installation
 paths, the exact availability gate, and the plugin's current IOS-XE-only scope.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,10 +93,11 @@ This project is under active development and is published as open source under
   `oci://ghcr.io/cisco-open/charts/cisco-virtual-kubelet`. Build locally only
   when you need a custom image. See [Getting Started](getting-started.md).
 - **Operator plugin** - the optional `kubectl-ciscovk` plugin provides
-  read-only, ad-hoc IOS-XE diagnostics. Krew installation begins after the
-  first plugin-bearing release following `v2026.08.0` is published and
-  `cisco-vk` is accepted into the public index; signed release archives and a
-  source-build fallback are documented in the [CLI & Plugin Reference](cisco-vk-cli.md).
+  read-only, ad-hoc IOS-XE diagnostics. `v2026.8.1` is the first
+  plugin-bearing release; Krew installation begins only after it is published
+  and `cisco-vk` is accepted into the public index. Signed release archives
+  and a source-build fallback are documented in the
+  [CLI & Plugin Reference](cisco-vk-cli.md).
 
 ### Feature Maturity
 

--- a/docs/website/src/components/GetStarted.tsx
+++ b/docs/website/src/components/GetStarted.tsx
@@ -53,7 +53,7 @@ const codeBlocks: Record<string, { language: string; code: string }> = {
     language: "bash",
     code: `# Install the published Helm chart and signed image from GHCR.
 helm install cvk oci://ghcr.io/cisco-open/charts/cisco-virtual-kubelet \\
-  --version 2026.8.0 \\
+  --version 2026.8.1 \\
   --namespace cvk-system --create-namespace
 
 # Verify the CRD and controller are up
@@ -62,8 +62,8 @@ kubectl -n cvk-system get pods`,
   },
   plugin: {
     language: "bash",
-    code: `# Optional IOS-XE operator plugin. Available after a plugin-bearing
-# release following v2026.08.0 is published and accepted into the Krew index.
+    code: `# Optional IOS-XE operator plugin. v2026.8.1 is the first
+# plugin-bearing release; Krew install begins after public-index acceptance.
 kubectl krew update
 kubectl krew install cisco-vk
 kubectl cisco-vk version
@@ -265,8 +265,8 @@ export default function GetStarted() {
           </div>
           <p className="mt-5 text-sm text-text-muted text-center">
             The CLI plugin is optional and currently targets IOS-XE diagnostics.
-            Before its first release use the source build; after release and
-            before public-index acceptance use the signed archive. See the{" "}
+            Until v2026.8.1 is published use the source build; after publication
+            and before public-index acceptance use its signed archive. See the{" "}
             <a
               href="https://cisco-open.github.io/cisco-virtual-kubelet/docs/cisco-vk-cli/"
               target="_blank"

--- a/docs/website/src/components/Hero.tsx
+++ b/docs/website/src/components/Hero.tsx
@@ -124,7 +124,7 @@ export default function Hero() {
                   <span className="text-accent-light"> \</span>
                   {"\n  "}
                   <span className="text-accent-light">--version</span>{" "}
-                  <span className="text-foreground">2026.8.0</span>{" "}
+                  <span className="text-foreground">2026.8.1</span>{" "}
                   <span className="text-accent-light">\</span>
                   {"\n  "}
                   <span className="text-accent-light">--namespace</span>{" "}

--- a/krew/README.md
+++ b/krew/README.md
@@ -36,5 +36,6 @@ execution gate.
    The bot receives no repository token or secret, and the CVK workflow has
    read-only contents permission.
 
-Do not retrofit plugin archives onto `v2026.08.0`; that release predates the
-archive pipeline and is already public.
+`v2026.8.1` is the first plugin-bearing release. Do not retrofit plugin archives
+onto `v2026.08.0`; that release predates the archive pipeline and is already
+public.


### PR DESCRIPTION
## Summary

- Prepare `v2026.8.1`, the first release that carries signed `kubectl-ciscovk` plugin archives.
- Update the Helm app/image version and both MkDocs and static website installation guidance.
- Disable Anchore's implicit artifact/release uploads so the release workflow remains the sole draft mutator.
- Require the draft's exact 16 assets to match local names, sizes, SHA-256 digests, and uploaded states before the tag workflow can pass.
- Require the post-publication Krew workflow to observe the same exact 16-asset immutable release contract.

## Validation

- `git diff --check`
- `go test ./...`
- 70 Python workflow, packaging, reporting, and Krew-render tests
- actionlint v1.7.12 and YAML parsing for both changed workflows
- `helm lint`, packaged chart metadata, and rendered image tag
- `mkdocs build --strict`
- website `npm ci`, lint, production build, and zero-vulnerability npm audit
- native `kubectl-ciscovk v2026.8.1` version build/execution
- independent final diff review: no blocker

## Release gates

The curated notes below are a hard pre-tag and pre-publication gate. Merge requires an independent approval at this exact head and all seven protected contexts. After merge, tag only the verified canonical-main squash commit; keep the release draft until the image, chart, plugin archives, signatures, SBOMs, provenance, exact asset metadata, and independent HIGH/CRITICAL scans are all green.

## v2026.8.1

### Highlights

- `v2026.8.1` is the first plugin-bearing Cisco Virtual Kubelet release. The optional `kubectl-ciscovk` operator plugin provides read-only, ad-hoc IOS-XE diagnostics and now reports release version, commit, and build time; forwards explicit `--context` and `--kubeconfig`; and uses portable, bounded port-forward startup and cleanup.
- The release pipeline builds reproducible plugin archives for Linux and macOS on amd64 and arm64, executes each exact downloadable archive on its native runner, then adds per-platform CycloneDX SBOMs, keyless Sigstore bundles, signed checksums, and GitHub build provenance.
- A deterministic `cisco-vk` Krew manifest and read-only post-publication verification flow now validate the immutable release, exact asset set and hashes, signatures, every advertised Krew install, and the native plugin version.

### Krew availability

Publishing `v2026.8.1` does not by itself make `kubectl krew install cisco-vk` available. After publication, the validated `cisco-vk.yaml` workflow artifact must be submitted as the initial `plugins/cisco-vk.yaml` entry to `kubernetes-sigs/krew-index`; Krew installation begins only after that upstream PR is accepted. Until then, install the signed `v2026.8.1` release archive. Windows remains unadvertised until a native Windows release gate exists.

### Security

- Updated the documentation-site PostCSS floor to the patched line and resolved PostCSS 8.5.25, fixing GHSA-fxqj-rqcc-2cmp / Dependabot alert #85.
- Resolved brace-expansion 5.0.9, fixing high-severity GHSA-rgw5-rvv9-x895; `npm audit` reports zero vulnerabilities.
- Hardened release jobs with pinned actions/toolchains, minimal permissions, disabled persisted checkout credentials, draft-only release mutation, remote tag/commit checks, disabled implicit SBOM uploads, and exact local/remote artifact allowlists.

### NX-OS qualification and scope

No NX-OS runtime or qualification behavior changed in this patch. NX-OS remains **Beta** and is **offline-oracle-qualified only** for `v2026.8.1`. The pinned conformance oracle covers NetAsCode module 0.3.0, NX-OS provider 0.13.1, and the `system`, `feature`, `feature_set`, `vlan`, and `interface_ethernet` families. Credentialed live qualification is pending, and NX-OS live CI remains disabled/non-required. This release does not claim full IOS-XE parity or full live NX-OS parity.

### Artifacts

- Multi-architecture `linux/amd64` and `linux/arm64` image at `ghcr.io/cisco-open/cisco-virtual-kubelet:v2026.8.1`
- Signed OCI Helm chart `oci://ghcr.io/cisco-open/charts/cisco-virtual-kubelet` version `2026.8.1`, with appVersion `v2026.8.1`
- Four `kubectl-ciscovk_v2026.8.1_{darwin,linux}_{amd64,arm64}.tar.gz` archives, four per-platform CycloneDX SBOMs, a signed checksum manifest, four per-archive Sigstore bundles, and a GitHub build-provenance bundle (15 plugin release assets total)
- CycloneDX image SBOM, keyless image and chart signatures, and image SBOM attestation
- Post-publication validated `cisco-vk.yaml` Krew manifest as a workflow artifact for the initial upstream submission

**Full changelog:** https://github.com/cisco-open/cisco-virtual-kubelet/compare/v2026.08.0...v2026.8.1
