### PR TITLE
test(release): gate Krew distribution

### DIFF
--- a/.github/scripts/test_render_krew_manifest.py
+++ b/.github/scripts/test_render_krew_manifest.py
@@ -181,6 +181,36 @@ class RenderKrewManifestTests(unittest.TestCase):
             renderer.write_manifest(output, "manifest\n")
             self.assertEqual(output.read_text(encoding="utf-8"), "manifest\n")
 
+    def test_release_workflow_krew_installs_each_native_archive_before_signing(
+        self,
+    ) -> None:
+        workflow = (
+            renderer.REPO_ROOT / ".github" / "workflows" / "release.yml"
+        ).read_text(encoding="utf-8")
+        verify_section = workflow.split("\n  verify-plugin:\n", 1)[1].split(
+            "\n  sign-plugin:\n", 1
+        )[0]
+        self.assertIn("push:\n    tags:\n      - 'v*'", workflow)
+        self.assertIn("if: startsWith(github.ref, 'refs/tags/v')", verify_section)
+        self.assertEqual(verify_section.count("target_os:"), 4)
+        self.assertEqual(verify_section.count("target_arch:"), 4)
+        self.assertIn("Krew-install and execute packaged plugin", verify_section)
+        self.assertIn("sigs.k8s.io/krew/cmd/krew@v0.4.5", verify_section)
+        self.assertIn('KREW_ROOT="$krew_root"', verify_section)
+        self.assertIn('KREW_OS="$TARGET_OS"', verify_section)
+        self.assertIn('KREW_ARCH="$TARGET_ARCH"', verify_section)
+        self.assertIn("KREW_NO_UPGRADE_CHECK=1", verify_section)
+        self.assertIn('--manifest "$manifest"', verify_section)
+        self.assertIn('--archive "$archive"', verify_section)
+        self.assertIn("kubectl-cisco_vk", verify_section)
+        self.assertIn(
+            "kubectl-ciscovk ${RELEASE_VERSION} (commit=${RELEASE_COMMIT},",
+            verify_section,
+        )
+        self.assertIn(
+            "sign-plugin:\n    needs: [package-plugin, verify-plugin]", workflow
+        )
+
     def test_post_publication_workflow_is_read_only_and_fail_closed(self) -> None:
         workflow = (
             renderer.REPO_ROOT / ".github" / "workflows" / "krew-index.yml"
@@ -197,6 +227,28 @@ class RenderKrewManifestTests(unittest.TestCase):
         self.assertNotIn("gh release edit", workflow)
         self.assertNotIn("${{ secrets.", workflow)
         self.assertIn("GITHUB_TOKEN: ''", workflow)
+        self.assertIn("group: krew-index-production", workflow)
+        self.assertIn("steps.upstream.outputs.current != 'true'", workflow)
+        self.assertIn("timeout-minutes: 45", workflow)
+        self.assertIn("deadline=$((SECONDS + 900))", workflow)
+        self.assertIn("while (( SECONDS < deadline ))", workflow)
+        self.assertIn("--connect-timeout 5", workflow)
+        self.assertIn("--max-time 15", workflow)
+        self.assertIn("--expected \"$expected_manifest\"", workflow)
+        self.assertIn("kubectl krew install cisco-vk", workflow)
+        self.assertIn(
+            "https://github.com/kubernetes-sigs/krew-index.git", workflow
+        )
+        self.assertIn('GIT_CONFIG_GLOBAL=/dev/null', workflow)
+        self.assertIn('GH_TOKEN=\'\'', workflow)
+        self.assertIn('GITHUB_TOKEN=\'\'', workflow)
+        self.assertIn(
+            "kubectl-ciscovk ${RELEASE_TAG} (commit=${RELEASE_COMMIT},",
+            workflow,
+        )
+        self.assertNotIn("continue-on-error", workflow)
+        self.assertNotIn("gh release create", workflow)
+        self.assertNotIn("gh release delete", workflow)
         self.assertIn(
             "3748407285b4cf866e9d4625e376aca927aa3f0b30f30ede83cc33a11566f28b",
             workflow,

--- a/.github/workflows/krew-index.yml
+++ b/.github/workflows/krew-index.yml
@@ -15,7 +15,9 @@
 # Krew updates happen only after a release is public and immutable. This
 # workflow cannot change the CVK repository or its release assets. The first
 # krew-index submission is intentionally manual; later updates are handed to
-# Krew's recommended release bot without passing it a token or secret.
+# Krew's recommended release bot without passing it a token or secret. After
+# submission, the workflow waits for the exact manifest to reach the official
+# index and verifies a clean install through that public index.
 
 name: krew-index
 
@@ -27,14 +29,15 @@ permissions:
   contents: read
 
 concurrency:
-  group: krew-index-${{ github.event.release.tag_name }}
+  # Serialize releases so two tags cannot race updates to the one public entry.
+  group: krew-index-production
   cancel-in-progress: false
 
 jobs:
   validate-and-submit:
     if: github.event.release.draft == false && github.event.release.prerelease == false
     runs-on: ubuntu-24.04
-    timeout-minutes: 25
+    timeout-minutes: 45
     permissions:
       contents: read
     steps:
@@ -200,6 +203,7 @@ jobs:
 
       - name: Validate every Krew platform and execute the native plugin
         env:
+          RELEASE_COMMIT: ${{ github.sha }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
@@ -229,7 +233,9 @@ jobs:
           version_output="$(
             PATH="$native_root/bin:$PATH" kubectl cisco-vk version
           )"
-          grep -F "kubectl-ciscovk ${RELEASE_TAG} (" <<< "$version_output"
+          grep -F \
+            "kubectl-ciscovk ${RELEASE_TAG} (commit=${RELEASE_COMMIT}," \
+            <<< "$version_output"
 
       - name: Upload validated initial-submission artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -243,17 +249,30 @@ jobs:
         id: upstream
         run: |
           set -euo pipefail
-          url="https://raw.githubusercontent.com/kubernetes-sigs/krew-index/master/plugins/cisco-vk.yaml"
+          url="https://raw.githubusercontent.com/kubernetes-sigs/krew-index/master/plugins/cisco-vk.yaml?run=${GITHUB_RUN_ID}-preflight"
           status="$(
-            curl -sS -L -o "$RUNNER_TEMP/upstream-cisco-vk.yaml" \
+            curl --silent --show-error --location \
+              --connect-timeout 5 \
+              --max-time 15 \
+              --header 'Cache-Control: no-cache' \
+              --output "$RUNNER_TEMP/upstream-cisco-vk.yaml" \
               -w '%{http_code}' "$url"
           )"
           case "$status" in
             200)
               echo 'exists=true' >> "$GITHUB_OUTPUT"
+              if go run ./tools/krew-manifest-owner-check \
+                --file "$RUNNER_TEMP/upstream-cisco-vk.yaml" \
+                --expected dist/krew/cisco-vk.yaml \
+                > /dev/null 2>&1; then
+                echo 'current=true' >> "$GITHUB_OUTPUT"
+              else
+                echo 'current=false' >> "$GITHUB_OUTPUT"
+              fi
               ;;
             404)
               echo 'exists=false' >> "$GITHUB_OUTPUT"
+              echo 'current=false' >> "$GITHUB_OUTPUT"
               echo 'Initial submission required: download the validated cisco-vk.yaml artifact and open the first krew-index PR.' >> "$GITHUB_STEP_SUMMARY"
               ;;
             *)
@@ -269,7 +288,9 @@ jobs:
           --file "$RUNNER_TEMP/upstream-cisco-vk.yaml"
 
       - name: Install checksum-pinned Krew release bot
-        if: steps.upstream.outputs.exists == 'true'
+        if: >-
+          steps.upstream.outputs.exists == 'true' &&
+          steps.upstream.outputs.current != 'true'
         run: |
           set -euo pipefail
           archive="$RUNNER_TEMP/krew-release-bot_v0.0.51_linux_amd64.tar.gz"
@@ -284,7 +305,9 @@ jobs:
           test -x "$destination/krew-release-bot"
 
       - name: Open the subsequent krew-index update PR
-        if: steps.upstream.outputs.exists == 'true'
+        if: >-
+          steps.upstream.outputs.exists == 'true' &&
+          steps.upstream.outputs.current != 'true'
         env:
           # The bot submits the public manifest to its webhook. It receives no
           # CVK repository credential and this job has read-only permissions.
@@ -293,3 +316,113 @@ jobs:
           INPUT_KREW_PLUGIN_RELEASE_TAG: ${{ github.event.release.tag_name }}
           INPUT_KREW_TEMPLATE_FILE: dist/krew/cisco-vk.yaml
         run: "$RUNNER_TEMP/krew-release-bot/krew-release-bot action"
+
+      - name: Wait for the exact official-index manifest
+        if: steps.upstream.outputs.exists == 'true'
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          expected_manifest="dist/krew/cisco-vk.yaml"
+          official_manifest="$RUNNER_TEMP/official-cisco-vk.yaml"
+          matched=false
+          deadline=$((SECONDS + 900))
+          attempt=0
+          while (( SECONDS < deadline )); do
+            attempt=$((attempt + 1))
+            remaining=$((deadline - SECONDS))
+            if (( remaining <= 0 )); then
+              break
+            fi
+            curl_budget=15
+            if (( remaining < curl_budget )); then
+              curl_budget=$remaining
+            fi
+            url="https://raw.githubusercontent.com/kubernetes-sigs/krew-index/master/plugins/cisco-vk.yaml?run=${GITHUB_RUN_ID}-${attempt}"
+            if curl --fail --silent --show-error --location \
+              --connect-timeout 5 \
+              --max-time "$curl_budget" \
+              --header 'Cache-Control: no-cache' \
+              --output "$official_manifest" \
+              "$url"; then
+              if go run ./tools/krew-manifest-owner-check \
+                --file "$official_manifest" \
+                --expected "$expected_manifest" \
+                > /dev/null 2>&1; then
+                echo "Official Krew index contains the exact ${RELEASE_TAG} manifest."
+                matched=true
+                break
+              fi
+              current_version="$(
+                sed -n 's/^  version: "\([^"]*\)"$/\1/p' "$official_manifest"
+              )"
+              echo "Waiting for ${RELEASE_TAG}; official index currently reports ${current_version:-unknown} (attempt ${attempt})."
+            fi
+            remaining=$((deadline - SECONDS))
+            if (( remaining > 0 )); then
+              sleep_for=15
+              if (( remaining < sleep_for )); then
+                sleep_for=$remaining
+              fi
+              sleep "$sleep_for"
+            fi
+          done
+          if [[ "$matched" != true ]]; then
+            echo "::error::Official Krew index did not publish the exact ${RELEASE_TAG} manifest within 15 minutes"
+            go run ./tools/krew-manifest-owner-check \
+              --file "$official_manifest" \
+              --expected "$expected_manifest" || true
+            exit 1
+          fi
+
+      - name: Install and execute from the official Krew index
+        if: steps.upstream.outputs.exists == 'true'
+        env:
+          RELEASE_COMMIT: ${{ github.sha }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          tool_dir="$RUNNER_TEMP/krew-tools"
+          public_root="$RUNNER_TEMP/krew-public-index"
+          public_home="$RUNNER_TEMP/krew-public-home"
+          export PATH="$tool_dir:$PATH"
+          test -x "$tool_dir/krew"
+          test -L "$tool_dir/kubectl-krew"
+          mkdir -p "$public_home"
+
+          HOME="$public_home" \
+            KREW_ROOT="$public_root" \
+            KREW_NO_UPGRADE_CHECK=1 \
+            GH_TOKEN='' \
+            GITHUB_TOKEN='' \
+            GIT_TERMINAL_PROMPT=0 \
+            GIT_CONFIG_GLOBAL=/dev/null \
+            kubectl krew install cisco-vk
+          default_index="$public_root/index/default"
+          test "$(
+            GIT_CONFIG_GLOBAL=/dev/null \
+              git -C "$default_index" remote get-url origin
+          )" = "https://github.com/kubernetes-sigs/krew-index.git"
+          go run ./tools/krew-manifest-owner-check \
+            --file "$default_index/plugins/cisco-vk.yaml" \
+            --expected dist/krew/cisco-vk.yaml
+          plugin_alias="$public_root/bin/kubectl-cisco_vk"
+          test -L "$plugin_alias"
+          test -x "$plugin_alias"
+          version_output="$(
+            PATH="$public_root/bin:$PATH" kubectl cisco-vk version
+          )"
+          grep -F \
+            "kubectl-ciscovk ${RELEASE_TAG} (commit=${RELEASE_COMMIT}," \
+            <<< "$version_output"
+
+          HOME="$public_home" \
+            KREW_ROOT="$public_root" \
+            KREW_NO_UPGRADE_CHECK=1 \
+            GH_TOKEN='' \
+            GITHUB_TOKEN='' \
+            GIT_TERMINAL_PROMPT=0 \
+            GIT_CONFIG_GLOBAL=/dev/null \
+            kubectl krew uninstall cisco-vk
+          test ! -e "$plugin_alias"
+          test ! -L "$plugin_alias"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -314,8 +314,9 @@ jobs:
           retention-days: 90
 
   # Execute the exact downloadable archive on every platform/architecture we
-  # publish. Windows stays intentionally absent until an equivalent native gate
-  # is added.
+  # publish, then install that same archive through Krew and execute the
+  # Krew-created plugin alias. Windows stays intentionally absent until an
+  # equivalent native gate is added.
   verify-plugin:
     needs: package-plugin
     if: startsWith(github.ref, 'refs/tags/v')
@@ -336,7 +337,7 @@ jobs:
             target_os: darwin
             target_arch: arm64
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 10
+    timeout-minutes: 15
     permissions:
       actions: read
       contents: read
@@ -349,6 +350,12 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.13.14'
+
+      - name: Set up pinned Go for Krew
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: '1.25.12'
+          cache: false
 
       - name: Download exact plugin artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -373,6 +380,43 @@ jobs:
             --dist-dir dist/kubectl-ciscovk \
             --require-sboms \
             --execute
+
+      - name: Krew-install and execute packaged plugin
+        env:
+          RELEASE_COMMIT: ${{ github.sha }}
+          RELEASE_VERSION: ${{ github.ref_name }}
+          TARGET_ARCH: ${{ matrix.target_arch }}
+          TARGET_OS: ${{ matrix.target_os }}
+        run: |
+          set -euo pipefail
+          tool_dir="$RUNNER_TEMP/krew-tools"
+          manifest="$RUNNER_TEMP/krew-manifest/cisco-vk.yaml"
+          krew_root="$RUNNER_TEMP/krew-root"
+          archive="dist/kubectl-ciscovk/kubectl-ciscovk_${RELEASE_VERSION}_${TARGET_OS}_${TARGET_ARCH}.tar.gz"
+          checksums="dist/kubectl-ciscovk/kubectl-ciscovk_${RELEASE_VERSION}_checksums.txt"
+          mkdir -p "$tool_dir" "$(dirname "$manifest")"
+
+          python3 .github/scripts/render_krew_manifest.py \
+            --release-tag "$RELEASE_VERSION" \
+            --checksums "$checksums" \
+            --output "$manifest"
+          env GOBIN="$tool_dir" \
+            go install sigs.k8s.io/krew/cmd/krew@v0.4.5
+
+          KREW_NO_UPGRADE_CHECK=1 \
+            KREW_ROOT="$krew_root" \
+            KREW_OS="$TARGET_OS" \
+            KREW_ARCH="$TARGET_ARCH" \
+            "$tool_dir/krew" install \
+              --manifest "$manifest" \
+              --archive "$archive"
+          alias="$krew_root/bin/kubectl-cisco_vk"
+          test -L "$alias"
+          test -x "$alias"
+          version_output="$("$alias" version)"
+          grep -F \
+            "kubectl-ciscovk ${RELEASE_VERSION} (commit=${RELEASE_COMMIT}," \
+            <<< "$version_output"
 
   # Sign only after all four exact archives execute successfully. This job can
   # mint OIDC identities and attestations, but it cannot mutate a release.

--- a/krew/README.md
+++ b/krew/README.md
@@ -22,19 +22,34 @@ execution gate.
    `v2026.9.0` rather than `v2026.09.0`. The release and Krew workflows reject
    padded month or patch components because Krew's new-plugin checklist
    requires the Git release tag itself to be semantic.
-4. Publish the already-verified GitHub draft. The read-only `krew-index`
+4. The tag workflow builds the four release archives and executes each one on
+   its native runner. The same matrix then renders the exact manifest, installs
+   the matching local archive through Krew, checks the `kubectl-cisco_vk`
+   alias, and requires the exact tag and commit before signing or draft staging.
+5. Publish the already-verified GitHub draft. The read-only `krew-index`
    workflow verifies the immutable release, signed checksums, exact archive
-   hashes, all four Krew installs, and the native plugin version. It uploads the
-   concrete `cisco-vk.yaml` as a workflow artifact.
-5. For the first release, submit that artifact manually as
+   hashes, all four public-URL Krew installs, and the native plugin version. It
+   uploads the concrete `cisco-vk.yaml` as a workflow artifact.
+6. For the first release, submit that artifact manually as
    `plugins/cisco-vk.yaml` in
    [kubernetes-sigs/krew-index](https://github.com/kubernetes-sigs/krew-index).
    Krew requires the initial submission and Kubernetes CLA to be handled by the
    plugin author.
-6. After the initial manifest is accepted, subsequent published releases use
+7. After the initial manifest is accepted, subsequent published releases use
    the checksum-pinned `krew-release-bot` binary to open version update PRs.
-   The bot receives no repository token or secret, and the CVK workflow has
-   read-only contents permission.
+   Reruns skip submission when the official entry already matches. The bot
+   receives no repository token or secret, and the CVK workflow has read-only
+   contents permission.
+8. The workflow waits up to 15 minutes for the exact distribution contract to
+   reach the official index, then performs a clean, credential-free
+   `kubectl krew install cisco-vk` and requires the exact tag and commit. A
+   timeout fails the Krew distribution workflow but cannot modify or unpublish
+   the immutable CVK release.
+
+These execution gates are release-lifecycle checks: the local-archive matrix
+runs for version tags, and the public-index check runs after a release is
+published. They do not add a pull-request job or another approval requirement
+to the normal PR flow.
 
 `v2026.8.1` is the first plugin-bearing release. Do not retrofit plugin archives
 onto `v2026.08.0`; that release predates the archive pipeline and is already

--- a/tools/krew-manifest-owner-check/main.go
+++ b/tools/krew-manifest-owner-check/main.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path"
+	"regexp"
 	"strings"
 
 	"sigs.k8s.io/yaml"
@@ -34,11 +36,32 @@ const (
 	expectedURIPath    = "/cisco-open/cisco-virtual-kubelet/releases/download/"
 )
 
+var sha256Pattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+var expectedTargets = map[string]struct{}{
+	"darwin/amd64": {},
+	"darwin/arm64": {},
+	"linux/amd64":  {},
+	"linux/arm64":  {},
+}
+
+type platformContract struct {
+	URI    string
+	SHA256 string
+	Bin    string
+}
+
+type manifestContract struct {
+	Version   string
+	Platforms map[string]platformContract
+}
+
 func main() {
 	manifestPath := flag.String("file", "", "path to the upstream Krew manifest")
+	expectedPath := flag.String("expected", "", "optional path to the expected Krew manifest contract")
 	flag.Parse()
 	if *manifestPath == "" || flag.NArg() != 0 {
-		fmt.Fprintln(os.Stderr, "usage: krew-manifest-owner-check --file <manifest.yaml>")
+		fmt.Fprintln(os.Stderr, "usage: krew-manifest-owner-check --file <manifest.yaml> [--expected <manifest.yaml>]")
 		os.Exit(2)
 	}
 	data, err := os.ReadFile(*manifestPath)
@@ -48,6 +71,18 @@ func main() {
 	}
 	if err := validateManifestOwnership(data); err != nil {
 		fmt.Fprintln(os.Stderr, "upstream Krew manifest ownership check failed:", err)
+		os.Exit(1)
+	}
+	if *expectedPath == "" {
+		return
+	}
+	expectedData, err := os.ReadFile(*expectedPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "read expected manifest:", err)
+		os.Exit(1)
+	}
+	if err := compareManifestContracts(data, expectedData); err != nil {
+		fmt.Fprintln(os.Stderr, "upstream Krew manifest contract mismatch:", err)
 		os.Exit(1)
 	}
 }
@@ -92,11 +127,115 @@ func validateManifestOwnership(data []byte) error {
 		}
 		parsed, err := url.Parse(rawURI)
 		if err != nil || parsed.Scheme != "https" || parsed.Host != "github.com" ||
-			!strings.HasPrefix(parsed.EscapedPath(), expectedURIPath) {
+			parsed.EscapedPath() != parsed.Path || path.Clean(parsed.Path) != parsed.Path ||
+			!strings.HasPrefix(parsed.Path, expectedURIPath) {
 			return fmt.Errorf("spec.platforms[%d].uri is not owned by %s", index, expectedHomepage)
 		}
 	}
 	return nil
+}
+
+func compareManifestContracts(actualData, expectedData []byte) error {
+	actual, err := extractManifestContract(actualData)
+	if err != nil {
+		return fmt.Errorf("actual manifest: %w", err)
+	}
+	expected, err := extractManifestContract(expectedData)
+	if err != nil {
+		return fmt.Errorf("expected manifest: %w", err)
+	}
+	if actual.Version != expected.Version {
+		return fmt.Errorf("spec.version is %q, expected %q", actual.Version, expected.Version)
+	}
+	for target := range expectedTargets {
+		actualPlatform := actual.Platforms[target]
+		expectedPlatform := expected.Platforms[target]
+		if actualPlatform.URI != expectedPlatform.URI {
+			return fmt.Errorf("platform %s URI is %q, expected %q", target, actualPlatform.URI, expectedPlatform.URI)
+		}
+		if actualPlatform.SHA256 != expectedPlatform.SHA256 {
+			return fmt.Errorf("platform %s sha256 is %q, expected %q", target, actualPlatform.SHA256, expectedPlatform.SHA256)
+		}
+		if actualPlatform.Bin != expectedPlatform.Bin {
+			return fmt.Errorf("platform %s bin is %q, expected %q", target, actualPlatform.Bin, expectedPlatform.Bin)
+		}
+	}
+	return nil
+}
+
+func extractManifestContract(data []byte) (manifestContract, error) {
+	if err := validateManifestOwnership(data); err != nil {
+		return manifestContract{}, err
+	}
+	var document map[string]any
+	if err := yaml.UnmarshalStrict(data, &document); err != nil {
+		return manifestContract{}, fmt.Errorf("parse strict YAML: %w", err)
+	}
+	spec, err := mapField(document, "spec")
+	if err != nil {
+		return manifestContract{}, err
+	}
+	version, err := stringField(spec, "version")
+	if err != nil {
+		return manifestContract{}, err
+	}
+	platforms, ok := spec["platforms"].([]any)
+	if !ok || len(platforms) != len(expectedTargets) {
+		return manifestContract{}, fmt.Errorf("spec.platforms must contain exactly %d entries", len(expectedTargets))
+	}
+	contract := manifestContract{
+		Version:   version,
+		Platforms: make(map[string]platformContract, len(expectedTargets)),
+	}
+	for index, item := range platforms {
+		platform, ok := item.(map[string]any)
+		if !ok {
+			return manifestContract{}, fmt.Errorf("spec.platforms[%d] must be a mapping", index)
+		}
+		if len(platform) != 4 {
+			return manifestContract{}, fmt.Errorf("spec.platforms[%d] must contain only selector, uri, sha256, and bin", index)
+		}
+		selector, err := mapField(platform, "selector")
+		if err != nil || len(selector) != 1 {
+			return manifestContract{}, fmt.Errorf("spec.platforms[%d].selector must contain only matchLabels", index)
+		}
+		labels, err := mapField(selector, "matchLabels")
+		if err != nil || len(labels) != 2 {
+			return manifestContract{}, fmt.Errorf("spec.platforms[%d].selector.matchLabels must contain only os and arch", index)
+		}
+		platformOS, err := stringField(labels, "os")
+		if err != nil {
+			return manifestContract{}, fmt.Errorf("spec.platforms[%d].selector.matchLabels: %w", index, err)
+		}
+		platformArch, err := stringField(labels, "arch")
+		if err != nil {
+			return manifestContract{}, fmt.Errorf("spec.platforms[%d].selector.matchLabels: %w", index, err)
+		}
+		target := platformOS + "/" + platformArch
+		if _, ok := expectedTargets[target]; !ok {
+			return manifestContract{}, fmt.Errorf("spec.platforms[%d] has unsupported target %q", index, target)
+		}
+		if _, duplicate := contract.Platforms[target]; duplicate {
+			return manifestContract{}, fmt.Errorf("spec.platforms contains duplicate target %q", target)
+		}
+		uri, err := stringField(platform, "uri")
+		if err != nil {
+			return manifestContract{}, fmt.Errorf("spec.platforms[%d]: %w", index, err)
+		}
+		sha256, err := stringField(platform, "sha256")
+		if err != nil || !sha256Pattern.MatchString(sha256) {
+			return manifestContract{}, fmt.Errorf("spec.platforms[%d].sha256 must be 64 lowercase hexadecimal characters", index)
+		}
+		bin, err := stringField(platform, "bin")
+		if err != nil {
+			return manifestContract{}, fmt.Errorf("spec.platforms[%d]: %w", index, err)
+		}
+		contract.Platforms[target] = platformContract{URI: uri, SHA256: sha256, Bin: bin}
+	}
+	if len(contract.Platforms) != len(expectedTargets) {
+		return manifestContract{}, errors.New("spec.platforms does not cover every supported target exactly once")
+	}
+	return contract, nil
 }
 
 func mapField(parent map[string]any, name string) (map[string]any, error) {

--- a/tools/krew-manifest-owner-check/main_test.go
+++ b/tools/krew-manifest-owner-check/main_test.go
@@ -29,6 +29,45 @@ spec:
   - uri: https://github.com/cisco-open/cisco-virtual-kubelet/releases/download/v2026.9.0/plugin.tar.gz
 `
 
+const validContractManifest = `apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: cisco-vk
+spec:
+  version: "v2026.9.0"
+  homepage: https://github.com/cisco-open/cisco-virtual-kubelet
+  shortDescription: Test manifest
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/cisco-open/cisco-virtual-kubelet/releases/download/v2026.9.0/kubectl-ciscovk_v2026.9.0_darwin_amd64.tar.gz
+    sha256: "1111111111111111111111111111111111111111111111111111111111111111"
+    bin: kubectl-ciscovk
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/cisco-open/cisco-virtual-kubelet/releases/download/v2026.9.0/kubectl-ciscovk_v2026.9.0_darwin_arm64.tar.gz
+    sha256: "2222222222222222222222222222222222222222222222222222222222222222"
+    bin: kubectl-ciscovk
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/cisco-open/cisco-virtual-kubelet/releases/download/v2026.9.0/kubectl-ciscovk_v2026.9.0_linux_amd64.tar.gz
+    sha256: "3333333333333333333333333333333333333333333333333333333333333333"
+    bin: kubectl-ciscovk
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    uri: https://github.com/cisco-open/cisco-virtual-kubelet/releases/download/v2026.9.0/kubectl-ciscovk_v2026.9.0_linux_arm64.tar.gz
+    sha256: "4444444444444444444444444444444444444444444444444444444444444444"
+    bin: kubectl-ciscovk
+`
+
 func TestValidateManifestOwnership(t *testing.T) {
 	if err := validateManifestOwnership([]byte(validManifest)); err != nil {
 		t.Fatalf("valid manifest rejected: %v", err)
@@ -40,6 +79,18 @@ func TestValidateManifestOwnershipRejectsForeignEntry(t *testing.T) {
 		"name":     strings.Replace(validManifest, "name: cisco-vk", "name: other", 1),
 		"homepage": strings.Replace(validManifest, expectedHomepage, "https://example.com/other", 1),
 		"archive":  strings.Replace(validManifest, "https://github.com/cisco-open/cisco-virtual-kubelet/releases/download/", "https://github.com/other/project/releases/download/", 1),
+		"dot segments": strings.Replace(
+			validManifest,
+			"releases/download/v2026.9.0/plugin.tar.gz",
+			"releases/download/../../../../kubernetes-sigs/krew-index/releases/download/v1/plugin.tar.gz",
+			1,
+		),
+		"encoded dot segments": strings.Replace(
+			validManifest,
+			"releases/download/v2026.9.0/plugin.tar.gz",
+			"releases/download/%2e%2e/%2e%2e/other/project/plugin.tar.gz",
+			1,
+		),
 	}
 	for name, manifest := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -54,5 +105,71 @@ func TestValidateManifestOwnershipRejectsDuplicateKeys(t *testing.T) {
 	manifest := strings.Replace(validManifest, "kind: Plugin", "kind: Plugin\nkind: Other", 1)
 	if err := validateManifestOwnership([]byte(manifest)); err == nil {
 		t.Fatal("manifest with duplicate keys accepted")
+	}
+}
+
+func TestCompareManifestContractsAcceptsExactAndReorderedPlatforms(t *testing.T) {
+	if err := compareManifestContracts([]byte(validContractManifest), []byte(validContractManifest)); err != nil {
+		t.Fatalf("exact manifest contract rejected: %v", err)
+	}
+	const separator = "  - selector:"
+	parts := strings.Split(validContractManifest, separator)
+	if len(parts) != 5 {
+		t.Fatalf("unexpected manifest fixture split: %d parts", len(parts))
+	}
+	reordered := parts[0]
+	for _, index := range []int{4, 2, 1, 3} {
+		reordered += separator + parts[index]
+	}
+	if err := compareManifestContracts([]byte(reordered), []byte(validContractManifest)); err != nil {
+		t.Fatalf("platform-order-only change rejected: %v", err)
+	}
+}
+
+func TestCompareManifestContractsRejectsDistributionDrift(t *testing.T) {
+	parts := strings.Split(validContractManifest, "  - selector:")
+	tests := map[string]string{
+		"version": strings.Replace(validContractManifest, "v2026.9.0", "v2026.9.1", 1),
+		"uri": strings.Replace(
+			validContractManifest,
+			"kubectl-ciscovk_v2026.9.0_darwin_amd64.tar.gz",
+			"kubectl-ciscovk_v2026.9.0_darwin_other.tar.gz",
+			1,
+		),
+		"sha256": strings.Replace(
+			validContractManifest,
+			strings.Repeat("1", 64),
+			strings.Repeat("a", 64),
+			1,
+		),
+		"bin":              strings.Replace(validContractManifest, "bin: kubectl-ciscovk", "bin: other", 1),
+		"selector":         strings.Replace(validContractManifest, "arch: amd64", "arch: arm64", 1),
+		"missing platform": strings.Join(parts[:4], "  - selector:"),
+		"extra platform":   validContractManifest + "  - selector:" + parts[4],
+		"extra field": strings.Replace(
+			validContractManifest,
+			"    bin: kubectl-ciscovk",
+			"    bin: kubectl-ciscovk\n    files: []",
+			1,
+		),
+		"invalid hash": strings.Replace(
+			validContractManifest,
+			strings.Repeat("1", 64),
+			strings.Repeat("A", 64),
+			1,
+		),
+		"duplicate key": strings.Replace(
+			validContractManifest,
+			"  version: \"v2026.9.0\"",
+			"  version: \"v2026.9.0\"\n  version: \"v2026.9.0\"",
+			1,
+		),
+	}
+	for name, manifest := range tests {
+		t.Run(name, func(t *testing.T) {
+			if err := compareManifestContracts([]byte(manifest), []byte(validContractManifest)); err == nil {
+				t.Fatal("drifted manifest contract accepted")
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- Krew-install and execute every tagged Linux/macOS amd64/arm64 plugin archive before signing or draft staging.
- Make the read-only post-publication workflow idempotent, wait for the exact official-index distribution contract, and verify a clean credential-free public Krew install.
- Compare the exact version, four selectors, URLs, hashes, and binary names while hardening release-asset ownership validation.
- Document that these execution gates are release-only and do not add an ordinary pull-request check or approval.

## Validation

- `go test ./...`
- `go test -race ./tools/krew-manifest-owner-check`
- `python3 -m unittest discover -s .github/scripts -p "test_*.py" -v` (72 tests)
- `actionlint v1.7.12` on both changed workflows
- Native archive packaging, rendered-manifest Krew install, alias execution, and exact tag/commit assertion
- Clean install from the official Krew index for `v2026.8.1`, including exact public manifest contract and commit assertion

## Release behavior

No new `pull_request` job or protected status context is introduced. The native Krew matrix runs only for release tags and blocks signing/staging on failure. The official-index check runs only after publication with read-only repository permissions and cannot edit or unpublish a release.